### PR TITLE
[highlighter] - fix disabled export button 

### DIFF
--- a/app/components-react/highlighter/ClipsViewModal.tsx
+++ b/app/components-react/highlighter/ClipsViewModal.tsx
@@ -20,7 +20,7 @@ export default function ClipsViewModal({
   streamId: string | undefined;
   modal: { modal: TModalClipsView; inspectedPathId?: string } | null;
   onClose: () => void;
-  deleteClip: (clipPath: string, streamId: string | undefined) => void;
+  deleteClip: (clipPath: string[], streamId: string | undefined) => void;
 }) {
   const { HighlighterService } = Services;
   const v = useVuex(() => ({

--- a/app/components-react/highlighter/PreviewModal.tsx
+++ b/app/components-react/highlighter/PreviewModal.tsx
@@ -11,6 +11,7 @@ import { TModalClipsView } from './ClipsView';
 import { CheckboxInput } from 'components-react/shared/inputs';
 import { formatSecondsToHMS } from './ClipPreview';
 import { TModalStreamCard } from './StreamCardModal';
+import { useVuex } from 'components-react/hooks';
 
 interface IPlaylist {
   src: string;
@@ -32,7 +33,9 @@ export default function PreviewModal({
   emitSetShowModal: (modal: 'export' | null) => void;
 }) {
   const { HighlighterService, UsageStatisticsService } = Services;
-  const clips = HighlighterService.getClips(HighlighterService.views.clips, streamId);
+  const clips = useVuex(() =>
+    HighlighterService.getClips(HighlighterService.views.clips, streamId),
+  );
   const { intro, outro } = HighlighterService.views.video;
   const audioSettings = HighlighterService.views.audio;
   const sortedClips = [...sortClipsByOrder(clips, streamId)];
@@ -368,6 +371,7 @@ export default function PreviewModal({
           />
           <Button
             type="primary"
+            disabled={playlist.filter(clip => clip.enabled).length === 0}
             onClick={() => {
               emitSetShowModal('export');
             }}

--- a/app/components-react/highlighter/RemoveModal.tsx
+++ b/app/components-react/highlighter/RemoveModal.tsx
@@ -11,7 +11,7 @@ export default function RemoveModal(p: {
   clip: TClip;
   streamId: string | undefined;
   close: () => void;
-  deleteClip: (clipPath: string, streamId: string | undefined) => void;
+  deleteClip: (clipPath: string[], streamId: string | undefined) => void;
 }) {
   const { HighlighterService } = Services;
   const [deleteAllSelected, setDeleteAllSelected] = useState<boolean>(false);
@@ -94,8 +94,8 @@ export default function RemoveModal(p: {
               clipsToDelete.forEach(clip => {
                 HighlighterService.actions.removeClip(clip.path, p.streamId);
               });
-
-              p.deleteClip(p.clip.path, p.streamId);
+              const clipsToDeletePaths = clipsToDelete.map(clip => clip.path);
+              p.deleteClip(clipsToDeletePaths, p.streamId);
               p.close();
             }}
           >


### PR DESCRIPTION
If the user deleted multiple clips via the 'delete selected clips' deletion, the export and preview button would stay stuck in the disabled state. This PR fixes that.
