### PR TITLE
Update obs-studio-node to v0.27.2

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.29b18",
+      "version": "0.27.0",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Updates `obs-studio-node`: **`0.26.29b18` → `0.27.2`**

Supersedes #6037, which covered `0.27.0` / `0.27.1`. That PR went stale waiting on the SL Desktop hotfix rollout, so it is folded in here and this is now the single PR for the whole bump. Its changelog is preserved below.

Diff is one line in `scripts/repositories.json`.

## osn changelog

### `0.27.0` / `0.27.1` — from #6037

| Author | Change |
| --- | --- |
| Aleksandr Voitenko | OBS Merge 32.1.1 (stream-labs/obs-studio-node#1722) |
| Aleksandr Voitenko | Add signals for missing resolutions in Enhanced Boradcasting (stream-labs/obs-studio-node#1742) |
| Aleksandr Voitenko | Add enhanced broadcasting per-display stats (stream-labs/obs-studio-node#1738) |
| Aleksandr Voitenko | Fix recording custom track names (stream-labs/obs-studio-node#1741) |
| Aleksandr Voitenko | Expose structured module load failures (stream-labs/obs-studio-node#1733) |
| Vladimir | Fix misleading `[BrowserMessage]` log tag on generic source ops (stream-labs/obs-studio-node#1725) |
| Vladimir | osn-input: log source id before creating input (stream-labs/obs-studio-node#1721) |

### `0.27.2`

| Author | Change |
| --- | --- |
| Vladimir | tests: regression for scene-wrapped source audio (stream-labs/obs-studio-node#1493) (stream-labs/obs-studio-node#1724) |
| Vladimir | Fix startup crash when recording audio encoder is not registered (stream-labs/obs-studio-node#1736) |
| Vladimir | CI: Pin symsrv-scripts to v1.1.1 (stream-labs/obs-studio-node#1752) |
| Vladimir | Update libobs to v32.1.1sl2 (stream-labs/obs-studio-node#1751) |
| Vladimir | CI: Drop the dead Sentry and breakpad downloads (stream-labs/obs-studio-node#1748) |

<sub>Issue numbers link to `stream-labs/obs-studio-node`.</sub>
