### PR TITLE
fix [ARCH] for virtual cam installer tar.gz

### DIFF
--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -124,20 +124,26 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
       [OS.Mac]: () => {
         this.signalsService.addCallback(this.handleSignalOutput);
 
-        obs.NodeObs.OBS_service_installVirtualCamPlugin();
-        this.signalInfoChanged.subscribe((signalInfo: IOBSOutputSignalInfo) => {
-          console.log(`virtual cam install signalInfo: ${signalInfo.signal}`);
-          this.setInstallStatus();
-          obs.NodeObs.OBS_service_createVirtualCam();
-        });
+        const errorMessage = obs.NodeObs.OBS_service_installVirtualCamPlugin();
+        if (errorMessage) {
+          remote.dialog.showErrorBox('Virtual Camera', errorMessage);
+        } else {
+          this.signalInfoChanged.subscribe((signalInfo: IOBSOutputSignalInfo) => {
+            console.log(`virtual cam install signalInfo: ${signalInfo.signal}`);
+            this.setInstallStatus();
+            obs.NodeObs.OBS_service_createVirtualCam();
+          });
+        }
       },
     });
   }
 
   @ExecuteInWorkerProcess()
   uninstall() {
-    obs.NodeObs.OBS_service_uninstallVirtualCamPlugin();
-
+    const errorMessage = obs.NodeObs.OBS_service_uninstallVirtualCamPlugin();
+    if (errorMessage) {
+      remote.dialog.showErrorBox('Virtual Camera Error', errorMessage);
+    }
     this.SET_INSTALL_STATUS(EVirtualWebcamPluginInstallStatus.NotPresent);
     this.SET_OUTPUT_TYPE(VCamOutputType.ProgramView);
 
@@ -150,8 +156,10 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
     if (this.state.running) return;
 
     //obs.NodeObs.OBS_service_createVirtualWebcam('Streamlabs Desktop Virtual Webcam');
-    obs.NodeObs.OBS_service_startVirtualCam();
-
+    const errorMessage = obs.NodeObs.OBS_service_startVirtualCam();
+    if (errorMessage) {
+      remote.dialog.showErrorBox('Virtual Camera Error', errorMessage);
+    }
     this.SET_RUNNING(true);
     this.runningChanged.next(true);
 

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -75,7 +75,7 @@ async function afterPackMac(context) {
     `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked`,
   );
 
-  // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
+  // virtual cam installer app requires the entitlements file
   const entitlements = "--entitlements electron-builder/mac-virtual-cam-entitlements.plist";
   const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
   const extraArgs = `${entitlements} --options runtime --verbose`;

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -58,7 +58,7 @@ function signXcodeApps(context) {
   const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
   console.log(`Signing: ${installerPath}`);
   cp.execSync(
-    `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${entitlements} --options runtime --deep --force --verbose "${installerPath}"`,
+    `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${entitlements} --options runtime,linker-signed --deep --force --verbose "${installerPath}"`,
   );
   // All files need to be writable for update to succeed on mac
   console.log(`Checking Writable: ${installerPath}`);

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -75,7 +75,7 @@ async function afterPackMac(context) {
     `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked`,
   );
 
-  // virtual cam installer app requires the entitlements file
+  // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
   const entitlements = "--entitlements electron-builder/mac-virtual-cam-entitlements.plist";
   const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
   const extraArgs = `${entitlements} --options runtime --verbose`;

--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -58,7 +58,7 @@ function signXcodeApps(context) {
   const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
   console.log(`Signing: ${installerPath}`);
   cp.execSync(
-    `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${entitlements} --options runtime,linker-signed --deep --force --verbose "${installerPath}"`,
+    `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${entitlements} --options runtime --deep --force --verbose "${installerPath}"`,
   );
   // All files need to be writable for update to succeed on mac
   console.log(`Checking Writable: ${installerPath}`);

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -1,26 +1,15 @@
-const pjson = require('../package.json');
+const cp = require('child_process');
 const fs = require('fs');
+const findDarwinArch = require('../scripts/find-darwin-arch');
+const pjson = require('../package.json');
 const stream = require('stream');
-const cp = require('child_process')
 
 // Download the Mac virtual camera system extension and pack it into the executable.
 async function buildVirtualCamExtension(context) {
   console.log("Download mac virtual camera");
   const destFile = 'slobs-virtual-cam-installer.tar.gz';
 
-  let arch = '';
-
-  if (process.env.npm_config_arch === 'arm64') {
-    arch = 'arm64';
-  } else if (process.env.npm_config_arch === 'x64') {
-    arch = 'x86_64';
-  } else if (process.arch === 'arm64') {
-    arch = 'arm64';
-  } else if (process.arch === 'x64') {
-    arch = 'x86_64';
-  } else {
-    throw 'CPU architecture not supported.';
-  }
+  const arch = findDarwinArch();
   const sourceUrl = pjson.macVirtualCamUrl.replace('[ARCH]', arch);
 
   await downloadFile(sourceUrl, destFile);

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -6,8 +6,23 @@ const cp = require('child_process')
 // Download the Mac virtual camera system extension and pack it into the executable.
 async function buildVirtualCamExtension(context) {
   console.log("Download mac virtual camera");
-  const sourceUrl = pjson.macVirtualCamUrl;
   const destFile = 'slobs-virtual-cam-installer.tar.gz';
+
+  let arch = '';
+
+  if (process.env.npm_config_arch === 'arm64') {
+    arch = 'arm64';
+  } else if (process.env.npm_config_arch === 'x64') {
+    arch = 'x86_64';
+  } else if (process.arch === 'arm64') {
+    arch = 'arm64';
+  } else if (process.arch === 'x64') {
+    arch = 'x86_64';
+  } else {
+    throw 'CPU architecture not supported.';
+  }
+  const sourceUrl = pjson.macVirtualCamUrl.replace('[ARCH]', arch);
+
   await downloadFile(sourceUrl, destFile);
   console.log('Extracting tar file');
   cp.execSync(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.4",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.11-release-osx-[ARCH].tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.11-release-osx[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.4",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.9-release-osx-[ARCH].tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.11-release-osx-[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.4",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.9-release-osx-arm64.tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.9-release-osx-[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.4",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.11-release-osx[ARCH].tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.12-release-osx[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",

--- a/scripts/find-darwin-arch.js
+++ b/scripts/find-darwin-arch.js
@@ -1,0 +1,17 @@
+function findDarwinArchitecture() {
+  let arch = '';
+  if (process.env.npm_config_arch == 'arm64') {
+    arch = '-arm64';
+  } else if (process.env.npm_config_arch == 'x64') {
+    arch = '-x86_64';
+  } else if (process.arch == 'arm64') {
+    arch = '-arm64';
+  } else if (process.arch == 'x64') {
+    arch = '-x86_64';
+  } else {
+    throw 'CPU architecture not supported.';
+  }
+  return arch;
+}
+
+module.exports = findDarwinArchitecture;

--- a/scripts/install-native-deps.js
+++ b/scripts/install-native-deps.js
@@ -1,7 +1,7 @@
 const sh = require('shelljs');
 const colors = require('colors/safe');
 const fs = require('fs');
-const os = require('os');
+const findDarwinArch = require('./find-darwin-arch');
 const path = require('path');
 const stream = require('stream');
 
@@ -80,17 +80,7 @@ async function runScript() {
       os = 'win64';
     } else if (process.platform === 'darwin') {
       os = 'osx';
-      if (process.env.npm_config_arch == 'arm64') {
-        arch = '-arm64';
-      } else if (process.env.npm_config_arch == 'x64') {
-        arch = '-x86_64';
-      } else if (process.arch == 'arm64') {
-        arch = '-arm64';
-      } else if (process.arch == 'x64') {
-        arch = '-x86_64';
-      } else {
-        throw 'CPU architecture not supported.';
-      }
+      arch = findDarwinArch();
     } else {
       throw 'Platform not supported.';
     }

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.43",
+      "version": "0.25.44",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
* fix mac x86_64 builds to download the correct virtual camera installer for their ARCH
* refactor reusable logic from `install-native-deps` (where it will lookup darwin ARCH)
* bump slobs-vcam-installer, `macVirtualCamUrl` in package.json, to resolve invalid code signature error due to missing camera extension
* bump obs-studio-node to `0.25.44` (for error messages, legacy DAL Plugin uninstall, virtual cam fixes)
* Display error/warning messages wheen virtual cam is installed
<img width="250" height="237" alt="image" src="https://github.com/user-attachments/assets/f3b4888e-5451-477f-a21d-469053e8b3e9" />


# How was this tested?
* Locally, I made a codesigned build and verified mac virtual camera worked 
* I rebuilt desktop (remove `node_modules` and run `yarn install` to force the script to redownload the dependencies from `script/repositories.json`) to verify my change to `install-native-deps`
