### PR TITLE
[highlighter] - Modal didn't update properly

### DIFF
--- a/app/components-react/highlighter/StreamView.tsx
+++ b/app/components-react/highlighter/StreamView.tsx
@@ -41,6 +41,7 @@ export default function StreamView({ emitSetView }: { emitSetView: (data: IViewS
     error: HighlighterService.views.error,
     uploadInfo: HighlighterService.views.uploadInfo,
     highlighterVersion: HighlighterService.views.highlighterVersion,
+    tempRecordingInfoPath: HighlighterService.views.tempRecordingInfo.recordingPath,
   }));
 
   useEffect(() => {
@@ -55,7 +56,7 @@ export default function StreamView({ emitSetView }: { emitSetView: (data: IViewS
         openedFrom: recordingInfo.source,
       });
     }
-  }, []);
+  }, [v.tempRecordingInfoPath]);
 
   // Below is only used because useVueX doesnt work as expected
   // there probably is a better way to do this


### PR DESCRIPTION
- before it was called when the component mounted. 

How to test:
1. runthrough: Go-live, toggle on highlighter, stream, end stream = should get redirected to streamView and the modal should open
2. runthrough: open/stay on streamView, Go-live, toggle on highlighter, stream, end stream = it should not redirect anywhere since you are already on the streamView + it should open the modal (before it didn't open the modal here)