### PR TITLE
Use slobs-virtual-cam-installer.app to install/uninstall mac-virtualcam

### DIFF
--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -55,11 +55,11 @@ function signBinaries(identity, directory) {
 function signXcodeApps(context) {
   // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
   const entitlements = "--entitlements electron-builder/entitlements.plist";
-  const fp = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
-  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${fp}"`);
+  const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
+  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${installerPath}"`);
 
-  const fp_ext = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions/com.streamlabs.slobs.mac-camera-extension.systemextension`;
-  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${fp_ext}"`);
+  const systemExtensionPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions/com.streamlabs.slobs.mac-camera-extension.systemextension`;
+  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${systemExtensionPath}"`);
 }
 
 async function afterPackMac(context) {

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -2,6 +2,7 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const buildCameraExt = require('./build-mac-virtualcam');
 
 function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
@@ -65,11 +66,17 @@ function afterPackMac(context) {
     `cp -R ./node_modules/obs-studio-node/Frameworks \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked/node_modules/\"`,
   );
 
+  buildCameraExt(context);
+
   if (process.env.SLOBS_NO_SIGN) return;
 
   signBinaries(
     context.packager.config.mac.identity,
     `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked`,
+  );
+  signBinaries(
+    context.packager.config.mac.identity,
+    `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`,
   );
 }
 

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -54,12 +54,9 @@ function signBinaries(identity, directory) {
 
 function signXcodeApps(context) {
   // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
-  const entitlements = "--entitlements electron-builder/entitlements.plist";
+  const entitlements = "--entitlements electron-builder/mac-virtual-cam-entitlements.plist";
   const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
-  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${installerPath}"`);
-
-  const systemExtensionPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library/SystemExtensions/com.streamlabs.slobs.mac-camera-extension.systemextension`;
-  cp.execSync(`codesign --sign Developer ID Application: "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${systemExtensionPath}"`);
+  cp.execSync(`codesign --sign "${context.packager.config.mac.identity}" ${entitlements} --deep --force --verbose "${installerPath}"`);
 }
 
 async function afterPackMac(context) {

--- a/electron-builder/afterSign.js
+++ b/electron-builder/afterSign.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const cp = require('child_process');
 const path = require('path');
 const os = require('os');
-const buildCameraExt = require('./build-mac-virtualcam');
 
 async function notarizeMac(context) {
   if (process.env.SLOBS_NO_NOTARIZE) return;
@@ -46,7 +45,6 @@ async function afterPackWin() {
 
 exports.default = async function afterSign(context) {
   if (process.platform === 'darwin') {
-    buildCameraExt(context);
     await notarizeMac(context);
   }
 

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -13,12 +13,9 @@ async function buildVirtualCamExtension(context) {
   cp.execSync(
     `tar -xzvf ${destFile}`,
   );
-  console.log('Copying app into Frameworks folder');
+  console.log('Copying slobs-virtual-cam-installer.app into Frameworks folder');
   cp.execSync(
     `cp -R ./slobs-virtual-cam-installer.app \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks\"`,
-  );
-  cp.execSync(
-    `cp -R ./slobs-virtual-cam-installer.app/Contents/Library \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library\"`,
   );
   cp.execSync(
     `rm -rf ./slobs-virtual-cam-installer.*`,

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -1,53 +1,52 @@
 const pjson = require('../package.json');
-const cp = require('child_process');
+const fs = require('fs');
+const stream = require('stream');
+const cp = require('child_process')
 
-function downloadTempRepo() {
-  const repoVersion = pjson.macVirtualCamVersion;
-  let result = true;
-  const downloadRepoCmd = `git clone --branch ${repoVersion} --depth 1 https://github.com/streamlabs/slobs-virtual-cam-installer.git`;
-  try {
-    const buffer = cp.execSync(downloadRepoCmd);
-    const stdoutString = buffer.toString();
-    console.log(stdoutString);
-  } catch {
-    result = false;
-  }
-  return result;
+// Download the Mac virtual camera system extension. Build and pack it into the executable.
+async function buildVirtualCamExtension(context) {
+  console.log("Download mac virtual camera");
+  const sourceUrl = pjson.macVirtualCamUrl;
+  const destFile = 'slobs-virtual-cam-installer.tar.gz';
+  await downloadFile(sourceUrl, destFile);
+  console.log('Extracting tar file');
+  cp.execSync(
+    `tar -xzvf ${destFile}`,
+  );
+  console.log('Copying app into Frameworks folder');
+  cp.execSync(
+    `cp -R ./slobs-virtual-cam-installer.app \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks\"`,
+  );
+  cp.execSync(
+    `cp -R ./slobs-virtual-cam-installer.app/Contents/Library \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Library\"`,
+  );
+  cp.execSync(
+    `rm -rf ./slobs-virtual-cam-installer.*`,
+  );
 }
 
-// Download the Mac virtual camera system extension. Build, codesign, and pack it into the executable.
-function buildVirtualCamExtension(context) {
-  const hasDownloadedRepo = downloadTempRepo(cp);
-  if (hasDownloadedRepo) {
-    try {
-      console.log('Build the camera system extension');
-      const result = cp.spawnSync('bash', ['./slobs-virtual-cam-installer/build.sh'], {
-        encoding: 'utf-8',
-      });
-      if (result.error) {
-        console.error('Error:', result.error.message);
-      } else {
-        console.log('stdout:', result.stdout);
-        console.log('stderr:', result.stderr);
-        console.log('Exit code:', result.status);
-      }
-
-      console.log('Copy the app into Frameworks folder');
-      const copyFrameworkBuffer = cp.execSync(
-        `cp -R ./slobs-virtual-cam-installer/build/RelWithDebInfo/slobs-virtual-cam-installer.app \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks\"`,
-      );
-      const stdoutString = copyFrameworkBuffer.toString();
-      console.log(stdoutString);
-
-      console.log('Perform cleanup');
-      cp.execSync('rm -rf slobs-virtual-cam-installer'); // Remove the repo. Not required for the build agent but helpful for local dev
-      console.log('Completed setting up the slobs-virtual-cam-installer.app');
-    } catch (error) {
-      console.error('Failed setup of slobs-virtual-cam-installer', error.message);
-    }
-  } else {
-    console.error('Could not download the mac-virtualcam repo');
-  }
+function downloadFile(srcUrl, dstPath) {
+  return new Promise((resolve, reject) => {
+    fetch(srcUrl)
+      .then(response => {
+        if (response.ok) return response;
+        console.error(`Got ${response.status} response from ${srcUrl}`);
+        return Promise.reject(response);
+      })
+      .then(({ body }) => {
+        const fileStream = fs.createWriteStream(dstPath);
+        stream.pipeline(body, fileStream, e => {
+          if (e) {
+            console.error(`Error downloading ${srcUrl}`, e);
+            reject(e);
+          } else {
+            console.log(`Successfully downloaded ${srcUrl}`);
+          }
+          resolve();
+        });
+      })
+      .catch(e => reject(e));
+  });
 }
 
 module.exports = buildVirtualCamExtension;

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const stream = require('stream');
 const cp = require('child_process')
 
-// Download the Mac virtual camera system extension. Build and pack it into the executable.
+// Download the Mac virtual camera system extension and pack it into the executable.
 async function buildVirtualCamExtension(context) {
   console.log("Download mac virtual camera");
   const sourceUrl = pjson.macVirtualCamUrl;

--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.developer.system-extension.install</key>
+    <true/>
   </dict>
 </plist>

--- a/electron-builder/mac-virtual-cam-entitlements.plist
+++ b/electron-builder/mac-virtual-cam-entitlements.plist
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.developer.system-extension.install</key>
+    <true/>
   </dict>
 </plist>

--- a/electron-builder/mac-virtual-cam-entitlements.plist
+++ b/electron-builder/mac-virtual-cam-entitlements.plist
@@ -2,15 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
     <key>com.apple.security.automation.apple-events</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>

--- a/electron-builder/mac-virtual-cam-entitlements.plist
+++ b/electron-builder/mac-virtual-cam-entitlements.plist
@@ -2,13 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.automation.apple-events</key>
-    <true/>
-    <key>com.apple.security.cs.allow-jit</key>
+    <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.developer.system-extension.install</key>
     <true/>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.1",
   "main": "main.js",
-  "macVirtualCamVersion": "1.0.5",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.8-release-osx-arm64.tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",


### PR DESCRIPTION
Updated to download the installer.app from streamlabs AWS S3, codesign it using the slobs-release build agent cert, and assign the correct entitlements 

# How was this tested?
Ran `yarn package:mac-arm64` with codesign enabled. Verified I could install/uninstall and utilize virtual cam with Google meet etc