### PR TITLE
add nosync flag to disable cloud sync when logged in

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,13 +43,13 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch With Native Logging",
+      "name": "Launch Without Sync",
       "protocol": "inspector",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd",
       "osx": {
         "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron"
       },
-      "runtimeArgs": [".", "--remote-debugging-port=9222"],
+      "runtimeArgs": [".", "--remote-debugging-port=9222", "--nosync"],
       "cwd": "${workspaceRoot}",
       "env": {
         "SLOBS_PRODUCTION_DEBUG": "true"

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -1185,7 +1185,11 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   }
 
   canSync(): boolean {
-    return this.userService.isLoggedIn && !this.appService.state.argv.includes('--nosync');
+    return (
+      this.userService.isLoggedIn &&
+      !this.appService.state.argv.includes('--nosync') &&
+      !process.argv.includes('--nosync')
+    );
   }
 
   /**


### PR DESCRIPTION
* Add --nosync flag so we can test streaming with another user's scene collection
* rename "Launch with Native Logging" -> "Launch Without Sync" and utilize the --nosync flag

"Launch with Dev Tools" already has native logging which I added in a previous PR (so "Launch with Native Logging" was redundant). So in this PR, was thinking to change that launch option to use this new `--nosync` flag which makes it much easier to troubleshoot various sceneCollections without fear of it being overwritten