### PR TITLE
[Mac crash fix] do not resize with 0 width/height

### DIFF
--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -213,7 +213,7 @@ export class Display {
   existingWindow = false;
 
   async resize(width: number, height: number) {
-    if (width === 0 || height === 0) {
+    if (getOS() === OS.Mac && (width === 0 || height === 0)) {
       return; // obs gs_draw_sprite() does not render zero sized sprites (so do not call resizeOBSDisplay)
     }
     this.currentPosition.width = width;

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -213,6 +213,9 @@ export class Display {
   existingWindow = false;
 
   async resize(width: number, height: number) {
+    if (width === 0 || height === 0) {
+      return; // obs gs_draw_sprite() does not render zero sized sprites (so do not call resizeOBSDisplay)
+    }
     this.currentPosition.width = width;
     this.currentPosition.height = height;
     this.videoService.actions.resizeOBSDisplay(this.name, width, height);


### PR DESCRIPTION
* fixes obs gs_draw_sprite log spew when the user closes the media file window
* resolves crash that happens later in node-window-rendering [mac] when the user opens/closes media file window multiple times