### PR TITLE
Update MixerItem to handle a Null audio source

### DIFF
--- a/app/components-react/editor/elements/mixer/MixerItem.tsx
+++ b/app/components-react/editor/elements/mixer/MixerItem.tsx
@@ -17,10 +17,10 @@ export default function MixerItem(p: { audioSourceId: string; volmetersEnabled?:
 
   const { sourceName, muted, deflection, db } = useVuex(() => ({
     performanceMode: CustomizationService.state.performanceMode,
-    sourceName: SourcesService.state.sources[p.audioSourceId].name,
-    muted: AudioService.views.getSource(p.audioSourceId).muted,
-    deflection: AudioService.views.getSource(p.audioSourceId).fader.deflection,
-    db: AudioService.views.getSource(p.audioSourceId).fader.db,
+    sourceName: SourcesService.state.sources[p.audioSourceId]?.name,
+    muted: AudioService.views.getSource(p.audioSourceId)?.muted,
+    deflection: AudioService.views.getSource(p.audioSourceId)?.fader.deflection,
+    db: AudioService.views.getSource(p.audioSourceId)?.fader.db,
   }));
 
   function setMuted() {
@@ -40,43 +40,49 @@ export default function MixerItem(p: { audioSourceId: string; volmetersEnabled?:
   }
 
   return (
-    <div className={cx(styles.mixerItem, { [styles.muted]: muted })}>
-      <div className="flex">
-        <div className={styles.sourceName}>{sourceName}</div>
-        <div className={styles.dbValue}>
-          {deflection === 0 && <div>-Inf dB</div>}
-          {deflection !== 0 && <div>{db.toFixed(1)} dB</div>}
-        </div>
-      </div>
+    <>
+      {AudioService.views.getSource(p.audioSourceId) ? (
+        <div className={cx(styles.mixerItem, { [styles.muted]: muted })}>
+          <div className="flex">
+            <div className={styles.sourceName}>{sourceName}</div>
+            <div className={styles.dbValue}>
+              {deflection === 0 && <div>-Inf dB</div>}
+              {deflection !== 0 && <div>{db.toFixed(1)} dB</div>}
+            </div>
+          </div>
 
-      {!performanceMode && (
-        <MixerVolmeter audioSourceId={p.audioSourceId} volmetersEnabled={volmetersEnabled} />
+          {!performanceMode && (
+            <MixerVolmeter audioSourceId={p.audioSourceId} volmetersEnabled={volmetersEnabled} />
+          )}
+
+          <div className="flex">
+            <div style={{ width: '100%', marginTop: '8px', marginBottom: '8px' }}>
+              <SliderInput
+                value={deflection}
+                onChange={onSliderChangeHandler}
+                min={0}
+                max={1}
+                step={0.01}
+                throttle={100}
+                nowrap
+              />
+            </div>
+            <div className={styles.controls}>
+              <i
+                className={cx('icon-button', muted ? 'icon-mute' : 'icon-audio')}
+                title={muted ? 'click to switch on' : 'click to switch off'}
+                onClick={setMuted}
+              />
+              <i
+                className="icon-button icon-settings"
+                onClick={() => showSourceMenu(p.audioSourceId)}
+              />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div></div>
       )}
-
-      <div className="flex">
-        <div style={{ width: '100%', marginTop: '8px', marginBottom: '8px' }}>
-          <SliderInput
-            value={deflection}
-            onChange={onSliderChangeHandler}
-            min={0}
-            max={1}
-            step={0.01}
-            throttle={100}
-            nowrap
-          />
-        </div>
-        <div className={styles.controls}>
-          <i
-            className={cx('icon-button', muted ? 'icon-mute' : 'icon-audio')}
-            title={muted ? 'click to switch on' : 'click to switch off'}
-            onClick={setMuted}
-          />
-          <i
-            className="icon-button icon-settings"
-            onClick={() => showSourceMenu(p.audioSourceId)}
-          />
-        </div>
-      </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
This is a fix for a bug I encountered on Mac

# Repro steps (mac, did not test Windows):
Go to Settings -> Audio
Make sure Mic Aux Device 1 has a device set (if not, select a device to save this selection and quit)
If you closed the app, reopen the app and reselect Settings->Audio
Use dropdown to disable the device
Desktop encounters an exception and the renderer closes (no render panel)
