### PR TITLE
Fix repeated display creation

### DIFF
--- a/app/components-react/shared/Display.tsx
+++ b/app/components-react/shared/Display.tsx
@@ -54,7 +54,9 @@ export default function Display(props: DisplayProps) {
     if (v.hideDisplay) {
       destroyDisplay();
     } else {
-      createDisplay();
+      if (!obsDisplay.current) {
+        createDisplay();
+      }
       if (obsDisplay.current) {
         obsDisplay.current.refreshOutputRegion();
       }
@@ -92,7 +94,9 @@ export default function Display(props: DisplayProps) {
 
   function updateDisplay() {
     destroyDisplay();
-    createDisplay();
+    if (!v.hideDisplay) {
+      createDisplay();
+    }
 
     return function cleanup() {
       destroyDisplay();


### PR DESCRIPTION
createDisplay was called from both handleHideDisplay() and updateDisplay(), both of which get triggered on window reload. This led to createDisplay creating a new OBSDisplay even when one already existed.