### PR TITLE
Fixed rendering issue (mac) / bump obs-studio-node version

### DIFF
--- a/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
@@ -38,7 +38,7 @@ export function TwitchEditStreamInfo(p: IPlatformComponentParams<'twitch'>) {
       <InputWrapper>
         <CheckboxInput label={$t('Stream features branded content')} {...bind.isBrandedContent} />
       </InputWrapper>
-      {p.enabledPlatformsCount === 1 && <InputWrapper>
+      {p.enabledPlatformsCount === 1 && process.platform !== 'darwin' && <InputWrapper>
         <div>
           <CheckboxInput style={{display: 'inline-block'}} label={$t('Enhanced broadcasting')} tooltip={enhancedBroadcastingTooltipText} {...bind.isEnhancedBroadcasting} />
           <Badge style={{display: 'inline-block'}} dismissableKey={EDismissable.EnhancedBroadcasting} content={'Beta'} />

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -216,7 +216,6 @@ export class Display {
     this.currentPosition.width = width;
     this.currentPosition.height = height;
     this.videoService.actions.resizeOBSDisplay(this.name, width, height);
-    if (this.outputRegionCallbacks.length) await this.refreshOutputRegion();
 
     // On mac, resizing the display is not enough, we also have to
     // recreate the window and IOSurface for the new size
@@ -226,13 +225,24 @@ export class Display {
         nwr.destroyIOSurface(this.name);
       }
 
-      const surface = this.videoService.createOBSIOSurface(this.name);
-      nwr.createWindow(
-        this.name,
-        remote.BrowserWindow.fromId(this.electronWindowId).getNativeWindowHandle(),
-      );
-      nwr.connectIOSurface(this.name, surface);
+      try {
+        const surface = this.videoService.createOBSIOSurface(this.name);
+        nwr.createWindow(
+          this.name,
+          remote.BrowserWindow.fromId(this.electronWindowId).getNativeWindowHandle(),
+        );
+        nwr.connectIOSurface(this.name, surface);
+
+        if (this.existingWindow && this.outputRegionCallbacks.length) {
+          await this.refreshOutputRegion();
+        }
+      } catch (ex)
+      {
+        console.log(`Error encountered creating iosurface: ${ex}`);
+      }
       this.existingWindow = true;
+    } else if (this.outputRegionCallbacks.length) {
+      await this.refreshOutputRegion();
     }
   }
 

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -233,7 +233,7 @@ export class Display {
         );
         nwr.connectIOSurface(this.name, surface);
 
-        if (this.existingWindow && this.outputRegionCallbacks.length) {
+        if (this.outputRegionCallbacks.length) {
           await this.refreshOutputRegion();
         }
       } catch (ex)

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -236,8 +236,7 @@ export class Display {
         if (this.outputRegionCallbacks.length) {
           await this.refreshOutputRegion();
         }
-      } catch (ex)
-      {
+      } catch (ex: unknown) {
         console.log(`Error encountered creating iosurface: ${ex}`);
       }
       this.existingWindow = true;

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -51,7 +51,7 @@ function signBinaries(identity, directory) {
   }
 }
 
-function afterPackMac() {
+function afterPackMac(context) {
   console.log('Updating dependency paths');
   cp.execSync(
     `install_name_tool -change ./node_modules/node-libuiohook/libuiohook.1.dylib @executable_path/../Resources/app.asar.unpacked/node_modules/node-libuiohook/libuiohook.1.dylib \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked/node_modules/node-libuiohook/node_libuiohook.node\"`,
@@ -83,7 +83,7 @@ function afterPackWin() {
 
 exports.default = async function(context) {
   if (process.platform === 'darwin') {
-    afterPackMac();
+    afterPackMac(context);
   }
 
   if (process.platform === 'win32') {

--- a/electron-builder/afterSign.js
+++ b/electron-builder/afterSign.js
@@ -4,7 +4,7 @@ const cp = require('child_process');
 const path = require('path');
 const os = require('os');
 
-async function notarizeMac() {
+async function notarizeMac(context) {
   if (process.env.SLOBS_NO_NOTARIZE) return;
   if (process.platform !== 'darwin') return;
 
@@ -45,7 +45,7 @@ async function afterPackWin() {
 
 exports.default = async function afterSign(context) {
   if (process.platform === 'darwin') {
-    await notarizeMac();
+    await notarizeMac(context);
   }
 
   if (process.platform === 'win32') {

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -5,7 +5,7 @@
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
       "version": "0.25.24",
-      "mac_version": "0.25.24",
+      "mac_version": "0.25.21test58",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -5,7 +5,7 @@
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
       "version": "0.25.24",
-      "mac_version": "0.25.21test58",
+      "mac_version": "0.25.27",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
* updated mac to properly utilize the feature added in commit 9e5216a34
* log if the iosurface cannot be created
* Bump Mac version to `0.25.27`
* Fix issue that occurs after packing in `electron-builder-mac` flow 

Manual Tests:
* Dual Output works properly (streamed to Kick / Youtube)
* Enhanced Broadcasting is properly disabled on Mac (made sure the option is not visible)
* Audio/Video works properly
* Built a package locally using `yarn package:mac`