### PR TITLE
Remove "Developer ID Application: " prefix

### DIFF
--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -6,7 +6,7 @@ const os = require('os');
 function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
 
-  cp.execSync(`codesign -fs "Developer ID Application: ${identity}" "${filePath}"`);
+  cp.execSync(`codesign -fs "${identity}" "${filePath}"`);
 
   // All files need to be writable for update to succeed on mac
   console.log(`Checking Writable: ${filePath}`);

--- a/electron-builder/beforePack.js
+++ b/electron-builder/beforePack.js
@@ -5,7 +5,7 @@ const path = require('path');
 function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
 
-  cp.execSync(`codesign -fs "Developer ID Application: ${identity}" "${filePath}"`);
+  cp.execSync(`codesign -fs "${identity}" "${filePath}"`);
 
   // All files need to be writable for update to succeed on mac
   console.log(`Checking Writable: ${filePath}`);


### PR DESCRIPTION
* Pass the $identity directly into codesign argument

Verified locally by running the `yarn package:mac` command

UPDATE: Setting this back into *draft*. Investigating 