### PR TITLE
Added checkbox to clean app data on uninstall

### DIFF
--- a/electron-builder/base.config.js
+++ b/electron-builder/base.config.js
@@ -30,6 +30,7 @@ const base = {
   nsis: {
     license: 'AGREEMENT',
     oneClick: false,
+    warningsAsErrors: false,
     perMachine: true,
     allowToChangeInstallationDirectory: true,
     include: 'installer.nsh',

--- a/installer.nsh
+++ b/installer.nsh
@@ -46,7 +46,7 @@ Function un.LeaveUnWelcome
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-client"
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-plugins"
     RMDir /r "$PROFILE\\AppData\\Roaming\\streamlabs-highlighter"
-    ; REBOOTOK flg is required, because files might get injected into a game process and system may prevent their removal
+    ; REBOOTOK flag is required, because files might get injected into a game process and system may prevent their removal
     ; see: https://nsis.sourceforge.io/Reference/RMDir
     RMDir /r /REBOOTOK "C:\\ProgramData\\obs-studio-hook"
   ${EndIf}

--- a/installer.nsh
+++ b/installer.nsh
@@ -1,10 +1,12 @@
+!include MUI2.nsh
+
 !macro customInstall
-  NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"  
-  
+  NSISdl::download https://aka.ms/vs/17/release/vc_redist.x64.exe "$INSTDIR\vc_redist.x64.exe"
+
   ${If} ${FileExists} `$INSTDIR\vc_redist.x64.exe`
     ExecWait '$INSTDIR\vc_redist.x64.exe /passive /norestart' $1
 
-    ${If} $1 != '0' 
+    ${If} $1 != '0'
       ${If} $1 != '3010'
         MessageBox MB_OK|MB_ICONEXCLAMATION 'WARNING: Streamlabs was unable to install the latest Visual C++ Redistributable package from Microsoft.'
       ${EndIf}
@@ -22,3 +24,26 @@
   FileWrite $0 $EXEFILE
   FileClose $0
 !macroend
+
+; Custom uninstall welcome page
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW un.ModifyUnWelcome
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.LeaveUnWelcome
+!insertmacro MUI_UNPAGE_WELCOME
+
+Var /GLOBAL cleanupCheckbox
+
+Function un.ModifyUnWelcome
+  ${NSD_CreateCheckbox} 120u -18u 50% 12u "Clean application data"
+  Pop $cleanupCheckbox
+
+  SetCtlColors $cleanupCheckbox 0x000000 0xffffff
+  ${NSD_Check} $cleanupCheckbox
+FunctionEnd
+
+Function un.LeaveUnWelcome
+  ${NSD_GetState} $cleanupCheckbox $0
+  ${If} $0 <> 0
+    RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-client"
+    RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-plugins"
+  ${EndIf}
+FunctionEnd

--- a/installer.nsh
+++ b/installer.nsh
@@ -45,5 +45,6 @@ Function un.LeaveUnWelcome
   ${If} $0 <> 0
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-client"
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-plugins"
+    RMDir /r "$PROFILE\\AppData\\Roaming\\streamlabs-highlighter"
   ${EndIf}
 FunctionEnd

--- a/installer.nsh
+++ b/installer.nsh
@@ -46,5 +46,8 @@ Function un.LeaveUnWelcome
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-client"
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-plugins"
     RMDir /r "$PROFILE\\AppData\\Roaming\\streamlabs-highlighter"
+    ; REBOOTOK flg is required, because files might get injected into a game process and system may prevent their removal
+    ; see: https://nsis.sourceforge.io/Reference/RMDir
+    RMDir /r /REBOOTOK "C:\\ProgramData\\obs-studio-hook"
   ${EndIf}
 FunctionEnd

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -17,34 +17,40 @@ fs.writeFileSync(antdLibSettingsPath, JSON.stringify(antdlibSettings, null, 2));
 
 
 // The code below is needed to provide a better uninstall experience.
-// Here we patch assistedInstaller.nsh to avoid redudant uninstaller welcome page.
+// Here we patch assistedInstaller.nsh to avoid redundant uninstaller welcome page.
 // When we upgrade electron-builder package to at least 23.0.6 we need to use the removeDefaultUninstallWelcomePage
 // option and the code below can be removed.
 // @see https://stackoverflow.com/questions/73454796/default-unwelcome-page-with-electron-builder-nsis-cant-be-changed-or-removed
 const assistedInstallerPath = path.resolve('./node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh');
 
-// Read the file, modify it, and write back
+// Function to read, modify, and write without closing the file
 const commentLineInFile = (assistedInstallerPath, lineToComment, commentString = ';') => {
-  if (!fs.existsSync(assistedInstallerPath)) {
-    console.error(`File not found: ${assistedInstallerPath}`);
-    process.exit(1);
-  }
+  let fd;
 
-  let fileContent = fs.readFileSync(assistedInstallerPath, 'utf-8');
-  const modifiedContent = fileContent
-    .split('\n')
-    .map((line) => {
+  try {
+    fd = fs.openSync(assistedInstallerPath, 'r+');
+
+    const fileContent = fs.readFileSync(fd, 'utf-8');
+    const modifiedContent = fileContent
+      .split('\n')
+      .map((line) => {
         if (line.includes(lineToComment) && !line.trim().startsWith(';')) {
-            return `${commentString}${line}`;
+          return `${commentString}${line}`; // Add commentString to the target line
         }
         return line; // Leave all other lines unchanged
-    })
-    .join('\n'); // Rejoin the lines back together into a single string
+      })
+      .join('\n'); // Rejoin the lines back together into a single string
 
+    fs.ftruncateSync(fd); // Truncate the file to ensure old content is removed
+    fs.writeSync(fd, modifiedContent);
 
-  if (fs.existsSync(assistedInstallerPath)) {
-    fs.writeFileSync(assistedInstallerPath, modifiedContent, 'utf-8');
     console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
+  } catch (error) {
+    console.error(`Post install. An error occurred while processing the file: ${error.message}`);
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
   }
 };
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,3 +14,36 @@ const antdlibSettings = JSON.parse(fs.readFileSync(antdLibSettingsPath, 'utf8'))
 delete antdlibSettings.module;
 antdlibSettings.main = 'dist/antd.min.js';
 fs.writeFileSync(antdLibSettingsPath, JSON.stringify(antdlibSettings, null, 2));
+
+
+// The code below is needed to provide a better uninstall experience.
+// Here we patch assistedInstaller.nsh to avoid redudant uninstaller welcome page.
+// When we upgrade electron-builder package to at least 23.0.6 we need to use the removeDefaultUninstallWelcomePage
+// option and the code below can be removed.
+// @see https://stackoverflow.com/questions/73454796/default-unwelcome-page-with-electron-builder-nsis-cant-be-changed-or-removed
+const assistedInstallerPath = path.resolve('./node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh');
+
+// Read the file, modify it, and write back
+const commentLineInFile = (assistedInstallerPath, lineToComment, commentString = ';') => {
+  if (!fs.existsSync(assistedInstallerPath)) {
+    console.error(`File not found: ${assistedInstallerPath}`);
+    process.exit(1);
+  }
+
+  let fileContent = fs.readFileSync(assistedInstallerPath, 'utf-8');
+  const modifiedContent = fileContent
+    .split('\n')
+    .map((line) => {
+        if (line.includes(lineToComment) && !line.trim().startsWith(';')) {
+            return `${commentString}${line}`;
+        }
+        return line; // Leave all other lines unchanged
+    })
+    .join('\n'); // Rejoin the lines back together into a single string
+
+
+  fs.writeFileSync(assistedInstallerPath, modifiedContent, 'utf-8');
+  console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
+};
+
+commentLineInFile(assistedInstallerPath, '!insertmacro MUI_UNPAGE_WELCOME');

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -17,33 +17,52 @@ fs.writeFileSync(antdLibSettingsPath, JSON.stringify(antdlibSettings, null, 2));
 
 
 // The code below is needed to provide a better uninstall experience.
-// Here we patch assistedInstaller.nsh to avoid redudant uninstaller welcome page.
+// Here we patch assistedInstaller.nsh to avoid redundant uninstaller welcome page.
 // When we upgrade electron-builder package to at least 23.0.6 we need to use the removeDefaultUninstallWelcomePage
 // option and the code below can be removed.
 // @see https://stackoverflow.com/questions/73454796/default-unwelcome-page-with-electron-builder-nsis-cant-be-changed-or-removed
 const assistedInstallerPath = path.resolve('./node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh');
 
-// Read the file, modify it, and write back
+// Read the file, modify it, and write back using file descriptors
 const commentLineInFile = (assistedInstallerPath, lineToComment, commentString = ';') => {
+  // Check if the file exists
   if (!fs.existsSync(assistedInstallerPath)) {
     console.error(`File not found: ${assistedInstallerPath}`);
     process.exit(1);
   }
 
-  let fileContent = fs.readFileSync(assistedInstallerPath, 'utf-8');
-  const modifiedContent = fileContent
-    .split('\n')
-    .map((line) => {
+  let fd = null;
+
+  try {
+    fd = fs.openSync(assistedInstallerPath, 'r');
+    const fileContent = fs.readFileSync(fd, 'utf-8');
+    fs.closeSync(fd);
+
+    const modifiedContent = fileContent
+      .split('\n')
+      .map((line) => {
         if (line.includes(lineToComment) && !line.trim().startsWith(';')) {
-            return `${commentString}${line}`;
+          return `${commentString}${line}`;
         }
         return line; // Leave all other lines unchanged
-    })
-    .join('\n'); // Rejoin the lines back together into a single string
+      })
+      .join('\n'); // Rejoin the lines back together into a single string
 
-
-  fs.writeFileSync(assistedInstallerPath, modifiedContent, 'utf-8');
-  console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
+    fd = fs.openSync(assistedInstallerPath, 'w');
+    if (fd) {
+      fs.writeFileSync(fd, modifiedContent, 'utf-8');
+      console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
+    } else {
+      throw Error('Failed to write');
+    }
+  } catch (error) {
+    console.error(`Post install. An error occurred while processing the file: ${error.message}`);
+  } finally {
+    if (fd) {
+      fs.closeSync(fd);
+    }
+  }
 };
 
+// Call the function to comment out a specific line
 commentLineInFile(assistedInstallerPath, '!insertmacro MUI_UNPAGE_WELCOME');

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -17,52 +17,35 @@ fs.writeFileSync(antdLibSettingsPath, JSON.stringify(antdlibSettings, null, 2));
 
 
 // The code below is needed to provide a better uninstall experience.
-// Here we patch assistedInstaller.nsh to avoid redundant uninstaller welcome page.
+// Here we patch assistedInstaller.nsh to avoid redudant uninstaller welcome page.
 // When we upgrade electron-builder package to at least 23.0.6 we need to use the removeDefaultUninstallWelcomePage
 // option and the code below can be removed.
 // @see https://stackoverflow.com/questions/73454796/default-unwelcome-page-with-electron-builder-nsis-cant-be-changed-or-removed
 const assistedInstallerPath = path.resolve('./node_modules/app-builder-lib/templates/nsis/assistedInstaller.nsh');
 
-// Read the file, modify it, and write back using file descriptors
+// Read the file, modify it, and write back
 const commentLineInFile = (assistedInstallerPath, lineToComment, commentString = ';') => {
-  // Check if the file exists
   if (!fs.existsSync(assistedInstallerPath)) {
     console.error(`File not found: ${assistedInstallerPath}`);
     process.exit(1);
   }
 
-  let fd = null;
-
-  try {
-    fd = fs.openSync(assistedInstallerPath, 'r');
-    const fileContent = fs.readFileSync(fd, 'utf-8');
-    fs.closeSync(fd);
-
-    const modifiedContent = fileContent
-      .split('\n')
-      .map((line) => {
+  let fileContent = fs.readFileSync(assistedInstallerPath, 'utf-8');
+  const modifiedContent = fileContent
+    .split('\n')
+    .map((line) => {
         if (line.includes(lineToComment) && !line.trim().startsWith(';')) {
-          return `${commentString}${line}`;
+            return `${commentString}${line}`;
         }
         return line; // Leave all other lines unchanged
-      })
-      .join('\n'); // Rejoin the lines back together into a single string
+    })
+    .join('\n'); // Rejoin the lines back together into a single string
 
-    fd = fs.openSync(assistedInstallerPath, 'w');
-    if (fd) {
-      fs.writeFileSync(fd, modifiedContent, 'utf-8');
-      console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
-    } else {
-      throw Error('Failed to write');
-    }
-  } catch (error) {
-    console.error(`Post install. An error occurred while processing the file: ${error.message}`);
-  } finally {
-    if (fd) {
-      fs.closeSync(fd);
-    }
+
+  if (fs.existsSync(assistedInstallerPath)) {
+    fs.writeFileSync(assistedInstallerPath, modifiedContent, 'utf-8');
+    console.log(`Post install. Successfully commented "${lineToComment}" in file: ${assistedInstallerPath}`);
   }
 };
 
-// Call the function to comment out a specific line
 commentLineInFile(assistedInstallerPath, '!insertmacro MUI_UNPAGE_WELCOME');


### PR DESCRIPTION
To implement this flawless UI, I had to patch electron-builder a little.
All other alternatives introduce ugly UX and at least one additional page for no reason.
We can get rid of that patching code when we upgrade to a newer version.

![image](https://github.com/user-attachments/assets/562ba0a0-4b21-40ad-90d6-429f78bcf192)
