### PR TITLE
Render OBS compat-info properties as rich text

### DIFF
--- a/app/components-react/obs/ObsCompatInfo.m.less
+++ b/app/components-react/obs/ObsCompatInfo.m.less
@@ -1,0 +1,46 @@
+@import '../../styles/index';
+
+// Frame for OBS_TEXT_INFO property messages. Geometry matches the shared Callout component;
+// `@radius` is the 4px input radius, callout surfaces use 8px.
+.frame {
+  display: flex;
+  align-items: flex-start;
+  gap: @spacing;
+  padding: 1.5 * @spacing;
+  border: 1px solid;
+  border-radius: 8px;
+  // launch options and URLs are long and unbreakable
+  overflow-wrap: anywhere;
+}
+
+.icon {
+  line-height: inherit;
+}
+
+// libobs severities. The token names invert: `--info` is amber, `--warning` is red.
+.normal {
+  background: var(--callout-semi);
+  border-color: var(--callout-border);
+
+  .icon {
+    color: var(--callout);
+  }
+}
+
+.warning {
+  background: var(--info-semi);
+  border-color: var(--info-border);
+
+  .icon {
+    color: var(--info);
+  }
+}
+
+.error {
+  background: var(--warning-semi);
+  border-color: var(--warning-border);
+
+  .icon {
+    color: var(--warning);
+  }
+}

--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -28,6 +28,7 @@ import { showFileDialog } from '../shared/inputs/FileInput';
 import cloneDeep from 'lodash/cloneDeep';
 import { Button, Collapse, Input, InputNumber } from 'antd';
 import InputWrapper from '../shared/inputs/InputWrapper';
+import ObsRichText from '../shared/ObsRichText';
 import { $t, $translateIfExist, $translateIfExistWithCheck } from '../../services/i18n';
 import Utils from 'services/utils';
 import cx from 'classnames';
@@ -86,6 +87,37 @@ interface IObsInputProps {
   extraProps?: IExtraInputProps;
 }
 
+// game-capture.c registers `compat_info` twice, so the visibility logic no-ops on a NULL
+// property and this never clears. Untranslated libobs literal. Remove once that is fixed.
+const HOOK_STATUS_PLACEHOLDER = 'Attempting to hook process...';
+
+// `--info` is amber and `--warning` is red, despite the names.
+function infoFieldTokens(infoType?: obs.ETextInfoType) {
+  switch (infoType) {
+    case obs.ETextInfoType.Error:
+      return {
+        accent: 'var(--warning)',
+        border: 'var(--warning-border)',
+        bg: 'var(--warning-semi)',
+        icon: 'icon-error',
+      };
+    case obs.ETextInfoType.Warning:
+      return {
+        accent: 'var(--info)',
+        border: 'var(--info-border)',
+        bg: 'var(--info-semi)',
+        icon: 'icon-information',
+      };
+    default:
+      return {
+        accent: 'var(--callout)',
+        border: 'var(--callout-border)',
+        bg: 'var(--callout-semi)',
+        icon: 'icon-question',
+      };
+  }
+}
+
 /**
  * Renders a single OBS input
  */
@@ -139,23 +171,35 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
       if (textVal.multiline) {
         return <TextAreaInput {...inputProps} debounce={300} data-name={p.value.name} />;
       } else if (textVal.infoField) {
-        const infoField = (textVal.infoField as unknown) as obs.ETextInfoType;
-        switch (textVal.infoField) {
-          case infoField === obs.ETextInfoType.Warning:
-            return (
-              <InputWrapper style={{ color: 'var(--info)' }} data-name={p.value.name}>
-                {textVal.description}
-              </InputWrapper>
-            );
-          case infoField === obs.ETextInfoType.Error:
-            return (
-              <InputWrapper style={{ color: 'var(--warning)' }} data-name={p.value.name}>
-                {textVal.description}
-              </InputWrapper>
-            );
-          default:
-            return <InputWrapper data-name={p.value.name}>{textVal.description}</InputWrapper>;
-        }
+        // libobs can leave this visible with an empty description; an empty frame is worse
+        // than nothing.
+        const infoText = textVal.description?.trim();
+        if (!infoText || infoText === HOOK_STATUS_PLACEHOLDER) return <></>;
+
+        // severity goes on the frame and icon, not the body text
+        const info = infoFieldTokens(textVal.infoType);
+
+        return (
+          <InputWrapper data-name={p.value.name}>
+            {/* `selectable` so launch options and URLs can be copied */}
+            <div
+              className="selectable"
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+                padding: '10px 12px',
+                border: `1px solid ${info.border}`,
+                borderRadius: '8px',
+                background: info.bg,
+                overflowWrap: 'anywhere',
+              }}
+            >
+              <i className={info.icon} style={{ color: info.accent, lineHeight: 'inherit' }} />
+              <ObsRichText text={infoText} />
+            </div>
+          </InputWrapper>
+        );
       } else {
         return (
           <ObsTextInput

--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -29,6 +29,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { Button, Collapse, Input, InputNumber } from 'antd';
 import InputWrapper from '../shared/inputs/InputWrapper';
 import ObsRichText from '../shared/ObsRichText';
+import styles from './ObsCompatInfo.m.less';
 import { $t, $translateIfExist, $translateIfExistWithCheck } from '../../services/i18n';
 import Utils from 'services/utils';
 import cx from 'classnames';
@@ -91,30 +92,14 @@ interface IObsInputProps {
 // property and this never clears. Untranslated libobs literal. Remove once that is fixed.
 const HOOK_STATUS_PLACEHOLDER = 'Attempting to hook process...';
 
-// `--info` is amber and `--warning` is red, despite the names.
-function infoFieldTokens(infoType?: obs.ETextInfoType) {
+function infoFieldSeverity(infoType?: obs.ETextInfoType) {
   switch (infoType) {
     case obs.ETextInfoType.Error:
-      return {
-        accent: 'var(--warning)',
-        border: 'var(--warning-border)',
-        bg: 'var(--warning-semi)',
-        icon: 'icon-error',
-      };
+      return { name: 'error', frame: styles.error, icon: 'icon-error' };
     case obs.ETextInfoType.Warning:
-      return {
-        accent: 'var(--info)',
-        border: 'var(--info-border)',
-        bg: 'var(--info-semi)',
-        icon: 'icon-information',
-      };
+      return { name: 'warning', frame: styles.warning, icon: 'icon-information' };
     default:
-      return {
-        accent: 'var(--callout)',
-        border: 'var(--callout-border)',
-        bg: 'var(--callout-semi)',
-        icon: 'icon-question',
-      };
+      return { name: 'normal', frame: styles.normal, icon: 'icon-question' };
   }
 }
 
@@ -177,25 +162,16 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
         if (!infoText || infoText === HOOK_STATUS_PLACEHOLDER) return <></>;
 
         // severity goes on the frame and icon, not the body text
-        const info = infoFieldTokens(textVal.infoType);
+        const severity = infoFieldSeverity(textVal.infoType);
 
         return (
           <InputWrapper data-name={p.value.name}>
             {/* `selectable` so launch options and URLs can be copied */}
             <div
-              className="selectable"
-              style={{
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: '8px',
-                padding: '10px 12px',
-                border: `1px solid ${info.border}`,
-                borderRadius: '8px',
-                background: info.bg,
-                overflowWrap: 'anywhere',
-              }}
+              className={cx(styles.frame, severity.frame, 'selectable')}
+              data-severity={severity.name}
             >
-              <i className={info.icon} style={{ color: info.accent, lineHeight: 'inherit' }} />
+              <i className={cx(styles.icon, severity.icon)} />
               <ObsRichText text={infoText} />
             </div>
           </InputWrapper>

--- a/app/components-react/shared/ObsRichText.m.less
+++ b/app/components-react/shared/ObsRichText.m.less
@@ -1,0 +1,16 @@
+@import '../../styles/index';
+
+.code {
+  padding: 0 3px;
+  font-family: monospace;
+  // launch flags read as a typo if they wrap mid-token
+  white-space: nowrap;
+  background: var(--section-alt);
+  border-radius: 2px;
+}
+
+// colour comes from the global `a` rule
+.link {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -1,0 +1,80 @@
+import React, { createElement, useMemo } from 'react';
+import * as remote from '@electron/remote';
+
+/**
+ * Renders the Qt rich text libobs puts in OBS_TEXT_INFO descriptions. Tags are rebuilt from an
+ * allowlist rather than injected, and links open externally so they can't navigate the window.
+ */
+export default function ObsRichText(p: { text: string }) {
+  const nodes = useMemo(
+    () => Array.from(new DOMParser().parseFromString(p.text ?? '', 'text/html').body.childNodes),
+    [p.text],
+  );
+
+  return <span>{nodes.map(renderNode)}</span>;
+}
+
+const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
+
+// dropped with their contents; other unknown tags keep their text
+const OPAQUE_TAGS = ['script', 'style'];
+
+const CODE_STYLE: React.CSSProperties = {
+  fontFamily: 'monospace',
+  whiteSpace: 'nowrap', // launch flags; wrapping mid-token reads as a typo
+  background: 'var(--section-alt)',
+  borderRadius: '2px',
+  padding: '0 3px',
+};
+
+// colour comes from the global `a` rule
+const LINK_STYLE: React.CSSProperties = {
+  textDecoration: 'underline',
+  cursor: 'pointer',
+};
+
+function renderChildren(node: Node) {
+  return Array.from(node.childNodes).map(renderNode);
+}
+
+function renderNode(node: Node, key: number): React.ReactNode {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+  if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+  const tag = (node as Element).tagName.toLowerCase();
+
+  if (OPAQUE_TAGS.includes(tag)) return null;
+
+  if (tag === 'br') return <br key={key} />;
+
+  if (tag === 'a') {
+    const href = (node as Element).getAttribute('href') ?? '';
+    if (!/^https?:\/\//i.test(href)) {
+      return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
+    }
+
+    return (
+      <a
+        key={key}
+        style={LINK_STYLE}
+        onClick={e => {
+          e.preventDefault();
+          remote.shell.openExternal(href);
+        }}
+      >
+        {renderChildren(node)}
+      </a>
+    );
+  }
+
+  if (INLINE_TAGS.includes(tag)) {
+    return createElement(
+      tag,
+      { key, style: tag === 'code' ? CODE_STYLE : undefined },
+      renderChildren(node),
+    );
+  }
+
+  // Unknown tag: drop it, keep its text.
+  return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
+}

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -1,5 +1,6 @@
 import React, { createElement, useMemo } from 'react';
 import * as remote from '@electron/remote';
+import styles from './ObsRichText.m.less';
 
 /**
  * Renders the Qt rich text libobs puts in OBS_TEXT_INFO descriptions. Tags are rebuilt from an
@@ -19,20 +20,6 @@ const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
 
 // dropped with their contents; other unknown tags keep their text
 const OPAQUE_TAGS = ['script', 'style'];
-
-const CODE_STYLE: React.CSSProperties = {
-  fontFamily: 'monospace',
-  whiteSpace: 'nowrap', // launch flags; wrapping mid-token reads as a typo
-  background: 'var(--section-alt)',
-  borderRadius: '2px',
-  padding: '0 3px',
-};
-
-// colour comes from the global `a` rule
-const LINK_STYLE: React.CSSProperties = {
-  textDecoration: 'underline',
-  cursor: 'pointer',
-};
 
 function renderChildren(node: Node) {
   return Array.from(node.childNodes).map(renderNode);
@@ -61,7 +48,7 @@ function renderNode(node: Node, key: number): React.ReactNode {
         key={key}
         role="link"
         tabIndex={0}
-        style={LINK_STYLE}
+        className={styles.link}
         onClick={e => {
           e.preventDefault();
           open();
@@ -81,7 +68,7 @@ function renderNode(node: Node, key: number): React.ReactNode {
   if (INLINE_TAGS.includes(tag)) {
     return createElement(
       tag,
-      { key, style: tag === 'code' ? CODE_STYLE : undefined },
+      { key, className: tag === 'code' ? styles.code : undefined },
       renderChildren(node),
     );
   }

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -11,7 +11,8 @@ export default function ObsRichText(p: { text: string }) {
     [p.text],
   );
 
-  return <span>{nodes.map(renderNode)}</span>;
+  // a block wrapper, not a span: it is a flex item and the allowlist permits <p>
+  return <div>{nodes.map(renderNode)}</div>;
 }
 
 const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
@@ -53,13 +54,23 @@ function renderNode(node: Node, key: number): React.ReactNode {
       return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
     }
 
+    // no href, so it needs an explicit role and key handling to stay reachable
+    const open = () => remote.shell.openExternal(href);
     return (
       <a
         key={key}
+        role="link"
+        tabIndex={0}
         style={LINK_STYLE}
         onClick={e => {
           e.preventDefault();
-          remote.shell.openExternal(href);
+          open();
+        }}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            open();
+          }
         }}
       >
         {renderChildren(node)}


### PR DESCRIPTION
Bug
<img width="488" height="354" alt="image" src="https://github.com/user-attachments/assets/21b6b95c-6b0b-4245-9664-7b16598a20b7" />

## Changes

- New `ObsRichText`: parses the description and rebuilds an allowlisted tag subset (`code`, `br`, `b`, `i`, `em`, `strong`, `span`, `p`, `a`). No `dangerouslySetInnerHTML`. Anchors carry no `href` and open via `shell.openExternal`, so a link can't navigate the properties window.
- Presented as a framed callout. Severity drives the frame and icon only; body text keeps the normal colour. Text is selectable so launch options can be copied.
- Fixes the severity switch, which compared a boolean against `ETextInfoType` and never matched — every message rendered uncoloured.
- Suppresses two states libobs leaves permanently visible: an empty description, and `Attempting to hook process...`, which never clears once capturing.

## Notes

`Attempting to hook process...` is suppressed client-side as a workaround. Root cause is in `game-capture.c`: `compat_info` is registered twice, so the second call returns `NULL` and the `COMPAT_INFO_VISIBLE` logic no-ops, and `status_message_changed_callback` is never registered. Same on the shipping `31.1.2sl19b3` line and on `32.1.1sl2`. Follow-up in obs-studio.

## Testing

Verified against Streamlabs Desktop with a local D3D11 test app renamed per `compatibility.json` entry:

- Warning (`cs2.exe`), Error (`destiny2.exe`), Normal (`terraria.exe`) — each renders the correct icon and frame tokens
- CS2 with injection blocked: warning shown while the source stays `0x0`, i.e. the real "no launch option" condition
- Link opens externally; `<script>` and non-http hrefs are dropped
- Empty description and the hook placeholder render nothing


Fixed for different messages from obs. 
<img width="600" height="800" alt="compat-info" src="https://github.com/user-attachments/assets/c0e0b1fc-04f0-40f7-b94a-e880a87f8fbd" />
<img width="600" height="800" alt="sev-destiny2" src="https://github.com/user-attachments/assets/4f4cfb65-39fb-4be5-9495-fe8347934589" />
<img width="600" height="800" alt="sev-terraria" src="https://github.com/user-attachments/assets/98ce77e2-1d1f-4ba8-b66a-dddb8489e546" />
Game Capture's compatibility warning for CS2 showed raw markup — `<code>`, `<br>`, `<a href>` — because `compat_info` carries Qt rich text from libobs and we rendered it as a JSX text node.

 