### PR TITLE
Restore set onboarding step for v2.

### DIFF
--- a/app/services/onboarding/onboarding-v2.ts
+++ b/app/services/onboarding/onboarding-v2.ts
@@ -263,10 +263,7 @@ export class OnboardingV2Service extends Service {
   }
 
   showOnboardingIfNecessary() {
-    if (
-      !Utils.env.SLD_FORCE_ONBOARDING_STEP &&
-      (this.userService.isAlphaGroup || localStorage.getItem(this.localStorageKey))
-    ) {
+    if (!Utils.env.SLD_FORCE_ONBOARDING_STEP && localStorage.getItem(this.localStorageKey)) {
       return;
     }
     this.appService.setOnboarded(true);

--- a/app/services/onboarding/onboarding-v2.ts
+++ b/app/services/onboarding/onboarding-v2.ts
@@ -263,7 +263,10 @@ export class OnboardingV2Service extends Service {
   }
 
   showOnboardingIfNecessary() {
-    if (!Utils.env.SLD_FORCE_ONBOARDING_STEP && localStorage.getItem(this.localStorageKey)) {
+    if (
+      !Utils.env.SLD_FORCE_ONBOARDING_STEP &&
+      (this.userService.isAlphaGroup || localStorage.getItem(this.localStorageKey))
+    ) {
       return;
     }
     this.appService.setOnboarded(true);
@@ -271,6 +274,20 @@ export class OnboardingV2Service extends Service {
   }
 
   showOnboarding() {
+    if (Utils.env.SLD_FORCE_ONBOARDING_STEP !== undefined) {
+      const isValidStep = Object.values(EOnboardingSteps).some(
+        step => step === Utils.env.SLD_FORCE_ONBOARDING_STEP,
+      );
+
+      if (isValidStep) {
+        this.initalizeView({
+          startingStep: { name: Utils.env.SLD_FORCE_ONBOARDING_STEP as EOnboardingSteps },
+          isSingleton: true,
+        });
+        return;
+      }
+    }
+
     this.initalizeView({
       startingStep: { name: EOnboardingSteps.Splash, isSkippable: false, isClosable: false },
       isSingleton: false,


### PR DESCRIPTION
# Fix force onboarding step in v2 regression

`SLD_FORCE_ONBOARDING_STEP` for onboarding v2 was added and then deleted a day later in a different PR.

---

## Summary

|           | Commit      | Date                      | Author       | PR                                               |
| --------- | ----------- | ------------------------- | ------------ | ------------------------------------------------ |
| **Added** | `2a832ef0a` | 2026-05-12 09:17:43 -0700 | Micheline Wu | **#5911 "Platforms refactor."** (the Patreon PR) |
| **Lost**  | `cb8f9e169` | 2026-05-13 13:09:36 -0700 | Micheline Wu | **#5916 "Onboarding and platform chat fixes"**   |

**Different PRs**, roughly 28 hours apart. The block was deleted by `d4611ca40`, the first commit on #5916's branch — not by the merge. That branch was cut from master (which had the block) but its `onboarding-v2.ts` was carried over from parallel `staging`-line work that predated the Patreon PR, silently reverting it.

#5916 dropped **two** pieces of #5911, from two different commits on its branch. The second — `'patreon'` in `PrimaryPlatformSelect.tsx`, removed by `ab5f98124` — was restored a week later in #5926.

#### Root cause: a stale file carried across the master/staging split

Blob history for `app/services/onboarding/onboarding-v2.ts`:

| Blob        | Contents                                        | Where                                                                     |
| ----------- | ----------------------------------------------- | ------------------------------------------------------------------------- |
| `518d9c5c2` | pre-#5911 — no force-step block                 | `31e436611` (staging line, 2026-05-12)                                    |
| `9619957ed` | **with** force-step block                       | `2a832ef0a` (#5911) → `a5ad2600c` → `01cba1d74` (master tip before #5916) |
| `aac66f879` | no force-step block, **with** `isPartialSLAuth` | `d4611ca40`…`851d76871` (#5916 branch) **and** `b1d9d9ba3` (#5913)        |

`d4611ca40`'s version is **byte-identical** to the staging-line version landed by #5913. The same `isPartialSLAuth` work was being done twice — once for `staging` (#5913, head `mw_res_conflict_5`) and once for `master` (#5916, head `mw_onboarding_fixes_master`) — and the staging-derived file, which was built on the pre-Patreon `518d9c5c2`, was carried onto the master-based branch. That overwrite reverted #5911.

#### Collateral audit: what else #5916 dropped

##### Second loss: `'patreon'` in `PrimaryPlatformSelect.tsx`

Same stale-file mechanism, **same PR, different commit**. Blob trail for that file:

| Commit      | Message                                                            | blob                               |
| ----------- | ------------------------------------------------------------------ | ---------------------------------- |
| `a5ad2600c` | branch base (master line)                                          | `1e781d58e` — **has `'patreon'`**  |
| `d4611ca40` | "Show new onboarding connect more."                                | `1e781d58e`                        |
| `2e607bce4` | "Only show X in old onboarding Connect"                            | `1e781d58e`                        |
| `ab5f98124` | "Handle linked platforms call silently failing after login in UI." | `4dff2be14` — **`'patreon'` gone** |
| `851d76871` | "Fix primary chat selection filtering."                            | `4dff2be14`                        |
| `cb8f9e169` | squash onto master                                                 | `4dff2be14`                        |

`ab5f98124`'s patch for that file carries the explicit `'patreon',` hunk. So the two losses inthis PR came from two different commits:

- `d4611ca40` → the `onboarding-v2.ts` force-step block
- `ab5f98124` → `'patreon'` in `PrimaryPlatformSelect.tsx`

**Restored** on 2026-05-20 by `3ffc85fe4` / `0f74b3394`, "Platform UI fixes. (#5926)", Micheline Wu — seven days later. `'patreon',` is present in that array on `origin/master` today (line 31). This one got noticed because it was user-visible; the onboarding force-step did not, because nothing exercised it.
