### PR TITLE
[Highlighter] - export settings updates

### DIFF
--- a/app/components-react/highlighter/Export/ExportModal.tsx
+++ b/app/components-react/highlighter/Export/ExportModal.tsx
@@ -144,15 +144,17 @@ function ExportModal({ close, streamId }: { close: () => void; streamId: string 
   // Clear all errors when this component unmounts
   useEffect(() => unmount, []);
 
-  if (!exportInfo.exported || exportInfo.exporting) {
+  if (!exportInfo.exported || exportInfo.exporting || exportInfo.error) {
     return (
-      <ExportFlow
-        isExporting={exportInfo.exporting}
-        close={close}
-        streamId={streamId}
-        videoName={videoName}
-        onVideoNameChange={setVideoName}
-      />
+      <>
+        <ExportFlow
+          isExporting={exportInfo.exporting}
+          close={close}
+          streamId={streamId}
+          videoName={videoName}
+          onVideoNameChange={setVideoName}
+        />
+      </>
     );
   }
   return <PlatformSelect onClose={close} videoName={videoName} streamId={streamId} />;
@@ -330,7 +332,6 @@ function ExportFlow({
                 buttonContent={<i className="icon-edit" />}
               />
             </div>
-
             <div
               className={cx(styles.thumbnail, isExporting && styles.thumbnailInProgress)}
               style={
@@ -369,7 +370,6 @@ function ExportFlow({
                 }
               />
             </div>
-
             <div className={styles.clipInfoWrapper}>
               <div
                 className={cx(isExporting && styles.isDisabled)}
@@ -393,7 +393,6 @@ function ExportFlow({
                 emitState={format => setCurrentFormat(format)}
               />
             </div>
-
             <div
               style={{
                 display: 'flex',
@@ -466,10 +465,8 @@ function ExportFlow({
                 </div>
               </div>
             )}
-
             {exportInfo.error && (
               <Alert
-                style={{ marginBottom: 24 }}
                 message={exportInfo.error}
                 type="error"
                 closable

--- a/app/components-react/highlighter/Export/ExportModal.tsx
+++ b/app/components-react/highlighter/Export/ExportModal.tsx
@@ -146,15 +146,13 @@ function ExportModal({ close, streamId }: { close: () => void; streamId: string 
 
   if (!exportInfo.exported || exportInfo.exporting || exportInfo.error) {
     return (
-      <>
-        <ExportFlow
-          isExporting={exportInfo.exporting}
-          close={close}
-          streamId={streamId}
-          videoName={videoName}
-          onVideoNameChange={setVideoName}
-        />
-      </>
+      <ExportFlow
+        isExporting={exportInfo.exporting}
+        close={close}
+        streamId={streamId}
+        videoName={videoName}
+        onVideoNameChange={setVideoName}
+      />
     );
   }
   return <PlatformSelect onClose={close} videoName={videoName} streamId={streamId} />;

--- a/app/components-react/highlighter/Export/ExportModal.tsx
+++ b/app/components-react/highlighter/Export/ExportModal.tsx
@@ -223,12 +223,10 @@ function ExportFlow({
     async function initializeSettings() {
       try {
         const resolution = await getClipResolution(streamId);
-        console.log('Detected resolution:', resolution);
-
         let setting: TSetting;
-        if (resolution?.height === 720) {
+        if (resolution?.height === 720 && exportInfo.resolution !== 720) {
           setting = settings.find(s => s.resolution === 720) || settings[settings.length - 1];
-        } else if (resolution?.height === 1080) {
+        } else if (resolution?.height === 1080 && exportInfo.resolution !== 1080) {
           setting = settings.find(s => s.resolution === 1080) || settings[settings.length - 1];
         } else {
           setting = settingMatcher({
@@ -241,7 +239,7 @@ function ExportFlow({
 
         setSetting(setting);
       } catch (error: unknown) {
-        console.error('Failed to detect resolution', error);
+        console.error('Failed to detect clip resolution, setting default. Error: ', error);
         setSetting(
           settingMatcher({
             name: 'from default',


### PR DESCRIPTION
- Now the export default selection takes the resolution of the input video into account. Eg if the input clip is 720p it will also select a matching export preset. Before it always selected a 1080p preset.
- also fixed a missing error state