### PR TITLE
update setVideoSetting to also sync the fps setting

### DIFF
--- a/app/components-react/windows/settings/Video.tsx
+++ b/app/components-react/windows/settings/Video.tsx
@@ -8,7 +8,7 @@ import { EScaleType, EFPSType, IVideoInfo } from '../../../../obs-api';
 import { $t } from 'services/i18n';
 import styles from './Common.m.less';
 import Tabs from 'components-react/shared/Tabs';
-import { invalidFps, IVideoInfoValue, TDisplayType } from 'services/settings-v2/video';
+import { invalidFps, IVideoInfoValue, TDisplayType, ObsSetting } from 'services/settings-v2/video';
 import { AuthModal } from 'components-react/shared/AuthModal';
 import Utils from 'services/utils';
 import DualOutputToggle from '../../shared/DualOutputToggle';
@@ -389,8 +389,7 @@ class VideoSettingsModule {
   setFPSType(value: EFPSType) {
     this.service.actions.setVideoSetting('fpsType', value, 'horizontal');
     this.service.actions.setVideoSetting('fpsNum', 30, 'horizontal');
-    this.service.actions.setVideoSetting('fpsDen', 1, 'horizontal');
-    this.service.actions.syncFPSSettings();
+    this.service.actions.setVideoSetting('fpsDen', 1, 'horizontal', true);
   }
 
   /**
@@ -402,9 +401,11 @@ class VideoSettingsModule {
   setCommonFPS(value: string) {
     const [fpsNum, fpsDen] = value.split('-');
 
-    this.service.actions.setVideoSetting('fpsNum', Number(fpsNum), 'horizontal');
-    this.service.actions.setVideoSetting('fpsDen', Number(fpsDen), 'horizontal');
-    this.service.actions.syncFPSSettings();
+    const obsSettings: ObsSetting[] = [
+      { key: 'fpsNum', value: Number(fpsNum) },
+      { key: 'fpsDen', value: Number(fpsDen) },
+    ];
+    this.service.actions.setVideoSettings('horizontal', obsSettings);
   }
   /**
    * Sets Integer FPS
@@ -415,9 +416,11 @@ class VideoSettingsModule {
   setIntegerFPS(value: string) {
     this.state.setFpsInt(Number(value));
     if (Number(value) > 0 && Number(value) < 1001) {
-      this.service.actions.setVideoSetting('fpsNum', Number(value), 'horizontal');
-      this.service.actions.setVideoSetting('fpsDen', 1, 'horizontal');
-      this.service.actions.syncFPSSettings();
+      const obsSettings: ObsSetting[] = [
+        { key: 'fpsNum', value: Number(value) },
+        { key: 'fpsDen', value: 1 },
+      ];
+      this.service.actions.setVideoSettings('horizontal', obsSettings);
     }
   }
 
@@ -434,14 +437,13 @@ class VideoSettingsModule {
       this.state.setFpsDen(Number(value));
     }
     if (!invalidFps(this.state.fpsNum, this.state.fpsDen) && Number(value) > 0) {
-      this.service.actions.setVideoSetting(key, Number(value), 'horizontal');
-      this.service.actions.syncFPSSettings();
+      this.service.actions.setVideoSetting(key, Number(value), 'horizontal', true);
     }
   }
 
   onChange(key: keyof IVideoInfo) {
     return (val: IVideoInfoValue) =>
-      this.service.actions.setVideoSetting(key, val, this.state.display);
+      this.service.actions.setVideoSetting(key, val, this.state.display, true);
   }
 
   setDisplay(display: TDisplayType) {

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -79,6 +79,11 @@ export function invalidFps(num: number, den: number) {
   return num / den > 1000 || num / den < 1;
 }
 
+export interface ObsSetting {
+  key: keyof IVideoInfo;
+  value: IVideoInfoValue;
+}
+
 export class VideoSettingsService extends StatefulService<IVideoSetting> {
   @Inject() dualOutputService: DualOutputService;
   @Inject() settingsService: SettingsService;
@@ -392,11 +397,14 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
   }
 
   @debounce(200)
-  updateObsSettings(display: TDisplayType = 'horizontal') {
+  updateObsSettings(display: TDisplayType = 'horizontal', shouldSyncFPS: Boolean = false) {
     // confirm all vertical fps settings are synced to the horizontal fps settings
     // update contexts to values on state
     this.contexts[display].video = this.state[display];
     this.contexts[display].legacySettings = this.state[display];
+    if (shouldSyncFPS) {
+      this.syncFPSSettings();
+    }
   }
 
   updateVideoSettings(patch: Partial<IVideoInfo>, display: TDisplayType = 'horizontal') {
@@ -420,15 +428,38 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     key: keyof IVideoInfo,
     value: IVideoInfoValue,
     display: TDisplayType = 'horizontal',
+    shouldSyncFPS: Boolean = false,
   ) {
     this.SET_VIDEO_SETTING(key, value, display);
-    this.updateObsSettings(display);
+    this.updateObsSettings(display, shouldSyncFPS);
 
     // also update the persisted settings
     this.dualOutputService.setVideoSetting({ [key]: value }, display);
 
     // refresh v1 settings
     this.settingsService.refreshVideoSettings();
+  }
+
+  /**
+   * Set Video Settings
+   * @remark V2 api. This also updates the video settings in the V1 api.
+   * @param display - name of context (aka display) to apply setting to. Default is horizontal.
+   * @param settings - collection of key/value pairs. Each pair is a video setting and its' value.
+   */
+  setVideoSettings(display: TDisplayType = 'horizontal', settings: ObsSetting[]) {
+    for (let i = 0; i < settings.length; i++) {
+      const setting: ObsSetting = settings[i];
+      this.SET_VIDEO_SETTING(setting.key, setting.value, display);
+      if (i === settings.length - 1) {
+        // On the last setting, pass in the sync fps parameter.
+        this.updateObsSettings(display, true);
+      }
+      // also update the persisted settings
+      this.dualOutputService.setVideoSetting({ [setting.key]: setting.value }, display);
+
+      // refresh v1 settings
+      this.settingsService.refreshVideoSettings();
+    }
   }
 
   setSettings(settings: Partial<IVideoInfo>, display: TDisplayType = 'horizontal') {
@@ -453,7 +484,7 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
    * we need to apply this change to both contexts to keep them synced.
    * @param - Currently, we must confirm fps settings are synced before start streaming
    */
-  syncFPSSettings(updateContexts?: boolean): boolean {
+  private syncFPSSettings(updateContexts?: boolean): boolean {
     const fpsSettings = ['scaleType', 'fpsType', 'fpsCom', 'fpsNum', 'fpsDen', 'fpsInt'];
 
     // update persisted local settings if the vertical context does not exist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "1.19.0",
+  "version": "1.19.1-preview.0",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "1.19.1-preview.0",
+  "version": "1.19.1-preview.1",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.35",
+      "version": "0.25.36",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.34",
+      "version": "0.25.35",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Bug fix for issue where the fps performance counter did not show the correct value 

* add optional parameter to updateObsSettings that will invoke `syncFPSSettings` after the settings have been applied to ensure these two operations are executed sequentially. Previously, syncFPSSettings()
would run *before* updateObsSettings (because it has the debounce modifier applied).