### PR TITLE
Fix platform type checking

### DIFF
--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -192,7 +192,7 @@ export interface IPlatformService {
 
   fetchUserInfo: () => Promise<IUserInfo>;
 
-  putChannelInfo: (channelInfo: TStartStreamOptions) => Promise<void>;
+  putChannelInfo(channelInfo: TStartStreamOptions): Promise<void>;
 
   searchGames?: (searchString: string) => Promise<IGame[]>;
 

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -503,7 +503,7 @@ export class TwitchService
     }).then(json => json.total);
   }
 
-  async putChannelInfo(settings: Partial<ITwitchStartStreamOptions>): Promise<void> {
+  async putChannelInfo(settings: ITwitchStartStreamOptions): Promise<void> {
     if (settings.tags) {
       this.twitchTagsService.actions.setTags(settings.tags);
     } else {


### PR DESCRIPTION

* platforms/index.ts: switch `putChannelInfo` from property shorthand to method shorthand, which uses bivariant parameter checking instead of strict contravariance
* twitch.js: update `putChannelInfo` to use updated signature properly

Tested this locally by running Twitch platform test: `yarn test:file test-dist/test/regular/streaming/twitch.js`

Fix this warning:
<img width="939" height="388" alt="image" src="https://github.com/user-attachments/assets/0276ac57-55e4-4319-bdbb-4ae481326e93" />

## Regression testing for QA

* Make sure we can still stream to Twitch
