### PR TITLE
[Highlighter] - Recording wrote tracking

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1392,6 +1392,10 @@ export class StreamingService
       }
 
       if (info.signal === EOBSOutputSignal.Wrote) {
+        this.usageStatisticsService.recordAnalyticsEvent('RecordingStatus', {
+          status: nextState,
+          code: info.code,
+        });
         const filename = NodeObs.OBS_service_getLastRecording();
         const parsedFilename = byOS({
           [OS.Mac]: filename,


### PR DESCRIPTION
It seems that we are not tracking recording finished anywhere in the streaming service at the moment. 
Just created this PR to add that. 
We still experience a big dropoff between recording started and recording finished for highlighter users, so want to know if the dropoff is the same for non-highlighter users. 

Please lmk if there is already tracking somewhere that i missed. 