### PR TITLE
fix(apps): don't load apps without a manifest, even if they're not beta apps.

### DIFF
--- a/app/services/platform-apps/index.ts
+++ b/app/services/platform-apps/index.ts
@@ -269,7 +269,7 @@ export class PlatformAppsService extends StatefulService<IPlatformAppServiceStat
     const disabledApps = this.getDisabledAppsFromStorage();
 
     productionApps.forEach(app => {
-      if (app.is_beta && !app.manifest) return;
+      if (!app.manifest) return;
 
       const unpackedVersionLoaded = this.state.loadedApps.find(
         loadedApp => loadedApp.id === app.id_hash && loadedApp.unpacked,


### PR DESCRIPTION
Issue:
When an app developer is tester in an beta only app and they get removed it breaks the entire app loading flow.

Fix:
Apps should only load if there is a valid manifest file, no matter if the app is beta or not beta.