### PR TITLE
Output native errors to console from Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,7 +37,8 @@
       "cwd": "${workspaceRoot}",
       "env": {
         "SLOBS_PRODUCTION_DEBUG": "true"
-      }
+      },
+      "outputCapture": "std"
     }
   ],
   "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,22 @@
         "SLOBS_PRODUCTION_DEBUG": "true"
       },
       "outputCapture": "std"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch With Native Logging",
+      "protocol": "inspector",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd",
+      "osx": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron"
+      },
+      "runtimeArgs": [".", "--remote-debugging-port=9222"],
+      "cwd": "${workspaceRoot}",
+      "env": {
+        "SLOBS_PRODUCTION_DEBUG": "true"
+      },
+      "outputCapture": "std"
     }
   ],
   "compounds": [


### PR DESCRIPTION
When troubleshooting issues from `obs-studio-node` it can be useful to capture `std` output in console.

However, one could argue perhaps this might be annoying to those that do not care to see native logs? We could add another launch target if that's the case? For now I added it to "Launch with DevTools".