### PR TITLE
Do not follow links when exporting an overlay file

### DIFF
--- a/app/components-react/windows/settings/Developer.tsx
+++ b/app/components-react/windows/settings/Developer.tsx
@@ -134,22 +134,29 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
       );
 
       if (!collectionFilePath) {
+        setBusy(false);
         setError(true);
         setMessage($t('Unable to convert dual output collection.'));
         return;
       }
 
       // save overlay
-      OverlaysPersistenceService.actions.return.saveOverlay(filePath).then(() => {
+      try {
+        await OverlaysPersistenceService.actions.return.saveOverlay(filePath);
         setError(false);
-        setBusy(false);
         setMessage(
           $t('Successfully saved %{filename} to %{filepath}', {
             filename: path.parse(collectionFilePath).base,
             filepath: filePath,
           }),
         );
-      });
+      } catch (e: unknown) {
+        console.error('Failed to export overlay', e);
+        setError(true);
+        setMessage($t('Failed to export overlay. Please choose a different location.'));
+      } finally {
+        setBusy(false);
+      }
     } else {
       setBusy(true);
 

--- a/app/components-react/windows/settings/SceneCollections.tsx
+++ b/app/components-react/windows/settings/SceneCollections.tsx
@@ -51,14 +51,20 @@ export function SceneCollectionsSettings() {
     setBusy(true);
     setMessage('');
 
-    // TODO: Expose progress to the user
-    await OverlaysPersistenceService.actions.return.saveOverlay(filePath);
-    setBusy(false);
-    setMessage(
-      $t('Successfully saved %{filename}', {
-        filename: path.parse(filePath).base,
-      }),
-    );
+    try {
+      // TODO: Expose progress to the user
+      await OverlaysPersistenceService.actions.return.saveOverlay(filePath);
+      setMessage(
+        $t('Successfully saved %{filename}', {
+          filename: path.parse(filePath).base,
+        }),
+      );
+    } catch (e: unknown) {
+      console.error('Failed to export overlay', e);
+      setMessage($t('Failed to export overlay. Please choose a different location.'));
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function loadOverlay() {

--- a/app/i18n/en-US/overlays.json
+++ b/app/i18n/en-US/overlays.json
@@ -3,6 +3,7 @@
   "Successfully converted %{filename}": "Successfully converted %{filename}",
   "Successfully saved %{filename} to %{filepath}": "Successfully saved %{filename} to %{filepath}",
   "Successfully loaded %{filename}.overlay": "Successfully loaded %{filename}.overlay",
+  "Failed to export overlay. Please choose a different location.": "Failed to export overlay. Please choose a different location.",
   "This is an experimental feature.  Use at your own risk.": "This is an experimental feature.  Use at your own risk.",
   "Export Overlay File": "Export Overlay File",
   "Import Overlay File": "Import Overlay File",

--- a/app/services/scene-collections/overlays.ts
+++ b/app/services/scene-collections/overlays.ts
@@ -24,6 +24,7 @@ import { importExtractZip } from '../../util/slow-imports';
 import { downloadFile, IDownloadProgress } from 'util/requests';
 import { NodeMapNode } from './nodes/node-map';
 import { SmartBrowserNode } from './nodes/overlays/smartBrowserSource';
+import { createExclusiveWriteStream } from 'util/safe-file';
 
 const NODE_TYPES = {
   RootNode,
@@ -92,25 +93,30 @@ export class OverlaysPersistenceService extends Service {
     const root = new RootNode();
     const assetsPath = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-assets'));
 
-    await root.save({ assetsPath });
-    const config = JSON.stringify(root, null, 2);
-    const configPath = path.join(assetsPath, 'config.json');
-    fs.writeFileSync(configPath, config);
+    try {
+      await root.save({ assetsPath });
+      const config = JSON.stringify(root, null, 2);
+      const configPath = path.join(assetsPath, 'config.json');
+      fs.writeFileSync(configPath, config);
 
-    const output = fs.createWriteStream(overlayFilePath);
-    // import of archiver takes to much time on startup, so import it dynamically
-    const archiver = (await import('archiver')).default;
-    const archive = archiver('zip', { zlib: { level: 9 } });
+      const output = createExclusiveWriteStream(overlayFilePath);
+      // import of archiver takes to much time on startup, so import it dynamically
+      const archiver = (await import('archiver')).default;
+      const archive = archiver('zip', { zlib: { level: 9 } });
 
-    await new Promise<void>(resolve => {
-      output.on('close', (err: any) => {
-        resolve();
+      await new Promise<void>((resolve, reject) => {
+        output.on('close', () => resolve());
+        output.on('error', reject);
+        archive.on('error', reject);
+
+        archive.pipe(output);
+        archive.directory(assetsPath, false);
+        archive.finalize();
       });
-
-      archive.pipe(output);
-      archive.directory(assetsPath, false);
-      archive.finalize();
-    });
+    } finally {
+      // These staging copies are the full uncompressed size of the collection.
+      fs.rmSync(assetsPath, { recursive: true, force: true });
+    }
   }
 
   ensureOverlaysDirectory() {

--- a/app/util/safe-file.ts
+++ b/app/util/safe-file.ts
@@ -1,0 +1,62 @@
+// Helper methods for writing files that other users may be able to tamper with
+// Namespace import so this module also loads outside the webpack bundle, which
+// is what supplies default-import interop for node builtins.
+import * as fs from 'fs';
+
+/**
+ * Opens `filePath` for writing without following a symlink or NTFS junction
+ * planted at that path by another user.
+ *
+ * Writing to a user-chosen path in a shared folder is a link-following hazard:
+ * a lower-privileged user can swap the target for a reparse point and redirect
+ * our write onto a file they could not otherwise touch. See HackerOne #3335683.
+ *
+ * Only the final path component is checked. Parent directories are left alone
+ * because Windows folder redirection (OneDrive, redirected Documents) uses
+ * junctions legitimately.
+ *
+ * @param filePath the file to create, replacing it if it already exists
+ */
+export function createExclusiveWriteStream(filePath: string): fs.WriteStream {
+  const existing = fs.lstatSync(filePath, { throwIfNoEntry: false });
+
+  if (existing) {
+    if (!existing.isFile()) {
+      throw new Error(`Refusing to write ${filePath}: not a regular file`);
+    }
+
+    // Deleting below would clear the Windows read-only attribute as a side
+    // effect, so check it first and keep refusing what a plain open refused.
+    if (!(existing.mode & 0o200)) {
+      throw new Error(`Refusing to write ${filePath}: file is read-only`);
+    }
+
+    // unlink never follows the final component, so this removes a link rather
+    // than its target if one is swapped in after the check above.
+    fs.unlinkSync(filePath);
+  }
+
+  // 'wx' is O_CREAT | O_EXCL, which maps to CREATE_NEW on Windows and fails
+  // outright if anything reappears at the path, so we never open an object
+  // that already existed.
+  const fd = fs.openSync(filePath, 'wx');
+
+  try {
+    const opened = fs.fstatSync(fd, { bigint: true });
+    const onDisk = fs.lstatSync(filePath, { bigint: true });
+
+    // A reparse point at the path resolves to a different file than the handle
+    // we just created, which is the only way the exclusive create above can
+    // still have landed somewhere unintended.
+    if (opened.ino !== onDisk.ino || opened.dev !== onDisk.dev) {
+      throw new Error(`Refusing to write ${filePath}: path was redirected`);
+    }
+  } catch (e: unknown) {
+    fs.closeSync(fd);
+    throw e;
+  }
+
+  // Hand over the descriptor rather than the path: reopening by path would
+  // reintroduce the window the checks above just closed.
+  return fs.createWriteStream('', { fd });
+}

--- a/test/regular/util/safe-file.ts
+++ b/test/regular/util/safe-file.ts
@@ -97,6 +97,7 @@ test('refuses to write through a link and leaves the victim untouched', async t 
     t.is(fs.readFileSync(victimFile, 'utf8'), 'DO NOT OVERWRITE');
 
     // The link itself must survive: deleting it would be a surprise of its own.
+    // lstat reports a Windows junction as a symlink, same as a POSIX one.
     t.true(fs.lstatSync(link).isSymbolicLink());
   } finally {
     cleanup(root, [link]);

--- a/test/regular/util/safe-file.ts
+++ b/test/regular/util/safe-file.ts
@@ -1,0 +1,176 @@
+import test from 'ava';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { createExclusiveWriteStream } from '../../../app/util/safe-file';
+
+/**
+ * Regression tests for HackerOne #3335683: overlay export followed symlinks and
+ * NTFS junctions, letting a lower-privileged user redirect the write onto a
+ * file they could not otherwise touch.
+ */
+
+const isWin = process.platform === 'win32';
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'safe-file-test'));
+}
+
+/** Removes the tree without ever recursing through a link. */
+function cleanup(root: string, links: string[] = []) {
+  links.forEach(link => {
+    try {
+      fs.rmdirSync(link);
+    } catch (e) {
+      try {
+        fs.unlinkSync(link);
+      } catch (e2) {
+        /* already gone */
+      }
+    }
+  });
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+function write(target: string, data: string) {
+  return new Promise<void>((resolve, reject) => {
+    const stream = createExclusiveWriteStream(target);
+    stream.on('error', reject);
+    stream.on('close', () => resolve());
+    stream.end(data);
+  });
+}
+
+/**
+ * Points `link` at `target` using whatever reparse/link primitive the platform
+ * offers without elevation. On Windows that is a directory junction, which is
+ * what the reported exploit uses.
+ */
+function linkTo(link: string, target: string) {
+  if (isWin) {
+    execFileSync('cmd', ['/c', 'mklink', '/J', link, target], { stdio: 'ignore' });
+  } else {
+    fs.symlinkSync(target, link);
+  }
+}
+
+test('writes a new file', async t => {
+  const root = makeRoot();
+  try {
+    const target = path.join(root, 'new.overlay');
+    await write(target, 'hello');
+
+    t.is(fs.readFileSync(target, 'utf8'), 'hello');
+    t.true(fs.lstatSync(target).isFile());
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('overwrites an existing regular file', async t => {
+  const root = makeRoot();
+  try {
+    const target = path.join(root, 'existing.overlay');
+    fs.writeFileSync(target, 'stale placeholder');
+    await write(target, 'fresh');
+
+    t.is(fs.readFileSync(target, 'utf8'), 'fresh');
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('refuses to write through a link and leaves the victim untouched', async t => {
+  const root = makeRoot();
+  const link = path.join(root, 'base.overlay');
+  try {
+    const victimDir = path.join(root, 'victim');
+    const victimFile = path.join(victimDir, 'poc.txt');
+    fs.mkdirSync(victimDir);
+    fs.writeFileSync(victimFile, 'DO NOT OVERWRITE');
+
+    linkTo(link, isWin ? victimDir : victimFile);
+
+    const err = t.throws(() => createExclusiveWriteStream(link));
+    t.regex(err.message, /not a regular file/);
+    t.is(fs.readFileSync(victimFile, 'utf8'), 'DO NOT OVERWRITE');
+
+    // The link itself must survive: deleting it would be a surprise of its own.
+    t.true(fs.lstatSync(link).isSymbolicLink());
+  } finally {
+    cleanup(root, [link]);
+  }
+});
+
+test('writes normally once the link is removed', async t => {
+  const root = makeRoot();
+  const link = path.join(root, 'base.overlay');
+  try {
+    const victimDir = path.join(root, 'victim');
+    const victimFile = path.join(victimDir, 'poc.txt');
+    fs.mkdirSync(victimDir);
+    fs.writeFileSync(victimFile, 'DO NOT OVERWRITE');
+
+    linkTo(link, isWin ? victimDir : victimFile);
+    if (isWin) fs.rmdirSync(link);
+    else fs.unlinkSync(link);
+
+    await write(link, 'now a real file');
+
+    t.is(fs.readFileSync(link, 'utf8'), 'now a real file');
+    t.true(fs.lstatSync(link).isFile());
+    t.is(fs.readFileSync(victimFile, 'utf8'), 'DO NOT OVERWRITE');
+  } finally {
+    cleanup(root, [link]);
+  }
+});
+
+test('refuses a directory', async t => {
+  const root = makeRoot();
+  try {
+    const target = path.join(root, 'dir.overlay');
+    fs.mkdirSync(target);
+
+    const err = t.throws(() => createExclusiveWriteStream(target));
+    t.regex(err.message, /not a regular file/);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('refuses a read-only file rather than clearing the flag', async t => {
+  const root = makeRoot();
+  const target = path.join(root, 'readonly.overlay');
+  try {
+    fs.writeFileSync(target, 'protected');
+    fs.chmodSync(target, 0o444);
+
+    // Deleting would silently drop the read-only attribute, so this must refuse
+    // exactly as a plain open would have.
+    const err = t.throws(() => createExclusiveWriteStream(target));
+    t.regex(err.message, /read-only/);
+    t.is(fs.readFileSync(target, 'utf8'), 'protected');
+  } finally {
+    fs.chmodSync(target, 0o666);
+    cleanup(root);
+  }
+});
+
+test('does not leak descriptors when it refuses', async t => {
+  const root = makeRoot();
+  try {
+    const target = path.join(root, 'dir.overlay');
+    fs.mkdirSync(target);
+
+    for (let i = 0; i < 500; i++) {
+      t.throws(() => createExclusiveWriteStream(target));
+    }
+
+    // A leak here would surface as EMFILE long before the loop ended.
+    await write(path.join(root, 'still-works.overlay'), 'ok');
+    t.pass();
+  } finally {
+    cleanup(root);
+  }
+});


### PR DESCRIPTION
Fixes HackerOne #3335683 (link following on overlay export).

Overlay export opened the chosen path directly, so a symlink or NTFS junction planted there redirected the write. In a shared folder that gave a standard user an arbitrary-write-as-victim primitive.

Export now goes through `createExclusiveWriteStream`: refuse anything that is not a regular writable file, unlink the leaf, create the replacement exclusively, and hand the descriptor to the stream so the path is never reopened.

**Not a complete fix.** Node cannot open a handle with `FILE_FLAG_OPEN_REPARSE_POINT`, so a narrow race can still create a *zero-byte* file at an attacker-chosen path. No attacker-influenced content is ever written. Please do not describe this as eliminated when replying to the reporter.

Sibling report #3335237 (recording) is **not** covered here — that path is owned by `obs-studio-node`/libobs and needs its own change.

Also in scope, both consequences of the above:
- export failures now surface instead of reporting success with a stuck spinner
- the staging directory every export leaked is now cleaned up

## Testing

`test/regular/util/safe-file.ts` — 7 ava cases, no webdriver, picked up by the existing `yarn test` glob. Creates a real junction via `mklink /J`, so it needs no elevation.

Verified in the running app: junction and read-only targets refused, normal export unaffected, no temp leak on either path.

Not covered by the suite: file symlinks and the oplock race. Manual retest needs `SetOpLock.exe` (H1 attachment F4774938) and a second local account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)