### PR TITLE
fix codesign issue / refactor vcam code

### DIFF
--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -2,7 +2,7 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const buildCameraExt = require('./build-mac-virtualcam');
+const virtualCameraPacker = require('./build-mac-virtualcam');
 
 function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
@@ -52,25 +52,6 @@ function signBinaries(identity, directory) {
   }
 }
 
-function signXcodeApps(context) {
-  // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
-  const entitlements = "--entitlements electron-builder/entitlements.plist";
-  const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
-  const executables = [installerPath];
-  for (const exe of executables) {
-    cp.execSync(
-      `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${entitlements} --options runtime --deep --force --verbose "${exe}"`,
-    );
-    // All files need to be writable for update to succeed on mac
-    console.log(`Checking Writable: ${exe}`);
-    try {
-      fs.accessSync(exe, fs.constants.W_OK);
-    } catch {
-      throw new Error(`File ${exe} is not writable!`);
-    }
-  }
-}
-
 async function afterPackMac(context) {
   console.log('Updating dependency paths');
   cp.execSync(
@@ -85,7 +66,7 @@ async function afterPackMac(context) {
     `cp -R ./node_modules/obs-studio-node/Frameworks \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked/node_modules/\"`,
   );
 
-  await buildCameraExt(context);
+  await virtualCameraPacker.downloadVirtualCamExtension(context);
 
   if (process.env.SLOBS_NO_SIGN) return;
 
@@ -93,7 +74,7 @@ async function afterPackMac(context) {
     context.packager.config.mac.identity,
     `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked`,
   );
-  signXcodeApps(context);
+  virtualCameraPacker.signApps(context);
 }
 
 function afterPackWin() {

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -4,8 +4,32 @@ const os = require('os');
 const pjson = require('../package.json');
 const stream = require('stream');
 
+function signApps(context) {
+  // For apps that requires specific entitlements. Ensures the entitlements file is provided during signing
+  const installer_entitlements = '--entitlements electron-builder/installer-entitlements.plist';
+  const extension_entitlements = '--entitlements electron-builder/extension-entitlements.plist';
+  const installerPath = `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks/slobs-virtual-cam-installer.app`;
+  const extensionPath = `${installerPath}/Contents/Library/SystemExtensions/com.streamlabs.slobs.mac-camera-extension.systemextension`;
+  const executables = [extensionPath, installerPath];
+  for (const exe of executables) {
+    const use_entitlement = exe === installerPath ? installer_entitlements : extension_entitlements;
+    console.log(`using entitlement ${use_entitlement}`);
+    cp.execSync(
+      `codesign --sign "Developer ID Application: ${context.packager.config.mac.identity}" ${use_entitlement} -o runtime --timestamp --force --verbose "${exe}"`,
+    );
+
+    // All files need to be writable for update to succeed on mac
+    console.log(`Checking Writable: ${exe}`);
+    try {
+      fs.accessSync(exe, fs.constants.W_OK);
+    } catch {
+      throw new Error(`File ${exe} is not writable!`);
+    }
+  }
+}
+
 // Download the Mac virtual camera system extension and pack it into the executable.
-async function buildVirtualCamExtension(context) {
+async function downloadVirtualCamExtension(context) {
   console.log("Download mac virtual camera");
   const destFile = 'slobs-virtual-cam-installer.tar.gz';
 
@@ -24,15 +48,14 @@ async function buildVirtualCamExtension(context) {
   await downloadFile(sourceUrl, destFile);
   console.log('Extracting tar file');
   cp.execSync(`tar -xzvf ${destFile}`);
-  // Remove the slobs developer provision profile
-  cp.execSync('rm -rf ./slobs-virtual-cam-installer.app/Contents/embedded.provisionprofile');
+  cp.execSync('rm -rf ./slobs-virtual-cam-installer.app/Contents/embedded.provisionprofile'); // remove the developer profile
+
   console.log('Copying slobs-virtual-cam-installer.app into Frameworks folder');
   cp.execSync(
     `cp -R ./slobs-virtual-cam-installer.app \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Frameworks\"`,
   );
-  cp.execSync(
-    `rm -rf ./slobs-virtual-cam-installer.*`,
-  );
+
+  cp.execSync('rm -rf ./slobs-virtual-cam-installer.*');
 }
 
 function downloadFile(srcUrl, dstPath) {
@@ -59,4 +82,4 @@ function downloadFile(srcUrl, dstPath) {
   });
 }
 
-module.exports = buildVirtualCamExtension;
+module.exports = { downloadVirtualCamExtension, signApps };

--- a/electron-builder/extension-entitlements.plist
+++ b/electron-builder/extension-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>UT675MBB9Q.com.streamlabs.slobs</string>
+	</array>
+</dict>
+</plist>

--- a/electron-builder/installer-entitlements.plist
+++ b/electron-builder/installer-entitlements.plist
@@ -1,0 +1,14 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.developer.system-extension.install</key>
+        <true/>
+        <key>com.apple.security.application-groups</key>
+        <array>
+            <string>UT675MBB9Q.com.streamlabs.slobs</string>
+        </array>
+    </dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.2-preview.10",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.12-release-osx-[ARCH].tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.14-release-osx-[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",


### PR DESCRIPTION
* relocate signApps -> build-virtual-cam
* fix codesign issue (hardcode Streamlabs team ID into entitlements) because we are not using xcode for final codesign so this will comply with Apple security restrictions. Xcode knows how to parse and replace the Team ID with environment vars but since this system extension installer is already built we will just hardcode the [Team ID][Bundle id]