### PR TITLE
fix Macos local non-codesign builds for development

### DIFF
--- a/electron-builder/afterPack.js
+++ b/electron-builder/afterPack.js
@@ -66,14 +66,14 @@ async function afterPackMac(context) {
     `cp -R ./node_modules/obs-studio-node/Frameworks \"${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked/node_modules/\"`,
   );
 
-  await virtualCameraPacker.downloadVirtualCamExtension(context);
-
   if (process.env.SLOBS_NO_SIGN) return;
 
   signBinaries(
     context.packager.config.mac.identity,
     `${context.appOutDir}/${context.packager.appInfo.productName}.app/Contents/Resources/app.asar.unpacked`,
   );
+
+  await virtualCameraPacker.downloadVirtualCamExtension(context); // codesign is required for mac-virtualcam (so dont run if SLOBS_NO_SIGN env var is set)
   virtualCameraPacker.signApps(context);
 }
 


### PR DESCRIPTION
If developer enables `SLOBS_NO_SIGN` environment variable then do not download mac-virtualcam installer because:
* non-codesigned builds cant use virtual camera
* non-codesigned build won't get pass gatekeeper with a codesigned slobs-virtualcam installer