### PR TITLE
mac-virtualcam: fix invalid code signature + show popup

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -148,6 +148,7 @@
   "An error has occured while uninstalling the virtual camera": "An error has occured while uninstalling the virtual camera",
   "Streamlabs Desktop cannot install the virtual camera if it's not in Applications. Please move Streamlabs Desktop to the Applications directory.": "Streamlabs Desktop cannot install the virtual camera if it's not in Applications. Please move Streamlabs Desktop to the Applications directory.",
   "The installation of the virtual camera will complete after a system reboot.": "The installation of the virtual camera will complete after a system reboot.",
+  "Streamlabs Virtual Webcam feature requires macOS 13 or later.": "Streamlabs Virtual Webcam feature requires macOS 13 or later.",
   "Output Type": "Output Type",
   "Output Selection": "Output Selection",
   "Output Source": "Output Source",

--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -135,9 +135,7 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
         }
         break;
       case InstallationErrorCodes.MacOS13Unavailable:
-        errorMessage = $t(
-          'Streamlabs Virtual Webcam feature requires macOS 13 or later.',
-        );
+        errorMessage = $t('Streamlabs Virtual Webcam feature requires macOS 13 or later.');
         break;
       default:
         errorMessage = $t('An error has occured while installing the virtual camera');

--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -42,6 +42,7 @@ enum InstallationErrorCodes {
   OSSystemExtensionErrorAuthorizationRequired = 13,
   RebootRequired = 100, // slobs-virtualcam-installer custom error
   UserApprovalRequired = 101, // slobs-virtualcam-installer custom error
+  MacOS13Unavailable = 102,
   UnknownError = 999, // slobs-virtualcam-installer custom error
 }
 
@@ -133,6 +134,11 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
           }
         }
         break;
+      case InstallationErrorCodes.MacOS13Unavailable:
+        errorMessage = $t(
+          'Streamlabs Virtual Webcam feature requires macOS 13 or later.',
+        );
+        break;
       default:
         errorMessage = $t('An error has occured while installing the virtual camera');
         break;
@@ -180,15 +186,6 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
         this.setInstallStatus();
       },
       [OS.Mac]: () => {
-        const macOSVersion = process.getSystemVersion();
-        const [major, _] = macOSVersion.split('.').map(Number);
-        if (major < 13) {
-          remote.dialog.showErrorBox(
-            $t('Virtual Webcam'),
-            $t('Streamlabs Virtual Webcam feature requires macOS 13 or later.'),
-          );
-          return;
-        }
         this.signalsService.addCallback(this.handleSignalOutput);
 
         const errorCode = obs.NodeObs.OBS_service_installVirtualCamPlugin();

--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -180,6 +180,15 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
         this.setInstallStatus();
       },
       [OS.Mac]: () => {
+        const macOSVersion = process.getSystemVersion();
+        const [major, _] = macOSVersion.split('.').map(Number);
+        if (major < 13) {
+          remote.dialog.showErrorBox(
+            $t('Virtual Webcam'),
+            $t('Streamlabs Virtual Webcam feature requires macOS 13 or later.'),
+          );
+          return;
+        }
         this.signalsService.addCallback(this.handleSignalOutput);
 
         const errorCode = obs.NodeObs.OBS_service_installVirtualCamPlugin();

--- a/electron-builder/build-mac-virtualcam.js
+++ b/electron-builder/build-mac-virtualcam.js
@@ -48,7 +48,13 @@ async function downloadVirtualCamExtension(context) {
   await downloadFile(sourceUrl, destFile);
   console.log('Extracting tar file');
   cp.execSync(`tar -xzvf ${destFile}`);
-  cp.execSync('rm -rf ./slobs-virtual-cam-installer.app/Contents/embedded.provisionprofile'); // remove the developer profile
+  cp.execSync('rm -rf ./slobs-virtual-cam-installer.app/Contents/embedded.provisionprofile'); // remove the old developer profile
+  if (fs.existsSync(process.env.APPLE_DEVELOPER_PROVISIONING_PROFILE)) {
+    console.log(`Embedding provisioning profile: ${process.env.APPLE_DEVELOPER_PROVISIONING_PROFILE}`);
+    fs.copyFileSync(process.env.APPLE_DEVELOPER_PROVISIONING_PROFILE, './slobs-virtual-cam-installer.app/Contents/embedded.provisionprofile');
+  } else {
+    console.warn("⚠️ No provisioning profile found, skipping embed.");
+  }
 
   console.log('Copying slobs-virtual-cam-installer.app into Frameworks folder');
   cp.execSync(

--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -14,7 +14,5 @@
     <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.developer.system-extension.install</key>
-    <true/>
   </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "version": "1.19.4-preview.0",
   "main": "main.js",
-  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.14-release-osx-[ARCH].tar.gz",
+  "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.15-release-osx-[ARCH].tar.gz",
   "scripts": {
     "compile": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config ./webpack.prod.config.js",


### PR DESCRIPTION
# Description

- Fix for "invalid code signature" error on non-developer machines. 
- Display a popup if mac-virtualcam cannot be installed on older, unsupported macos
- Removing `com.apple.developer.system-extension.install` entitlement from Desktop (I added in previous commit but it is not required since the child installer app already has this entitlement)
- Embed provisioning profile in the installer for non-developer machine (non-developer macs which did not have streamlabs provisioning profiles installed would get "Invalid Code Signature" errors from Apple Gatekeeper). We will use the provisioning profile installed on the release agent to enable the `com.apple.developer.system-extension.install` entitlement

# How Was This Tested?

* Verified that the "macos 13  is required" popup displays on macOS 12 (<macOS 13)
* Verified vcam-installer opens on non-developer machine (macOS that never installed developer provisioning profiles into 'Device Management')
