### PR TITLE
[mac] upgrade OSN to 0.25.50

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -5,6 +5,7 @@
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
       "version": "0.25.47",
+      "mac_version": "0.25.49",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,8 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.47",
-      "mac_version": "0.25.49",
+      "version": "0.25.50",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Upgrade obs-studio-node version to get macOS Screen capture, CEFInitialize, and audio init crash fix