### PR TITLE
Add to youtube form cleanup to prevent state update on unmounted component.

### DIFF
--- a/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
@@ -65,11 +65,18 @@ export const YoutubeEditStreamInfo = InputComponent((p: IPlatformComponentParams
   useEffect(() => {
     if (!broadcastId) return;
 
+    let isMounted = true;
+
     Services.YoutubeService.actions.return
       .fetchStartStreamOptionsForBroadcast(broadcastId)
       .then(newYtSettings => {
+        if (!isMounted) return;
         updateSettings(newYtSettings);
       });
+
+    return () => {
+      isMounted = false;
+    };
   }, [broadcastId]);
 
   function fieldIsDisabled(fieldName: keyof IYoutubeStartStreamOptions): boolean {


### PR DESCRIPTION
# Guard YouTube Broadcast Fetch Against Unmount and Stale Responses

## Issues

`YoutubeEditStreamInfo` re-fills the form whenever `broadcastId` changes: the effect calls `fetchStartStreamOptionsForBroadcast` and writes the result back through `updateSettings`. The promise had no cancellation, which left two failures:

**Unmount.** Closing the Go Live window, toggling YouTube off, or switching platform tabs while the fetch is in flight resolves the promise into a component that no longer exists. This is the warning users see.

**Stale response.** The more damaging of the two, and silent. Selecting broadcast A and then switching to B before A resolves leaves both fetches racing. If A lands second it overwrites B's title, description, privacy status, category, thumbnail, and monetization flags — the form ends up showing the previous event's settings with the new event selected. `fetchStartStreamOptionsForBroadcast` (`app/services/platforms/youtube.ts:1212`) issues two API calls in a `Promise.all` (`fetchBroadcast` + `fetchVideo`), so latency varies enough for one response to overtake another in practice.

## Fixes

Added an `isMounted` and cleanup. This covers both failure modes with one mechanism. React runs an effect's cleanup before re-running the effect, so a `broadcastId` change invalidates the previous fetch as well as an unmount — whichever broadcast the user selected last is guaranteed to win regardless of response order.

The pattern matches the existing convention in `Hotkeys.tsx:54`, which uses the same flag on a non-empty dependency array. `usePromise` (`app/components-react/hooks.ts:110`) exists for this purpose but is mount-only (`deps: []`), so it cannot drive an effect keyed on `broadcastId`.

**File changed:** `app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx`

## Performance Implications

None meaningful. One boolean per effect run and a closure check before an already-scheduled state write. Marginally positive: discarded responses now skip a `updateSettings` call and the resulting re-render of the platform settings form.