### PR TITLE
Bump obs-studio-node to 0.25.35

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.34",
+      "version": "0.25.35",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
# Description

Bump OSN to 0.25.35

# Motivation

Contains [fix for non-functional encoder](https://github.com/streamlabs/obs-studio-node/pull/1540). Addresses an issue found by QA during the full pass test for Mac 1.19