### PR TITLE
Update Desktop to support the new mac virtual camera system extension

### DIFF
--- a/app/services/core/signals.ts
+++ b/app/services/core/signals.ts
@@ -1,0 +1,46 @@
+import { EOutputCode } from '../../../obs-api';
+
+export enum EOBSOutputType {
+  Streaming = 'streaming',
+  Recording = 'recording',
+  ReplayBuffer = 'replay-buffer',
+  VirtualCam = 'virtual-camera',
+}
+
+export enum EOBSOutputSignal {
+  Starting = 'starting',
+  Start = 'start',
+  Stopping = 'stopping',
+  Stop = 'stop',
+  Activate = 'activate',
+  Deactivate = 'deactivate',
+  Reconnect = 'reconnect',
+  ReconnectSuccess = 'reconnect_success',
+  Wrote = 'wrote',
+  Writing = 'writing',
+  WriteError = 'writing_error',
+}
+
+export enum EOutputSignalState {
+  Saving = 'saving',
+  Starting = 'starting',
+  Start = 'start',
+  Stopping = 'stopping',
+  Stop = 'stop',
+  Activate = 'activate',
+  Deactivate = 'deactivate',
+  Reconnect = 'reconnect',
+  ReconnectSuccess = 'reconnect_success',
+  Running = 'running',
+  Wrote = 'wrote',
+  Writing = 'writing',
+  WriteError = 'writing_error',
+}
+
+export interface IOBSOutputSignalInfo {
+  type: EOBSOutputType;
+  signal: EOBSOutputSignal;
+  code: EOutputCode;
+  error: string;
+  service: string; // 'default' | 'vertical'
+}

--- a/app/services/streaming/stream-error.ts
+++ b/app/services/streaming/stream-error.ts
@@ -1,7 +1,7 @@
 import { getPlatformService, TPlatform } from '../platforms';
 import { $t } from 'services/i18n';
 import { Services } from '../../components-react/service-provider';
-import { IOBSOutputSignalInfo } from './streaming';
+import { IOBSOutputSignalInfo } from '../core/signals';
 import { capitalize } from 'lodash';
 
 // the `message` is shown to the user in the error notification

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -79,57 +79,7 @@ import { byOS, OS } from 'util/operating-systems';
 import { DualOutputService } from 'services/dual-output';
 import { capitalize } from 'lodash';
 import { YoutubeService } from 'app-services';
-
-enum EOBSOutputType {
-  Streaming = 'streaming',
-  Recording = 'recording',
-  ReplayBuffer = 'replay-buffer',
-}
-
-const outputType = (type: EOBSOutputType) =>
-  ({
-    [EOBSOutputType.Streaming]: $t('Streaming'),
-    [EOBSOutputType.Recording]: $t('Recording'),
-    [EOBSOutputType.ReplayBuffer]: $t('Replay Buffer'),
-  }[type]);
-
-enum EOBSOutputSignal {
-  Starting = 'starting',
-  Start = 'start',
-  Stopping = 'stopping',
-  Stop = 'stop',
-  Activate = 'activate',
-  Deactivate = 'deactivate',
-  Reconnect = 'reconnect',
-  ReconnectSuccess = 'reconnect_success',
-  Wrote = 'wrote',
-  Writing = 'writing',
-  WriteError = 'writing_error',
-}
-
-enum EOutputSignalState {
-  Saving = 'saving',
-  Starting = 'starting',
-  Start = 'start',
-  Stopping = 'stopping',
-  Stop = 'stop',
-  Activate = 'activate',
-  Deactivate = 'deactivate',
-  Reconnect = 'reconnect',
-  ReconnectSuccess = 'reconnect_success',
-  Running = 'running',
-  Wrote = 'wrote',
-  Writing = 'writing',
-  WriteError = 'writing_error',
-}
-
-export interface IOBSOutputSignalInfo {
-  type: EOBSOutputType;
-  signal: EOBSOutputSignal;
-  code: EOutputCode;
-  error: string;
-  service: string; // 'default' | 'vertical'
-}
+import { EOBSOutputType, EOBSOutputSignal, IOBSOutputSignalInfo } from 'services/core/signals';
 
 /**
  * Output descriptor for extra outputs (e.g YouTube vertical)
@@ -1733,6 +1683,7 @@ export class StreamingService
         [EOBSOutputType.Streaming]: $t('Streaming Error'),
         [EOBSOutputType.Recording]: $t('Recording Error'),
         [EOBSOutputType.ReplayBuffer]: $t('Replay Buffer Error'),
+        [EOBSOutputType.VirtualCam]: $t('Virtual Cam Error'),
       }[info.type];
 
       if (linkToDriverInfo) buttons.push($t('Learn More'));

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -2,6 +2,7 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const packVirtualCamera = require('./build-mac-virtualcam');
 
 function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
@@ -64,6 +65,8 @@ function afterPackMac(context) {
   cp.execSync(
     `cp -R ./node_modules/obs-studio-node/Frameworks \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked/node_modules/\"`,
   );
+
+  packVirtualCamera(context);
 
   if (process.env.SLOBS_NO_SIGN) return;
 

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -1,0 +1,38 @@
+const pjson = require('../package.json');
+const cp = require('child_process');
+
+function downloadTempRepo() {
+  const repoVersion = pjson.macVirtualCamVersion;
+  let result = true;
+  const repo = `git clone --branch ${repoVersion} --depth 1 https://github.com/streamlabs/obs-studio.git`;
+  try {
+    cp.execSync(
+      'rm -rf obs-studio',
+    );
+    cp.execSync(repo);
+  } catch {
+    result = false;
+  }
+  return result;
+}
+
+// Download the Mac virtual camera system extension. Build, codesign, and pack it into the executable.
+function buildVirtualCamExtension(context) {
+  const hasDownloadedRepo = downloadTempRepo(cp);
+  if (hasDownloadedRepo) {
+    const hasBuiltProj = cp.execSync(`cd ./obs-studio/plugins/mac-virtualcam/src/camera-extension && ./build-slobs-cameraextension.sh`);
+    if (hasBuiltProj) {
+      cp.execSync(
+        `mkdir -p \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions\"`,
+      );
+      // Now copy the system extension into the dist app
+      cp.execSync(
+        `cp -R ./obs-studio/plugins/mac-virtualcam/src/camera-extension/build_macos/RelWithDebInfo/com.streamlabs.slobs.mac-camera-extension.systemextension \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions\"`,
+      );
+    }
+  } else {
+    console.log('Could not download the vcam repo');
+  }
+}
+
+module.exports = buildVirtualCamExtension;

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -6,9 +6,7 @@ function downloadTempRepo() {
   let result = true;
   const repo = `git clone --branch ${repoVersion} --depth 1 https://github.com/streamlabs/obs-studio.git`;
   try {
-    cp.execSync(
-      'rm -rf obs-studio',
-    );
+    cp.execSync('rm -rf obs-studio');
     cp.execSync(repo);
   } catch {
     result = false;
@@ -20,7 +18,7 @@ function downloadTempRepo() {
 function buildVirtualCamExtension(context) {
   const hasDownloadedRepo = downloadTempRepo(cp);
   if (hasDownloadedRepo) {
-    const hasBuiltProj = cp.execSync(`cd ./obs-studio/plugins/mac-virtualcam/src/camera-extension && ./build-slobs-cameraextension.sh`);
+    const hasBuiltProj = cp.execSync('cd ./obs-studio/plugins/mac-virtualcam/src/camera-extension && ./build-slobs-cameraextension.sh');
     if (hasBuiltProj) {
       cp.execSync(
         `mkdir -p \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions\"`,

--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.developer.system-extension.install</key>
+    <true/>
   </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
   "version": "1.19.0-preview.8",
+  "macVirtualCamVersion": "30.2.4sl19test5",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.29",
+      "version": "0.25.30vcamTest1",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
### Description
Updates the virtualcam included in obs30 to work with externally outside of OBS.app by configuring it with the `com.streamlabs.slobs` bundle identifier and enabling the swift camera-extension to be downloaded and built by a different repo for `codesign`.

### Motivation and Context
The former legacy DAL plugin was deprecated by Apple. Enabled the mac obs30 virtual camera to be used with Streamlabs Desktop. This way we are using the same implementation as obs.

### How Has This Been Tested?
* In OSN, added a small test case that initialized the virtual cam. However, this only works locally due to System extension(s) security restrictions (cant install those on a build agent).
* In Streamlabs-Desktop, verified this works in non-codesigned builds.
* Tested mostly outside of app bundles via the `VIRTUALCAM_BYPASS_SYSTEM_CHECK` environment var (I updated cmake to look for this var when its building the project for xcode). Also tested within an app bundle but w/o codesign.