### PR TITLE
Fix collection repair by convert to single output collection.

### DIFF
--- a/app/components-react/windows/settings/Developer.tsx
+++ b/app/components-react/windows/settings/Developer.tsx
@@ -156,6 +156,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
       // convert collection
       const filePath = await SceneCollectionsService.actions.return.convertDualOutputCollection(
         assignToHorizontal,
+        p.collection,
       );
 
       if (filePath) {
@@ -181,7 +182,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
         )}
       </span>
       <div>
-        <h4>{$t('Convert to Vanilla Scene')}</h4>
+        <h4>{$t('Convert to Single Output')}</h4>
         <div style={{ display: 'flex', justifyContent: 'space-evenly', paddingBottom: '16px' }}>
           <Button
             className="button--soft-warning"

--- a/app/components-react/windows/settings/Developer.tsx
+++ b/app/components-react/windows/settings/Developer.tsx
@@ -111,7 +111,7 @@ export function DualOutputDeveloperSettings(p: { collectionId?: string }) {
     exportOverlay: boolean = false,
   ) {
     const collection = p.collectionId
-      ? SceneCollectionsService.collections.find(c => c.name === p.collectionId)
+      ? SceneCollectionsService.collections.find(c => c.id === p.collectionId)
       : SceneCollectionsService.activeCollection;
 
     // confirm that the scene collection is a dual output collection
@@ -120,7 +120,7 @@ export function DualOutputDeveloperSettings(p: { collectionId?: string }) {
       (collection?.sceneNodeMaps && Object.values(collection?.sceneNodeMaps).length === 0)
     ) {
       setError(true);
-      setMessage($t('The active scene collection is not a dual output scene collection.'));
+      setMessage($t('The scene collection is not a dual output scene collection.'));
       return;
     }
     if (exportOverlay) {
@@ -139,6 +139,8 @@ export function DualOutputDeveloperSettings(p: { collectionId?: string }) {
       if (!collectionFilePath) {
         setError(true);
         setMessage($t('Unable to convert dual output collection.'));
+        setBusy(false);
+
         return;
       }
 

--- a/app/components-react/windows/settings/Developer.tsx
+++ b/app/components-react/windows/settings/Developer.tsx
@@ -101,7 +101,7 @@ export function DualOutputDeveloperSettings(p: { collectionId?: string }) {
   const [error, setError] = useState(false);
 
   /**
-   * Convert a dual output scene collection to a vanilla scene collection
+   * Convert a dual output scene collection to a single output collection
    * @param assignToHorizontal Boolean for if the vertical sources should be assigned to the
    * horizontal display or should be deleted
    * @param exportOverlay Boolean for is the scene collection should be exported upon completion

--- a/app/components-react/windows/settings/Developer.tsx
+++ b/app/components-react/windows/settings/Developer.tsx
@@ -93,7 +93,7 @@ export function DeveloperSettings() {
   );
 }
 
-export function DualOutputDeveloperSettings(p: { collection?: string }) {
+export function DualOutputDeveloperSettings(p: { collectionId?: string }) {
   const { OverlaysPersistenceService, SceneCollectionsService } = Services;
 
   const [busy, setBusy] = useState(false);
@@ -110,11 +110,14 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
     assignToHorizontal: boolean = false,
     exportOverlay: boolean = false,
   ) {
-    // confirm that the active scene collection is a dual output collection
+    const collection = p.collectionId
+      ? SceneCollectionsService.collections.find(c => c.name === p.collectionId)
+      : SceneCollectionsService.activeCollection;
+
+    // confirm that the scene collection is a dual output collection
     if (
-      !SceneCollectionsService?.sceneNodeMaps ||
-      (SceneCollectionsService?.sceneNodeMaps &&
-        Object.values(SceneCollectionsService?.sceneNodeMaps).length === 0)
+      !collection?.sceneNodeMaps ||
+      (collection?.sceneNodeMaps && Object.values(collection?.sceneNodeMaps).length === 0)
     ) {
       setError(true);
       setMessage($t('The active scene collection is not a dual output scene collection.'));
@@ -130,7 +133,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
       // convert collection
       const collectionFilePath = await SceneCollectionsService.actions.return.convertDualOutputCollection(
         assignToHorizontal,
-        p.collection,
+        p.collectionId,
       );
 
       if (!collectionFilePath) {
@@ -156,7 +159,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
       // convert collection
       const filePath = await SceneCollectionsService.actions.return.convertDualOutputCollection(
         assignToHorizontal,
-        p.collection,
+        p.collectionId,
       );
 
       if (filePath) {
@@ -192,7 +195,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
           >
             {$t('Convert')}
           </Button>
-          {!p.collection && (
+          {!p.collectionId && (
             <Button
               className="button--soft-warning"
               onClick={() => convertDualOutputCollection(false, true)}
@@ -203,7 +206,7 @@ export function DualOutputDeveloperSettings(p: { collection?: string }) {
           )}
         </div>
       </div>
-      {!p.collection && (
+      {!p.collectionId && (
         <div style={{ marginTop: '10px' }}>
           <h4>{$t('Assign Vertical Sources to Horizontal Display')}</h4>
           <div style={{ display: 'flex', justifyContent: 'space-evenly', paddingBottom: '16px' }}>

--- a/app/components-react/windows/settings/Experimental.tsx
+++ b/app/components-react/windows/settings/Experimental.tsx
@@ -3,11 +3,10 @@ import { Button } from 'antd';
 import { ObsSettingsSection } from './ObsSettings';
 import { Services } from '../../service-provider';
 import { alertAsync } from '../../modals';
-import { CheckCircleOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { $t } from 'services/i18n/index';
 
 export function ExperimentalSettings() {
-  const { ScenesService, WindowsService, SceneCollectionsService } = Services;
+  const { ScenesService, WindowsService } = Services;
 
   function repairSceneCollection() {
     ScenesService.repair();
@@ -22,88 +21,11 @@ export function ExperimentalSettings() {
     });
   }
 
-  /**
-   * Convert a dual output scene collection to a vanilla scene collection
-   * @param assignToHorizontal Boolean for if the vertical sources should be assigned to the
-   * horizontal display or should be deleted
-   * @param exportOverlay Boolean for is the scene collection should be exported upon completion
-   */
-  async function convertDualOutputCollection(assignToHorizontal: boolean = false) {
-    // confirm that the active scene collection is a dual output collection
-    if (
-      !SceneCollectionsService?.sceneNodeMaps ||
-      (SceneCollectionsService?.sceneNodeMaps &&
-        Object.values(SceneCollectionsService?.sceneNodeMaps).length === 0)
-    ) {
-      alertAsync({
-        icon: <ExclamationCircleOutlined style={{ color: 'var(--red)' }} />,
-        getContainer: '#mainWrapper',
-        className: 'react',
-        title: $t('Invalid Scene Collection'),
-        content: $t('The active scene collection is not a dual output scene collection.'),
-      });
-      return;
-    }
-
-    await SceneCollectionsService.actions.return
-      .convertDualOutputCollection(assignToHorizontal)
-      .then((message: string) => {
-        const messageData = JSON.parse(message);
-
-        const className = messageData.error ? 'react convert-error' : 'react convert-success';
-
-        const icon = messageData.error ? (
-          <ExclamationCircleOutlined style={{ color: 'var(--red)' }} />
-        ) : (
-          <CheckCircleOutlined style={{ color: 'var(--teal)' }} />
-        );
-
-        const title = $t(messageData?.title) ?? 'Success';
-
-        const content = messageData?.content ?? $t('Successfully converted scene collection.');
-
-        alertAsync({
-          icon,
-          getContainer: '#mainWrapper',
-          className,
-          title,
-          content,
-        });
-      });
-  }
-
   return (
     <ObsSettingsSection>
       <div className="section">
         <h2>{$t('Repair Scene Collection')}</h2>
         <Button onClick={repairSceneCollection}>Repair Scene Collection</Button>
-      </div>
-      <div className="section">
-        <h2>{$t('Convert Dual Output Scene Collection')}</h2>
-
-        <span>
-          {$t(
-            'The below will create a copy of the active scene collection, set the copy as the active collection, and then remove all vertical sources.',
-          )}
-        </span>
-        <div style={{ marginTop: '10px' }}>
-          <h4>{$t('Convert to Vanilla Scene')}</h4>
-          <Button
-            className="convert-collection button button--soft-warning"
-            onClick={async () => await convertDualOutputCollection()}
-          >
-            {$t('Convert')}
-          </Button>
-        </div>
-        {/* <div style={{ marginTop: '10px' }}>
-          <h4>{$t('Assign Vertical Sources to Horizontal Display')}</h4>
-          <Button
-            className="assign-collection button button--soft-warning"
-            onClick={async () => await convertDualOutputCollection(true)}
-          >
-            {$t('Assign')}
-          </Button>
-        </div> */}
       </div>
       <div className="section">
         <h2>{$t('Show Components Library')}</h2>

--- a/app/components-react/windows/settings/SceneCollections.tsx
+++ b/app/components-react/windows/settings/SceneCollections.tsx
@@ -151,7 +151,7 @@ export function SceneCollectionsSettings() {
           onChange={setCollection}
           options={collectionOptions}
         />
-        <DualOutputDeveloperSettings collection={collection} />
+        <DualOutputDeveloperSettings collectionId={collection} />
       </ObsSettingsSection>
     </>
   );

--- a/app/i18n/en-US/overlays.json
+++ b/app/i18n/en-US/overlays.json
@@ -26,5 +26,6 @@
   "The below will create a copy of the active scene collection, set the copy as the active collection, and then remove all vertical sources.": "The below will create a copy of the active scene collection, set the copy as the active collection, and then remove all vertical sources.",
   "Show Components Library": "Show Components Library",
   "Convert Dual Output Scene Collection": "Convert Dual Output Scene Collection",
-  "Repair Scene Collection": "Repair Scene Collection"
+  "Repair Scene Collection": "Repair Scene Collection",
+  "The scene collection is not a dual output scene collection.": "The scene collection is not a dual output scene collection."
 }

--- a/app/i18n/en-US/overlays.json
+++ b/app/i18n/en-US/overlays.json
@@ -9,6 +9,7 @@
   "Import Widget File in Current Scene": "Import Widget File in Current Scene",
   "The active scene collection is not a dual output scene collection.": "The active scene collection is not a dual output scene collection.",
   "Convert to Vanilla Scene": "Convert to Vanilla Scene",
+  "Convert to Single Output": "Convert to Single Output",
   "Convert": "Convert",
   "Convert and Export Overlay": "Convert and Export Overlay",
   "Assign": "Assign",

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -360,7 +360,6 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     this.sceneCollectionsService.collectionSwitched.subscribe(collection => {
       const hasNodeMap =
         collection?.sceneNodeMaps && Object.entries(collection?.sceneNodeMaps).length > 0;
-      console.log('Collection switched has nodemap');
 
       if (this.state.dualOutputMode && !hasNodeMap) {
         this.convertSingleOutputToDualOutputCollection();

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -358,6 +358,13 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
      * @remark Optimize by only confirming when the collection is switched
      */
     this.sceneCollectionsService.collectionSwitched.subscribe(collection => {
+      // Skip validating a collection that is being converted to a single output collection
+      // to prevent recreating the partner nodes
+      if (this.sceneCollectionsService.isConvertingCollection) {
+        this.collectionHandled.next(null);
+        return;
+      }
+
       const hasNodeMap =
         collection?.sceneNodeMaps && Object.entries(collection?.sceneNodeMaps).length > 0;
 

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -416,6 +416,7 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
       }
 
       this.SET_SHOW_DUAL_OUTPUT(false);
+      this.selectionService.views.globalSelection.reset();
 
       this.SET_IS_LOADING(false);
       this.dualOutputModeChanged.next(status);

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -360,6 +360,7 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     this.sceneCollectionsService.collectionSwitched.subscribe(collection => {
       const hasNodeMap =
         collection?.sceneNodeMaps && Object.entries(collection?.sceneNodeMaps).length > 0;
+      console.log('Collection switched has nodemap');
 
       if (this.state.dualOutputMode && !hasNodeMap) {
         this.convertSingleOutputToDualOutputCollection();
@@ -404,7 +405,24 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     status: boolean = true,
     skipShowVideoSettings: boolean = false,
     showGoLiveWindow?: boolean,
+    force?: boolean,
   ) {
+    if (!status && force) {
+      if (!this.state.videoSettings.horizontal) {
+        this.toggleDisplay(true, 'horizontal');
+      }
+
+      if (this.state.videoSettings.vertical) {
+        this.toggleDisplay(false, 'vertical');
+      }
+
+      this.SET_SHOW_DUAL_OUTPUT(false);
+
+      this.SET_IS_LOADING(false);
+      this.dualOutputModeChanged.next(status);
+      return;
+    }
+
     if (!this.userService.isLoggedIn) return;
 
     // If a user is not in protected mode (ie using "Stream to a Custom Ingest")

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -407,11 +407,11 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     force?: boolean,
   ) {
     if (!status && force) {
-      if (!this.state.videoSettings.horizontal) {
+      if (!this.views.showHorizontalDisplay) {
         this.toggleDisplay(true, 'horizontal');
       }
 
-      if (this.state.videoSettings.vertical) {
+      if (this.views.showVerticalDisplay) {
         this.toggleDisplay(false, 'vertical');
       }
 

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -16,7 +16,7 @@ import { SceneCollectionsService } from '../scene-collections';
 
 interface ISchema {
   /**
-   * this is for backward compatibility with vanilla scene collections
+   * this is for backward compatibility with single output collections
    */
   baseResolution: {
     baseWidth: number;

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -363,9 +363,11 @@ export class SceneCollectionsService extends Service implements ISceneCollection
 
     if (!newCollectionId) return;
 
-    this.dualOutputService.setDualOutputModeIfPossible(false);
-
     await this.load(newCollectionId);
+
+    // Disable dual output mode after loading the duplicate to prevent the converted collection
+    // from being saved as a dual output collection.
+    this.dualOutputService.setDualOutputModeIfPossible(false, true, false, true);
 
     await this.convertToVanillaSceneCollection(assignToHorizontal);
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -1340,7 +1340,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * display instead of removing them
    */
   async convertToSingleOutputSceneCollection(assignToHorizontal?: boolean) {
-    if (!this.activeCollection) return;
+    if (!this.activeCollection || !this.activeCollection?.sceneNodeMaps) return;
 
     const allSceneIds: string[] = this.scenesService.getSceneIds();
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -119,6 +119,12 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   private collectionErrorOpen = false;
 
   /**
+   * Whether a dual output collection is currently being converted
+   * to a single output collection.
+   */
+  isConvertingCollection = false;
+
+  /**
    * true if the scene-collections sync in progress
    */
   private syncPending = false;
@@ -359,19 +365,28 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     const collection = collectionId ? this.getCollection(collectionId) : this.activeCollection;
     const name = `${collection?.name} - Converted`;
 
-    const newCollectionId = await this.duplicate(name, collectionId);
+    // Prevent recreating vertical nodes while converting the collection to a single output.
+    this.isConvertingCollection = true;
 
-    if (!newCollectionId) return;
+    try {
+      const newCollectionId = await this.duplicate(name, collectionId);
 
-    await this.load(newCollectionId);
+      if (!newCollectionId) return;
 
-    // Disable dual output mode after loading the duplicate to prevent the converted collection
-    // from being saved as a dual output collection.
-    this.dualOutputService.setDualOutputModeIfPossible(false, true, false, true);
+      await this.load(newCollectionId);
 
-    await this.convertToVanillaSceneCollection(assignToHorizontal);
+      // Disable dual output mode after loading the duplicate to prevent the converted collection
+      // from being saved as a dual output collection.
+      this.dualOutputService.setDualOutputModeIfPossible(false, true, false, true);
 
-    return this.stateService.getCollectionFilePath(newCollectionId);
+      await this.convertToSingleOutputSceneCollection(assignToHorizontal);
+
+      return this.stateService.getCollectionFilePath(newCollectionId);
+    } finally {
+      // Always reset this flag to false, even if the conversion fails, so that the user can
+      // attempt to convert the collection again or repair it manually
+      this.isConvertingCollection = false;
+    }
   }
 
   downloadProgress = new Subject<IDownloadProgress>();
@@ -1320,10 +1335,12 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   }
 
   /**
-   * Convert dual output scene collection to vanilla scene collection
+   * Convert dual output scene collection to single output collection
+   * @param assignToHorizontal - Whether to reassign the vertical nodes to the horizontal
+   * display instead of removing them
    */
-  async convertToVanillaSceneCollection(assignToHorizontal?: boolean) {
-    if (!this.activeCollection?.sceneNodeMaps) return;
+  async convertToSingleOutputSceneCollection(assignToHorizontal?: boolean) {
+    if (!this.activeCollection) return;
 
     const allSceneIds: string[] = this.scenesService.getSceneIds();
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1267,6 +1267,8 @@ export class StreamingService
       this.handleUpdatePlatformError(e, platform);
       return false;
     }
+
+    return true;
   }
 
   handleUpdatePlatformError(e: unknown, platform: TPlatform) {


### PR DESCRIPTION
# Fix Scene Collection repair to use the selected collection id

## Summary

The repair/convert tool on the **Scene Collections** settings page always operated on the **active** scene collection, ignoring whichever collection the user picked from the list. This passes the selected collection id through, fixes dual output mode switching itself back on partway through the conversion, removes a duplicate (and broken) copy of the same tool from **Experimental** settings, and picks up an unrelated missing `return` in `StreamingService`.

Converting a dual output scene collection to a single output collection was producing a collection with duplicate nodes, and the conversion UI operated on the wrong collection when a non-active collection was selected. This fixes the conversion flow, moves the entry point to a single place, and renames "vanilla" to "single output" across the feature.

## Changes

### `app/components-react/windows/settings/Developer.tsx`

`convertDualOutputCollection` now forwards `p.collection` to `SceneCollectionsService.convertDualOutputCollection` in the non-export branch. The service already accepts `collectionId?: string` and falls back to `this.activeCollection` when it's omitted, so the missing argument silently converted the wrong collection instead of failing.

Renamed the section heading from "Convert to Vanilla Scene" to "Convert to Single Output".

### `app/services/scene-collections/scene-collections.ts`

Moved the `setDualOutputModeIfPossible(false, ...)` call in `convertDualOutputCollection` to **after** `await this.load(newCollectionId)`, and passed `force: true`.

Dual output mode was being disabled before `duplicate()`, but `duplicate()` → `insertCollection(..., fromId)` → `stateService.copyCollectionFile` copies the source collection's config file straight off disk, and that file was serialized while dual output was on — so the copy still carries `dualOutputMode: true`. Loading it then runs `RootNode.load()`, which calls `this.streamingService.setDualOutputMode(this.data.dualOutputMode)` (`nodes/root.ts:128`), and `StreamingService.setDualOutputMode` forwards `true` right back to `DualOutputService.setDualOutputModeIfPossible(true, true)` (`streaming.ts:1520-1523`). Dual output was therefore back on before `convertToVanillaSceneCollection` ran, and its closing `await this.save()` re-serialized `dualOutputMode: this.dualOutputService.views.dualOutputMode` (`nodes/root.ts:90`) as `true` — persisting the converted collection as a dual output collection despite it having no vertical nodes, and re-enabling the mode on every subsequent load.

`force: true` is needed because the default path bails at the `!this.userService.isLoggedIn` guard (`dual-output.ts:425`) and otherwise falls through to `@RunInLoadingMode private setDualOutputMode`, nesting a second loading mode inside the one `convertDualOutputCollection` already holds. The `force` branch (`dual-output.ts:409-423`) skips both and tears the vertical display down directly.

### `app/components-react/windows/settings/Experimental.tsx`

Removed the "Convert Dual Output Scene Collection" section and its local `convertDualOutputCollection` helper. It was a stale duplicate of the Developer/Scene Collections tool that hardcoded the active collection with no way to choose one, and did `JSON.parse(message)` on the return value — but the service returns a **file path string**, not JSON, so the success path threw a `SyntaxError` on every invocation. Dropped the now-unused `SceneCollectionsService` and `@ant-design/icons` imports.

### `app/services/streaming/streaming.ts`

`updatePlatformSettings` declares `Promise<boolean>` but only returned on the `catch` path; the success path fell through to `undefined`. Added the missing `return true`.

## Background: when did the collection id get dropped?

Short version: **it was never dropped from `Developer.tsx` — the id was wired to the wrong branch when two divergent copies of this tool were merged during the React migration.** `Developer.tsx`'s ancestor never passed a collection id in the first place.

The tool existed in two places in the Vue era:

| Commit | What happened |
| --- | --- |
| `65e9f1c4b` (#4722) | Original dev tool added to Vue `DeveloperSettings.tsx`. No collection picker — always the active collection. The service had no `collectionId` param yet. |
| `d1d86decd` (#4800, Nov 2023) | A **second** copy was added to Vue `OverlaySettings.tsx`, this one *with* a collection dropdown. `SceneCollectionsService.convertDualOutputCollection` gained `collectionId?: string`, and the `OverlaySettings` copy passed `this.collection` — but only in the non-export branch. The `DeveloperSettings.tsx` copy was left untouched. |
| `fb879c47b` (#5584) | Vue `DeveloperSettings.tsx` → React `Developer.tsx`. A faithful port of the copy that never had a picker, so `DualOutputDeveloperSettings()` had no `collection` prop at all. Nothing was lost here. |
| `251fb8220` (#5585) | Vue `OverlaySettings.tsx` was deleted; its collection dropdown became React `SceneCollections.tsx`, which renders `<DualOutputDeveloperSettings collection={collection} />`. The prop was threaded in and wired to the `exportOverlay` branch — **the opposite branch from the one the Vue original had wired.** |

That last step is where the behavior regressed, and the wiring guaranteed the id could never take effect: the "Convert and Export Overlay" button — the only caller that reaches the `exportOverlay` branch — is rendered behind `{!p.collection && ...}`. So the branch that received `p.collection` is unreachable whenever `p.collection` is set, and the branch that actually runs from the Scene Collections page never received it. The dropdown has been decorative since #5585.

This PR adds the argument to the branch that runs.