### PR TITLE
use notarytool which is substantially (10x) faster then legacy

### DIFF
--- a/electron-builder/afterSign.js
+++ b/electron-builder/afterSign.js
@@ -19,6 +19,7 @@ async function notarizeMac(context) {
   console.log('This can take several minutes.');
 
   await notarize({
+    tool: 'notarytool',
     appPath,
     appBundleId: 'com.streamlabs.slobs',
     appleId: process.env['APPLE_ID'],

--- a/electron-builder/afterSign.js
+++ b/electron-builder/afterSign.js
@@ -21,10 +21,8 @@ async function notarizeMac(context) {
   await notarize({
     tool: 'notarytool',
     appPath,
-    appBundleId: 'com.streamlabs.slobs',
     appleId: process.env['APPLE_ID'],
     appleIdPassword: process.env['APPLE_APP_PASSWORD'],
-    ascProvider: process.env['APPLE_ASC_PROVIDER'],
     teamId: process.env['APPLE_TEAM_ID'],
   });
 


### PR DESCRIPTION
[electron-builder] Fix electron/notarize to use the 'notarytool' instead of 'legacy' which is crazy slow