### PR TITLE
Provision the shared graphics hook directory from the installer

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -1,11 +1,9 @@
 !include MUI2.nsh
 
-; Ownership and the DACL are reset only for a file we actually wrote. Doing it
-; for one we merely found would take somebody else's file and make it look
-; administrator-installed to the app, which decides what to trust on exactly
-; that basis. CopyFileW can carry explicit ACEs from the source, so changing
-; only the owner is not enough: /reset makes the file inherit the protected
-; directory descriptor.
+; Only ever for a file we just wrote. On one we merely found, this would make
+; somebody else's file look administrator-installed to the app, which decides
+; what to trust on exactly that basis. /reset as well as /setowner, because
+; CopyFileW can carry explicit ACEs over from the source.
 !macro SecureHookFile FileName
   nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7\${FileName}" /setowner "*S-1-5-32-544" /Q'
   Pop $R8
@@ -22,29 +20,21 @@
   ${EndIf}
 !macroend
 
-; Copies one graphics hook file into the locked-down shared directory ($R7)
-; from the install directory ($R9), setting $R6 if the file could not be put in
-; place right now.
+; Copies one graphics hook file from $R9 into the locked-down shared directory
+; $R7, setting $R6 if it could not be put in place right now.
 ;
-; Each destination is deleted before it is written, and the copy refuses to
-; overwrite. An entry left there while the directory was writable may be a hard
-; link sharing its data with some other file, and copying onto it would put our
-; bytes into that file - an arbitrary write, since the installer is elevated.
-; Deleting removes the directory entry, not the link target.
+; $R9 is the installer's own plugin directory, extracted from the signed
+; installer. Do not copy these out of $INSTDIR: the user chooses that path, so
+; a standard user may be able to rewrite it while we are running elevated.
 ;
-; CopyFiles takes a destination directory rather than a destination file, which
-; the staged path needs, so this goes through CopyFileW directly for a real
-; return value. The target can be loaded by another process at this very moment
-; - the vulkan layer pulls the hook into anything that renders - so a locked
-; file is staged beside it and swapped in by Windows on the next reboot. That
-; swap is link-safe: it replaces the directory entry rather than writing
-; through it, and the file we leave behind until then keeps whoever put it
-; there as its owner, so the app will not use it.
+; Delete first, then copy without overwrite. An entry left there while the
+; directory was writable may be a hard link, and writing through it would put
+; our bytes into the link target - an arbitrary write, since we are elevated.
+; CopyFileW rather than CopyFiles, which takes a destination directory and
+; gives no usable return value.
 ;
-; The source is embedded in the signed installer and extracted to its private
-; plugin directory. Do not copy these files out of $INSTDIR: the installer lets
-; the user choose that path, so a standard user may be able to rewrite it while
-; this elevated process is running.
+; The vulkan layer pulls the hook into anything that renders, so the target may
+; be loaded right now; a locked file is staged beside it and swapped on reboot.
 !macro InstallHookFile FileName
   Delete "$R7\${FileName}"
   System::Call 'kernel32::CopyFileW(w "$R9\${FileName}", w "$R7\${FileName}", i 1) i .s'
@@ -69,19 +59,15 @@
 ; Moves an existing hook directory aside instead of repairing it where it
 ; stands, and records the result in $R4 (empty if nothing was moved) and $R6.
 ;
-; Rewriting a DACL does not revoke handles that are already open. Whoever
-; created the directory can hold one with delete access, let us harden it, and
-; rename it away afterwards - then put their own back at the same path. The app
-; would reject what it finds there, but the vulkan loader does not repeat its
-; checks. A directory that did not exist when they opened their handle is not
-; reachable that way.
+; An ACL change does not revoke handles opened before it, so whoever created
+; the directory could rename the hardened one away afterwards and put their own
+; back at the same path.
 ;
-; Unlike the app and the updater we cannot tell an administrator-provisioned
-; directory from a planted one - that needs an ownership check, and NSIS has no
-; plugin for it here - so this happens whenever one exists. It does mean the
+; This happens whenever a directory exists, because unlike the app and the
+; updater we cannot tell an administrator-provisioned one from a planted one -
+; that needs an ownership check and NSIS has no plugin for it here. So the
 ; installer cannot take part in the newest-hook-wins arbitration the other two
-; do: nothing survives to arbitrate against. The updater sorts that out on its
-; next run, and it runs far more often than this does.
+; do; the updater settles that on its next run.
 !macro QuarantineHookDir
   StrCpy $R4 ""
   System::Call 'kernel32::GetFileAttributesW(w "$R7") i .s'
@@ -104,9 +90,8 @@
       StrCpy $R6 "unverified"
     ${Else}
       DetailPrint "Moved the existing hook directory to $R4"
-      ; Only the names we know. RMDir /r would follow a junction left inside
-      ; and delete whatever is on the other side of it. Anything else in there
-      ; keeps the directory alive, which is untidy but harmless.
+      ; Only names we own. RMDir /r would follow a junction left inside and
+      ; delete whatever is on the other side of it.
       Delete /REBOOTOK "$R4\graphics-hook32.dll"
       Delete /REBOOTOK "$R4\graphics-hook64.dll"
       Delete /REBOOTOK "$R4\obs-vulkan32.json"
@@ -141,11 +126,10 @@
   ${EndIf}
 
   ; The graphics hook is injected into other processes out of a shared
-  ; directory, so only administrators may write to it. We are the elevated
-  ; part of the install; the app itself runs unelevated and cannot provision
-  ; this. Releases up to 1.21 granted BUILTIN\Users write access here, so an
-  ; existing directory may be owned by, and full of files planted by, a
-  ; standard user.
+  ; directory, so only administrators may write to it. We are the elevated part
+  ; of the install; the app runs unelevated and cannot provision this. Releases
+  ; up to 1.21 granted BUILTIN\Users write access here, so an existing
+  ; directory may be owned by, and full of files planted by, a standard user.
   Push $R1
   Push $R2
   Push $R3
@@ -158,16 +142,15 @@
 
   StrCpy $R6 ""
 
-  ; Not the ProgramData environment variable: that is inherited from whoever
-  ; launched us, so a standard user could point this at a directory of their
-  ; choosing and have an elevated process provision it. Under the all-users
-  ; context $APPDATA is CSIDL_COMMON_APPDATA, which comes from the shell.
+  ; Not the ProgramData environment variable, which is inherited from whoever
+  ; launched us. Under the all-users context $APPDATA is CSIDL_COMMON_APPDATA,
+  ; which comes from the shell.
   SetShellVarContext all
   StrCpy $R7 "$APPDATA\obs-studio-hook"
 
   ; A junction left behind by whoever owned this directory before us would send
-  ; the icacls calls and the copies below to its target instead. RMDir without
-  ; /r unlinks the junction itself and leaves whatever it pointed at alone.
+  ; every step below to its target instead. RMDir without /r unlinks the
+  ; junction and leaves whatever it pointed at alone.
   System::Call 'kernel32::GetFileAttributesW(w "$R7") i .s'
   Pop $R8
   ${If} $R8 <> -1
@@ -192,15 +175,12 @@
   ${EndIf}
 
   ${If} $R6 == ""
-    ; Only accept a directory created by this call. If a standard user wins
-    ; the name after quarantine, hardening their directory would leave any
-    ; delete-capable handle they already opened alive.
-    ;
-    ; The descriptor goes on at creation rather than being fixed up by the
-    ; icacls calls below. A directory created under %ProgramData% inherits an
-    ; entry letting users create files in it, and that would stand for as long
-    ; as it takes to spawn icacls. This is the same descriptor, and the same
-    ; reasoning, as hook_dir_create() in obs-studio's hook-dir-security.h.
+    ; Same descriptor, and the same reasoning, as hook_dir_create() in
+    ; obs-studio's hook-dir-security.h. It goes on at creation rather than being
+    ; fixed up by the icacls calls below: a directory created under
+    ; %ProgramData% inherits an entry letting users create files in it, and that
+    ; would stand for as long as it takes to spawn icacls. A failure here means
+    ; somebody won the name after quarantine, and must not be repaired in place.
     System::Call 'advapi32::ConvertStringSecurityDescriptorToSecurityDescriptorW(w "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FRFX;;;BU)(A;OICI;FRFX;;;AC)(A;OICI;FRFX;;;S-1-15-2-2)", i 1, *p .r13, p 0) i .s'
     Pop $R8
     ${If} $R8 == 0
@@ -227,9 +207,8 @@
     ;
     ; No /T anywhere. Recursing through a directory that standard users could
     ; write until a moment ago means walking whatever links they left, and
-    ; icacls follows link targets by default. Only the directory itself is
-    ; touched here; the four files are handled individually once we have
-    ; written them.
+    ; icacls follows link targets. The four files are handled individually once
+    ; we have written them.
     ;
     ; SIDs rather than account names, which are localized:
     ;   S-1-5-18       SYSTEM
@@ -272,11 +251,9 @@
 
   ${If} $R6 != ""
     ; A file we could not replace is still whatever was on disk, which on an
-    ; already-compromised machine is the planted hook. The directory is locked
-    ; down now so nobody can refresh the plant, but we must not keep pointing
-    ; the vulkan loader at it - it hands this directory to every vulkan
-    ; process on the machine. The app re-registers the layer once it sees a
-    ; directory it trusts.
+    ; already-compromised machine is the planted hook. The loader hands this
+    ; directory to every vulkan process on the machine, so it must not point
+    ; here. The app re-registers the layer once it sees a directory it trusts.
     SetRegView 64
     DeleteRegValue HKLM "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan64.json"
     DeleteRegValue HKCU "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan64.json"
@@ -323,8 +300,26 @@ Function un.LeaveUnWelcome
     RMDir /r "$PROFILE\\AppData\\Roaming\\slobs-plugins"
     RMDir /r "$PROFILE\\AppData\\Roaming\\streamlabs-highlighter"
     RMDir /r "$PROFILE\\.cache\\streamlabs-vision"
+
+    ; The same shell-resolved path customInstall provisions, not a literal
+    ; C:\ProgramData - that can be relocated.
+    SetShellVarContext all
+
     ; REBOOTOK flag is required, because files might get injected into a game process and system may prevent their removal
     ; see: https://nsis.sourceforge.io/Reference/RMDir
-    RMDir /r /REBOOTOK "C:\\ProgramData\\obs-studio-hook"
+    ;
+    ; RMDir /r follows a junction and deletes what is on the other side, and we
+    ; are elevated here. A directory left behind by a release that let standard
+    ; users write to it may be one.
+    System::Call 'kernel32::GetFileAttributesW(w "$APPDATA\obs-studio-hook") i .s'
+    Pop $1
+    ${If} $1 <> -1
+      IntOp $1 $1 & 0x400 ; FILE_ATTRIBUTE_REPARSE_POINT
+      ${If} $1 <> 0
+        RMDir "$APPDATA\obs-studio-hook"
+      ${Else}
+        RMDir /r /REBOOTOK "$APPDATA\obs-studio-hook"
+      ${EndIf}
+    ${EndIf}
   ${EndIf}
 FunctionEnd

--- a/installer.nsh
+++ b/installer.nsh
@@ -48,7 +48,7 @@
     ${Else}
       !insertmacro SecureHookFile "${FileName}.new"
       Rename /REBOOTOK "$R7\${FileName}.new" "$R7\${FileName}"
-      DetailPrint "${FileName} is in use; it will be replaced on the next reboot"
+      DetailPrint "${FileName} could not be replaced now; it is staged for the next reboot"
     ${EndIf}
     StrCpy $R6 "unverified"
   ${Else}
@@ -305,20 +305,46 @@ Function un.LeaveUnWelcome
     ; C:\ProgramData - that can be relocated.
     SetShellVarContext all
 
-    ; REBOOTOK flag is required, because files might get injected into a game process and system may prevent their removal
-    ; see: https://nsis.sourceforge.io/Reference/RMDir
-    ;
-    ; RMDir /r follows a junction and deletes what is on the other side, and we
-    ; are elevated here. A directory left behind by a release that let standard
-    ; users write to it may be one.
+    ; The layer registration outlives whatever it names, and the loader hands
+    ; that directory to every vulkan process on the machine, elevated ones
+    ; included. So it goes before the files do, never after: at no point may an
+    ; enabled entry point somewhere we no longer stand behind.
+    SetRegView 64
+    DeleteRegValue HKLM "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$APPDATA\obs-studio-hook\obs-vulkan64.json"
+    DeleteRegValue HKCU "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$APPDATA\obs-studio-hook\obs-vulkan64.json"
+    SetRegView 32
+    DeleteRegValue HKLM "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$APPDATA\obs-studio-hook\obs-vulkan32.json"
+    DeleteRegValue HKCU "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$APPDATA\obs-studio-hook\obs-vulkan32.json"
+    SetRegView lastused
+
     System::Call 'kernel32::GetFileAttributesW(w "$APPDATA\obs-studio-hook") i .s'
     Pop $1
     ${If} $1 <> -1
       IntOp $1 $1 & 0x400 ; FILE_ATTRIBUTE_REPARSE_POINT
       ${If} $1 <> 0
+        ; Nothing under this path is ours - it all resolves somewhere else.
+        ; RMDir without /r unlinks the junction and leaves the target alone.
         RMDir "$APPDATA\obs-studio-hook"
       ${Else}
-        RMDir /r /REBOOTOK "$APPDATA\obs-studio-hook"
+        ; Only the names we installed, and no RMDir /r: that follows a junction
+        ; left inside the directory and deletes what is on the other side of
+        ; it, and we are elevated. The directory not being a reparse point says
+        ; nothing about what is under it.
+        ;
+        ; REBOOTOK because the hook may be loaded into a game right now.
+        ; see: https://nsis.sourceforge.io/Reference/Delete
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\graphics-hook32.dll"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\graphics-hook64.dll"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan32.json"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan64.json"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\graphics-hook32.dll.new"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\graphics-hook64.dll.new"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan32.json.new"
+        Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan64.json.new"
+
+        ; The directory itself stays, emptied. It is administrator-owned and
+        ; read-only to standard users; releasing the name lets one recreate it
+        ; and own whatever the next OBS-derived application installs there.
       ${EndIf}
     ${EndIf}
   ${EndIf}

--- a/installer.nsh
+++ b/installer.nsh
@@ -2,8 +2,10 @@
 
 ; Only ever for a file we just wrote. On one we merely found, this would make
 ; somebody else's file look administrator-installed to the app, which decides
-; what to trust on exactly that basis. /reset as well as /setowner, because
-; CopyFileW can carry explicit ACEs over from the source.
+; what to trust on exactly that basis. /setowner is the one that matters:
+; CopyFileW leaves the copy inheriting from the destination rather than
+; carrying the source's ACEs, so /reset only restates what the directory
+; already grants.
 !macro SecureHookFile FileName
   nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7\${FileName}" /setowner "*S-1-5-32-544" /Q'
   Pop $R8

--- a/installer.nsh
+++ b/installer.nsh
@@ -1,5 +1,125 @@
 !include MUI2.nsh
 
+; Ownership and the DACL are reset only for a file we actually wrote. Doing it
+; for one we merely found would take somebody else's file and make it look
+; administrator-installed to the app, which decides what to trust on exactly
+; that basis. CopyFileW can carry explicit ACEs from the source, so changing
+; only the owner is not enough: /reset makes the file inherit the protected
+; directory descriptor.
+!macro SecureHookFile FileName
+  nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7\${FileName}" /setowner "*S-1-5-32-544" /Q'
+  Pop $R8
+  ${If} $R8 <> 0
+    DetailPrint "Could not set the owner of ${FileName}"
+    StrCpy $R6 "unverified"
+  ${Else}
+    nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7\${FileName}" /reset /Q'
+    Pop $R8
+    ${If} $R8 <> 0
+      DetailPrint "Could not reset the permissions on ${FileName}"
+      StrCpy $R6 "unverified"
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+; Copies one graphics hook file into the locked-down shared directory ($R7)
+; from the install directory ($R9), setting $R6 if the file could not be put in
+; place right now.
+;
+; Each destination is deleted before it is written, and the copy refuses to
+; overwrite. An entry left there while the directory was writable may be a hard
+; link sharing its data with some other file, and copying onto it would put our
+; bytes into that file - an arbitrary write, since the installer is elevated.
+; Deleting removes the directory entry, not the link target.
+;
+; CopyFiles takes a destination directory rather than a destination file, which
+; the staged path needs, so this goes through CopyFileW directly for a real
+; return value. The target can be loaded by another process at this very moment
+; - the vulkan layer pulls the hook into anything that renders - so a locked
+; file is staged beside it and swapped in by Windows on the next reboot. That
+; swap is link-safe: it replaces the directory entry rather than writing
+; through it, and the file we leave behind until then keeps whoever put it
+; there as its owner, so the app will not use it.
+;
+; The source is embedded in the signed installer and extracted to its private
+; plugin directory. Do not copy these files out of $INSTDIR: the installer lets
+; the user choose that path, so a standard user may be able to rewrite it while
+; this elevated process is running.
+!macro InstallHookFile FileName
+  Delete "$R7\${FileName}"
+  System::Call 'kernel32::CopyFileW(w "$R9\${FileName}", w "$R7\${FileName}", i 1) i .s'
+  Pop $R8
+  ${If} $R8 == 0
+    Delete "$R7\${FileName}.new"
+    System::Call 'kernel32::CopyFileW(w "$R9\${FileName}", w "$R7\${FileName}.new", i 1) i .s'
+    Pop $R8
+    ${If} $R8 == 0
+      DetailPrint "Could not install ${FileName} into $R7"
+    ${Else}
+      !insertmacro SecureHookFile "${FileName}.new"
+      Rename /REBOOTOK "$R7\${FileName}.new" "$R7\${FileName}"
+      DetailPrint "${FileName} is in use; it will be replaced on the next reboot"
+    ${EndIf}
+    StrCpy $R6 "unverified"
+  ${Else}
+    !insertmacro SecureHookFile "${FileName}"
+  ${EndIf}
+!macroend
+
+; Moves an existing hook directory aside instead of repairing it where it
+; stands, and records the result in $R4 (empty if nothing was moved) and $R6.
+;
+; Rewriting a DACL does not revoke handles that are already open. Whoever
+; created the directory can hold one with delete access, let us harden it, and
+; rename it away afterwards - then put their own back at the same path. The app
+; would reject what it finds there, but the vulkan loader does not repeat its
+; checks. A directory that did not exist when they opened their handle is not
+; reachable that way.
+;
+; Unlike the app and the updater we cannot tell an administrator-provisioned
+; directory from a planted one - that needs an ownership check, and NSIS has no
+; plugin for it here - so this happens whenever one exists. It does mean the
+; installer cannot take part in the newest-hook-wins arbitration the other two
+; do: nothing survives to arbitrate against. The updater sorts that out on its
+; next run, and it runs far more often than this does.
+!macro QuarantineHookDir
+  StrCpy $R4 ""
+  System::Call 'kernel32::GetFileAttributesW(w "$R7") i .s'
+  Pop $R8
+  ${If} $R8 <> -1
+    StrCpy $R5 0
+    ${Do}
+      ClearErrors
+      Rename "$R7" "$R7.quarantine$R5"
+      ${IfNot} ${Errors}
+        StrCpy $R4 "$R7.quarantine$R5"
+        ${ExitDo}
+      ${EndIf}
+      IntOp $R5 $R5 + 1
+    ${LoopUntil} $R5 >= 10
+    ClearErrors
+
+    ${If} $R4 == ""
+      DetailPrint "Could not move the existing hook directory aside"
+      StrCpy $R6 "unverified"
+    ${Else}
+      DetailPrint "Moved the existing hook directory to $R4"
+      ; Only the names we know. RMDir /r would follow a junction left inside
+      ; and delete whatever is on the other side of it. Anything else in there
+      ; keeps the directory alive, which is untidy but harmless.
+      Delete /REBOOTOK "$R4\graphics-hook32.dll"
+      Delete /REBOOTOK "$R4\graphics-hook64.dll"
+      Delete /REBOOTOK "$R4\obs-vulkan32.json"
+      Delete /REBOOTOK "$R4\obs-vulkan64.json"
+      Delete /REBOOTOK "$R4\graphics-hook32.dll.new"
+      Delete /REBOOTOK "$R4\graphics-hook64.dll.new"
+      Delete /REBOOTOK "$R4\obs-vulkan32.json.new"
+      Delete /REBOOTOK "$R4\obs-vulkan64.json.new"
+      RMDir /REBOOTOK "$R4"
+    ${EndIf}
+  ${EndIf}
+!macroend
+
 !macro customInstall
   ; Download to the secure NSIS temp dir (not user-writable) to prevent
   ; binary planting / privilege escalation if $INSTDIR is a world-writable path.
@@ -19,6 +139,162 @@
   ${Else}
     MessageBox MB_OK|MB_ICONEXCLAMATION 'WARNING: Streamlabs could not download the Microsoft Visual C++ v14 Redistributable (x64), for Visual Studio 2017-2026, from Microsoft.$\r$\n$\r$\nCheck your internet connection, then install it manually from:$\r$\nhttps://aka.ms/vs/17/release/vc_redist.x64.exe'
   ${EndIf}
+
+  ; The graphics hook is injected into other processes out of a shared
+  ; directory, so only administrators may write to it. We are the elevated
+  ; part of the install; the app itself runs unelevated and cannot provision
+  ; this. Releases up to 1.21 granted BUILTIN\Users write access here, so an
+  ; existing directory may be owned by, and full of files planted by, a
+  ; standard user.
+  Push $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  Push $R6
+  Push $R7
+  Push $R8
+  Push $R9
+
+  StrCpy $R6 ""
+
+  ; Not the ProgramData environment variable: that is inherited from whoever
+  ; launched us, so a standard user could point this at a directory of their
+  ; choosing and have an elevated process provision it. Under the all-users
+  ; context $APPDATA is CSIDL_COMMON_APPDATA, which comes from the shell.
+  SetShellVarContext all
+  StrCpy $R7 "$APPDATA\obs-studio-hook"
+
+  ; A junction left behind by whoever owned this directory before us would send
+  ; the icacls calls and the copies below to its target instead. RMDir without
+  ; /r unlinks the junction itself and leaves whatever it pointed at alone.
+  System::Call 'kernel32::GetFileAttributesW(w "$R7") i .s'
+  Pop $R8
+  ${If} $R8 <> -1
+    IntOp $R8 $R8 & 0x400 ; FILE_ATTRIBUTE_REPARSE_POINT
+    ${If} $R8 <> 0
+      RMDir "$R7"
+      ; if it is still there, stop rather than operate through it
+      System::Call 'kernel32::GetFileAttributesW(w "$R7") i .s'
+      Pop $R8
+      ${If} $R8 <> -1
+        IntOp $R8 $R8 & 0x400
+        ${If} $R8 <> 0
+          DetailPrint "$R7 is a reparse point that could not be unlinked"
+          StrCpy $R6 "unverified"
+        ${EndIf}
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R6 == ""
+    !insertmacro QuarantineHookDir
+  ${EndIf}
+
+  ${If} $R6 == ""
+    ; Only accept a directory created by this call. If a standard user wins
+    ; the name after quarantine, hardening their directory would leave any
+    ; delete-capable handle they already opened alive.
+    ;
+    ; The descriptor goes on at creation rather than being fixed up by the
+    ; icacls calls below. A directory created under %ProgramData% inherits an
+    ; entry letting users create files in it, and that would stand for as long
+    ; as it takes to spawn icacls. This is the same descriptor, and the same
+    ; reasoning, as hook_dir_create() in obs-studio's hook-dir-security.h.
+    System::Call 'advapi32::ConvertStringSecurityDescriptorToSecurityDescriptorW(w "O:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FRFX;;;BU)(A;OICI;FRFX;;;AC)(A;OICI;FRFX;;;S-1-15-2-2)", i 1, *p .r13, p 0) i .s'
+    Pop $R8
+    ${If} $R8 == 0
+      DetailPrint "Could not build the hook directory descriptor"
+      StrCpy $R6 "unverified"
+    ${Else}
+      ; SECURITY_ATTRIBUTES {nLength, lpSecurityDescriptor, bInheritHandle};
+      ; 12 bytes because NSIS installers are 32-bit
+      System::Call '*(i 12, p r13, i 0) p .r12'
+      System::Call 'kernel32::CreateDirectoryW(w "$R7", p r12) i .s'
+      Pop $R8
+      System::Free $R2
+      System::Call 'kernel32::LocalFree(p r13) p'
+      ${If} $R8 == 0
+        DetailPrint "Could not create a new hook directory; the name may have been recreated"
+        StrCpy $R6 "unverified"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R6 == ""
+    ; icacls by full path: this process is elevated, and a bare name would be
+    ; resolved against the search path.
+    ;
+    ; No /T anywhere. Recursing through a directory that standard users could
+    ; write until a moment ago means walking whatever links they left, and
+    ; icacls follows link targets by default. Only the directory itself is
+    ; touched here; the four files are handled individually once we have
+    ; written them.
+    ;
+    ; SIDs rather than account names, which are localized:
+    ;   S-1-5-18       SYSTEM
+    ;   S-1-5-32-544   Administrators
+    ;   S-1-5-32-545   Users
+    ;   S-1-15-2-1     ALL APPLICATION PACKAGES
+    ;   S-1-15-2-2     ALL RESTRICTED APPLICATION PACKAGES
+    ; The last two are what lets an AppContainer capture target load the hook.
+    nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7" /setowner "*S-1-5-32-544" /Q'
+    Pop $R8
+    ${If} $R8 <> 0
+      DetailPrint "Could not take ownership of $R7"
+      StrCpy $R6 "unverified"
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R6 == ""
+    nsExec::ExecToLog '"$SYSDIR\icacls.exe" "$R7" /inheritance:r /grant:r "*S-1-5-18:(OI)(CI)(F)" "*S-1-5-32-544:(OI)(CI)(F)" "*S-1-5-32-545:(OI)(CI)(RX)" "*S-1-15-2-1:(OI)(CI)(RX)" "*S-1-15-2-2:(OI)(CI)(RX)"'
+    Pop $R8
+    ${If} $R8 <> 0
+      DetailPrint "Could not secure $R7"
+      StrCpy $R6 "unverified"
+    ${EndIf}
+  ${EndIf}
+
+  ${If} $R6 == ""
+    SetOutPath "$PLUGINSDIR\obs-studio-hook"
+    File /oname=graphics-hook32.dll "${PROJECT_DIR}\node_modules\obs-studio-node\data\obs-plugins\win-capture\graphics-hook32.dll"
+    File /oname=graphics-hook64.dll "${PROJECT_DIR}\node_modules\obs-studio-node\data\obs-plugins\win-capture\graphics-hook64.dll"
+    File /oname=obs-vulkan32.json "${PROJECT_DIR}\node_modules\obs-studio-node\data\obs-plugins\win-capture\obs-vulkan32.json"
+    File /oname=obs-vulkan64.json "${PROJECT_DIR}\node_modules\obs-studio-node\data\obs-plugins\win-capture\obs-vulkan64.json"
+    SetOutPath "$INSTDIR"
+
+    StrCpy $R9 "$PLUGINSDIR\obs-studio-hook"
+    !insertmacro InstallHookFile "graphics-hook32.dll"
+    !insertmacro InstallHookFile "graphics-hook64.dll"
+    !insertmacro InstallHookFile "obs-vulkan32.json"
+    !insertmacro InstallHookFile "obs-vulkan64.json"
+  ${EndIf}
+
+  ${If} $R6 != ""
+    ; A file we could not replace is still whatever was on disk, which on an
+    ; already-compromised machine is the planted hook. The directory is locked
+    ; down now so nobody can refresh the plant, but we must not keep pointing
+    ; the vulkan loader at it - it hands this directory to every vulkan
+    ; process on the machine. The app re-registers the layer once it sees a
+    ; directory it trusts.
+    SetRegView 64
+    DeleteRegValue HKLM "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan64.json"
+    DeleteRegValue HKCU "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan64.json"
+    SetRegView 32
+    DeleteRegValue HKLM "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan32.json"
+    DeleteRegValue HKCU "SOFTWARE\Khronos\Vulkan\ImplicitLayers" "$R7\obs-vulkan32.json"
+    SetRegView lastused
+  ${EndIf}
+
+  Pop $R9
+  Pop $R8
+  Pop $R7
+  Pop $R6
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
 
   FileOpen $0 "$INSTDIR\installername" w
   FileWrite $0 $EXEFILE

--- a/installer.nsh
+++ b/installer.nsh
@@ -342,9 +342,15 @@ Function un.LeaveUnWelcome
         Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan32.json.new"
         Delete /REBOOTOK "$APPDATA\obs-studio-hook\obs-vulkan64.json.new"
 
-        ; The directory itself stays, emptied. It is administrator-owned and
-        ; read-only to standard users; releasing the name lets one recreate it
-        ; and own whatever the next OBS-derived application installs there.
+        ; And the container, if those were the last things in it - still no /r.
+        ; Keeping it would be the hostile choice: the directory is ours only
+        ; while we are installed, and an unelevated OBS-derived application
+        ; cannot write into an administrator-owned one. Upstream's
+        ; update_hook_file() fails the copy and then never reaches
+        ; init_vulkan_registry(), so a hardened leftover costs the next
+        ; application vulkan capture for good. Nothing points at the name we
+        ; are releasing; the registrations went first.
+        RMDir /REBOOTOK "$APPDATA\obs-studio-hook"
       ${EndIf}
     ${EndIf}
   ${EndIf}


### PR DESCRIPTION
Fixes the installer half of HackerOne #3319516 (local privilege escalation, High / 7.8).

`%ProgramData%\obs-studio-hook` holds the graphics hook we inject into the processes we capture, and it is registered as an implicit Vulkan layer, so the loader maps whatever sits there into every process that renders. Releases up to 1.21 leave it writable by `BUILTIN\Users`, and a directory created by an unelevated run is owned outright by whichever account got there first — on this machine, without the app ever having been run elevated, the owner was a standard user with Full control. The app runs unelevated and cannot repair that. We are the elevated part of the install, so `customInstall` provisions the directory instead.

## What it does

- Creates the directory with the final protected descriptor already attached — `O:BA D:PAI` granting Full to SYSTEM and Administrators, Read/Execute to Users, `ALL APPLICATION PACKAGES` and `ALL RESTRICTED APPLICATION PACKAGES`. Not `CreateDirectory(..., NULL)` followed by `icacls`: one created under `%ProgramData%` inherits an entry letting users write to it, and that would stand for as long as it takes to spawn a process.
- Moves an existing directory aside rather than repairing it in place. Rewriting a DACL does not revoke handles opened before the change, so whoever created it could otherwise rename the hardened directory away afterwards and put their own back under the same name. Only a directory this run created is accepted.
- Installs `graphics-hook{32,64}.dll` and `obs-vulkan{32,64}.json` from the signed installer payload rather than from `$INSTDIR` — the user chooses that path, so a standard user may be able to rewrite it while this elevated process is running.
- Removes the Vulkan layer registration if anything could not be put in place, rather than leaving it pointing at a directory we cannot stand behind.

## Notes for review

- Unlike the app and the updater, NSIS has no plugin here that can tell an administrator-provisioned directory from a planted one, so the quarantine happens whenever a directory exists. That means the installer cannot take part in newest-hook-wins arbitration with other OBS-derived applications — nothing survives to arbitrate against. The updater settles that on its next run, and runs far more often than this does.
- `icacls` is invoked by full path, since a bare name would be resolved against the search path in an elevated process, and never with `/T`: recursing through a directory standard users could write until a moment ago means walking whatever links they left, and `icacls` follows link targets.
- Ownership and the DACL are reset only for a file we actually wrote. Doing it for one we merely found would make somebody else's file look administrator-installed to the app, which decides what to trust on exactly that basis.
- The shell's all-users `$APPDATA` is used rather than the `ProgramData` environment variable, which is inherited from whoever launched us.

## Ship order

Pairs with streamlabs/obs-studio#756 (app side: validate before trusting, quarantine an untrusted directory) and streamlabs/a-files-updater#140 (repairs the installed base, since NSIS does not re-run on auto-update).

**This should not ship ahead of the obs-studio change.** Today's `add_aap_perms()` re-grants `BUILTIN\Users` write on the hook directory on any elevated app launch, which would undo what this installer just did. Merge after obs-studio-node carries the matching hook and `repositories.json` is bumped.

## Testing

Verified on an elevated end-to-end install of 1.22.0-preview.1 (Windows 11 26200, x64) against a deliberately staged vulnerable directory — ownership reassigned away from Administrators to a user account, `BUILTIN\Users` granted Full, and `graphics-hook64.dll` replaced with a marker file. How the directory got into that state does not matter to the code path: the quarantine keys on the directory existing, not on who owns it.

Before:

```
Owner : <machine>\<user>
C:\ProgramData\obs-studio-hook NT AUTHORITY\SYSTEM:(OI)(CI)(F)
                               BUILTIN\Administrators:(OI)(CI)(F)
                               BUILTIN\Users:(OI)(CI)(F)
                               APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES:(OI)(CI)(RX)
                               APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES:(OI)(CI)(RX)

graphics-hook64.dll  7 bytes  sha256=1D29EE7BEDD603FDB36DA6F156C363AA29011A95CAE04A78B92D0726E8049123
```

After:

```
Owner  : BUILTIN\Administrators
SDDL   : O:BA...D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)(A;OICI;0x1200a9;;;AC)(A;OICI;0x1200a9;;;S-1-15-2-2)
Reparse: False

C:\ProgramData\obs-studio-hook NT AUTHORITY\SYSTEM:(OI)(CI)(F)
                               BUILTIN\Administrators:(OI)(CI)(F)
                               BUILTIN\Users:(OI)(CI)(RX)
                               APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES:(OI)(CI)(RX)
                               APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES:(OI)(CI)(RX)

graphics-hook32.dll  248680 bytes  owner=BUILTIN\Administrators  sha256=5BEA21AB3A4DF3FA35AF3B203EB59FEAFC4A193A4BA121EA0F8D42833E6CF104
graphics-hook64.dll  303464 bytes  owner=BUILTIN\Administrators  sha256=F89ADE59480DE0D55FCC100495D78E8E491BED469FAB4DBD3D430837B58B27A5
obs-vulkan32.json       514 bytes  owner=BUILTIN\Administrators  sha256=C16E0707AE66AD71E8A0720AEB6E6997A1017F19762333452AEF692115A9AB41
obs-vulkan64.json       514 bytes  owner=BUILTIN\Administrators  sha256=7B6B0813FB58B276847A8583EB5C3F94AEE7D7AD0AE3A1EF6133D5D8771F20F4
```

- The descriptor is protected (`D:PA`, no inherited ACEs) and owned by Administrators; `Users` is demoted to Read/Execute; both AppContainer SIDs are kept at Read/Execute.
- The marker is gone — all four files carry the payload hashes and administrator ownership.
- The directory's creation time advanced across the install, and no `obs-studio-hook.quarantine*` survives.
- A Basic User restricted token (`runas /trustlevel:0x20000`) is denied `OpenWrite` on `graphics-hook64.dll`.

The sequence itself comes from the USN journal, because `DetailPrint` and `nsExec::ExecToLog` produce nothing observable in a release build — electron-builder sets `ShowInstDetails nevershow` and `SetDetailsPrint none`:

```
Rename: old name    obs-studio-hook
Rename: new name    obs-studio-hook.quarantine0
File delete         obs-studio-hook.quarantine0
File create         obs-studio-hook              <- new file reference number
Security change     obs-studio-hook              <- /setowner
Security change     obs-studio-hook              <- /inheritance:r /grant:r
```

The new file reference number is the load-bearing part: the directory the app ends up trusting is one this install created, not the staged one with its DACL rewritten.

Earlier checks, unchanged:

- The `CopyFileW` and `SECURITY_ATTRIBUTES` marshalling were exercised against a real `makensis` build (`good=1 missing=0`), since NSIS `System::Call` gets these wrong silently.
- `mklink /J` confirms directory junctions need no elevation, which is what the reparse-point check and the no-`/T` rule are there for.
- `icacls /setowner` on a file owned by another account fails without `SeRestorePrivilege`, which is what makes remove-protection → tamper → restore-protection incomplete.

Not covered: the `Rename /REBOOTOK` staging path for a hook mapped into a running process, and the junction branch end to end — only the `mklink /J` premise it rests on was checked.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

