### PR TITLE
Add Game Capture e2e tests driven by game-capture-target

### DIFF
--- a/app/components-react/obs/ObsCompatInfo.m.less
+++ b/app/components-react/obs/ObsCompatInfo.m.less
@@ -1,0 +1,46 @@
+@import '../../styles/index';
+
+// Frame for OBS_TEXT_INFO property messages. Geometry matches the shared Callout component;
+// `@radius` is the 4px input radius, callout surfaces use 8px.
+.frame {
+  display: flex;
+  align-items: flex-start;
+  gap: @spacing;
+  padding: 1.5 * @spacing;
+  border: 1px solid;
+  border-radius: 8px;
+  // launch options and URLs are long and unbreakable
+  overflow-wrap: anywhere;
+}
+
+.icon {
+  line-height: inherit;
+}
+
+// libobs severities. The token names invert: `--info` is amber, `--warning` is red.
+.normal {
+  background: var(--callout-semi);
+  border-color: var(--callout-border);
+
+  .icon {
+    color: var(--callout);
+  }
+}
+
+.warning {
+  background: var(--info-semi);
+  border-color: var(--info-border);
+
+  .icon {
+    color: var(--info);
+  }
+}
+
+.error {
+  background: var(--warning-semi);
+  border-color: var(--warning-border);
+
+  .icon {
+    color: var(--warning);
+  }
+}

--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -28,6 +28,7 @@ import { showFileDialog } from '../shared/inputs/FileInput';
 import cloneDeep from 'lodash/cloneDeep';
 import { Button, Collapse, Input, InputNumber } from 'antd';
 import InputWrapper from '../shared/inputs/InputWrapper';
+import ObsRichText from '../shared/ObsRichText';
 import { $t, $translateIfExist, $translateIfExistWithCheck } from '../../services/i18n';
 import Utils from 'services/utils';
 import cx from 'classnames';
@@ -86,6 +87,37 @@ interface IObsInputProps {
   extraProps?: IExtraInputProps;
 }
 
+// game-capture.c registers `compat_info` twice, so the visibility logic no-ops on a NULL
+// property and this never clears. Untranslated libobs literal. Remove once that is fixed.
+const HOOK_STATUS_PLACEHOLDER = 'Attempting to hook process...';
+
+// `--info` is amber and `--warning` is red, despite the names.
+function infoFieldTokens(infoType?: obs.ETextInfoType) {
+  switch (infoType) {
+    case obs.ETextInfoType.Error:
+      return {
+        accent: 'var(--warning)',
+        border: 'var(--warning-border)',
+        bg: 'var(--warning-semi)',
+        icon: 'icon-error',
+      };
+    case obs.ETextInfoType.Warning:
+      return {
+        accent: 'var(--info)',
+        border: 'var(--info-border)',
+        bg: 'var(--info-semi)',
+        icon: 'icon-information',
+      };
+    default:
+      return {
+        accent: 'var(--callout)',
+        border: 'var(--callout-border)',
+        bg: 'var(--callout-semi)',
+        icon: 'icon-question',
+      };
+  }
+}
+
 /**
  * Renders a single OBS input
  */
@@ -139,23 +171,35 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
       if (textVal.multiline) {
         return <TextAreaInput {...inputProps} debounce={300} data-name={p.value.name} />;
       } else if (textVal.infoField) {
-        const infoField = (textVal.infoField as unknown) as obs.ETextInfoType;
-        switch (textVal.infoField) {
-          case infoField === obs.ETextInfoType.Warning:
-            return (
-              <InputWrapper style={{ color: 'var(--info)' }} data-name={p.value.name}>
-                {textVal.description}
-              </InputWrapper>
-            );
-          case infoField === obs.ETextInfoType.Error:
-            return (
-              <InputWrapper style={{ color: 'var(--warning)' }} data-name={p.value.name}>
-                {textVal.description}
-              </InputWrapper>
-            );
-          default:
-            return <InputWrapper data-name={p.value.name}>{textVal.description}</InputWrapper>;
-        }
+        // libobs can leave this visible with an empty description; an empty frame is worse
+        // than nothing.
+        const infoText = textVal.description?.trim();
+        if (!infoText || infoText === HOOK_STATUS_PLACEHOLDER) return <></>;
+
+        // severity goes on the frame and icon, not the body text
+        const info = infoFieldTokens(textVal.infoType);
+
+        return (
+          <InputWrapper data-name={p.value.name}>
+            {/* `selectable` so launch options and URLs can be copied */}
+            <div
+              className="selectable"
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+                padding: '10px 12px',
+                border: `1px solid ${info.border}`,
+                borderRadius: '8px',
+                background: info.bg,
+                overflowWrap: 'anywhere',
+              }}
+            >
+              <i className={info.icon} style={{ color: info.accent, lineHeight: 'inherit' }} />
+              <ObsRichText text={infoText} />
+            </div>
+          </InputWrapper>
+        );
       } else {
         return (
           <ObsTextInput

--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -29,6 +29,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { Button, Collapse, Input, InputNumber } from 'antd';
 import InputWrapper from '../shared/inputs/InputWrapper';
 import ObsRichText from '../shared/ObsRichText';
+import styles from './ObsCompatInfo.m.less';
 import { $t, $translateIfExist, $translateIfExistWithCheck } from '../../services/i18n';
 import Utils from 'services/utils';
 import cx from 'classnames';
@@ -91,30 +92,14 @@ interface IObsInputProps {
 // property and this never clears. Untranslated libobs literal. Remove once that is fixed.
 const HOOK_STATUS_PLACEHOLDER = 'Attempting to hook process...';
 
-// `--info` is amber and `--warning` is red, despite the names.
-function infoFieldTokens(infoType?: obs.ETextInfoType) {
+function infoFieldSeverity(infoType?: obs.ETextInfoType) {
   switch (infoType) {
     case obs.ETextInfoType.Error:
-      return {
-        accent: 'var(--warning)',
-        border: 'var(--warning-border)',
-        bg: 'var(--warning-semi)',
-        icon: 'icon-error',
-      };
+      return { name: 'error', frame: styles.error, icon: 'icon-error' };
     case obs.ETextInfoType.Warning:
-      return {
-        accent: 'var(--info)',
-        border: 'var(--info-border)',
-        bg: 'var(--info-semi)',
-        icon: 'icon-information',
-      };
+      return { name: 'warning', frame: styles.warning, icon: 'icon-information' };
     default:
-      return {
-        accent: 'var(--callout)',
-        border: 'var(--callout-border)',
-        bg: 'var(--callout-semi)',
-        icon: 'icon-question',
-      };
+      return { name: 'normal', frame: styles.normal, icon: 'icon-question' };
   }
 }
 
@@ -177,25 +162,16 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
         if (!infoText || infoText === HOOK_STATUS_PLACEHOLDER) return <></>;
 
         // severity goes on the frame and icon, not the body text
-        const info = infoFieldTokens(textVal.infoType);
+        const severity = infoFieldSeverity(textVal.infoType);
 
         return (
           <InputWrapper data-name={p.value.name}>
             {/* `selectable` so launch options and URLs can be copied */}
             <div
-              className="selectable"
-              style={{
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: '8px',
-                padding: '10px 12px',
-                border: `1px solid ${info.border}`,
-                borderRadius: '8px',
-                background: info.bg,
-                overflowWrap: 'anywhere',
-              }}
+              className={cx(styles.frame, severity.frame, 'selectable')}
+              data-severity={severity.name}
             >
-              <i className={info.icon} style={{ color: info.accent, lineHeight: 'inherit' }} />
+              <i className={cx(styles.icon, severity.icon)} />
               <ObsRichText text={infoText} />
             </div>
           </InputWrapper>

--- a/app/components-react/shared/ObsRichText.m.less
+++ b/app/components-react/shared/ObsRichText.m.less
@@ -1,0 +1,16 @@
+@import '../../styles/index';
+
+.code {
+  padding: 0 3px;
+  font-family: monospace;
+  // launch flags read as a typo if they wrap mid-token
+  white-space: nowrap;
+  background: var(--section-alt);
+  border-radius: 2px;
+}
+
+// colour comes from the global `a` rule
+.link {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -1,0 +1,80 @@
+import React, { createElement, useMemo } from 'react';
+import * as remote from '@electron/remote';
+
+/**
+ * Renders the Qt rich text libobs puts in OBS_TEXT_INFO descriptions. Tags are rebuilt from an
+ * allowlist rather than injected, and links open externally so they can't navigate the window.
+ */
+export default function ObsRichText(p: { text: string }) {
+  const nodes = useMemo(
+    () => Array.from(new DOMParser().parseFromString(p.text ?? '', 'text/html').body.childNodes),
+    [p.text],
+  );
+
+  return <span>{nodes.map(renderNode)}</span>;
+}
+
+const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
+
+// dropped with their contents; other unknown tags keep their text
+const OPAQUE_TAGS = ['script', 'style'];
+
+const CODE_STYLE: React.CSSProperties = {
+  fontFamily: 'monospace',
+  whiteSpace: 'nowrap', // launch flags; wrapping mid-token reads as a typo
+  background: 'var(--section-alt)',
+  borderRadius: '2px',
+  padding: '0 3px',
+};
+
+// colour comes from the global `a` rule
+const LINK_STYLE: React.CSSProperties = {
+  textDecoration: 'underline',
+  cursor: 'pointer',
+};
+
+function renderChildren(node: Node) {
+  return Array.from(node.childNodes).map(renderNode);
+}
+
+function renderNode(node: Node, key: number): React.ReactNode {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+  if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+  const tag = (node as Element).tagName.toLowerCase();
+
+  if (OPAQUE_TAGS.includes(tag)) return null;
+
+  if (tag === 'br') return <br key={key} />;
+
+  if (tag === 'a') {
+    const href = (node as Element).getAttribute('href') ?? '';
+    if (!/^https?:\/\//i.test(href)) {
+      return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
+    }
+
+    return (
+      <a
+        key={key}
+        style={LINK_STYLE}
+        onClick={e => {
+          e.preventDefault();
+          remote.shell.openExternal(href);
+        }}
+      >
+        {renderChildren(node)}
+      </a>
+    );
+  }
+
+  if (INLINE_TAGS.includes(tag)) {
+    return createElement(
+      tag,
+      { key, style: tag === 'code' ? CODE_STYLE : undefined },
+      renderChildren(node),
+    );
+  }
+
+  // Unknown tag: drop it, keep its text.
+  return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
+}

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -1,5 +1,6 @@
 import React, { createElement, useMemo } from 'react';
 import * as remote from '@electron/remote';
+import styles from './ObsRichText.m.less';
 
 /**
  * Renders the Qt rich text libobs puts in OBS_TEXT_INFO descriptions. Tags are rebuilt from an
@@ -19,20 +20,6 @@ const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
 
 // dropped with their contents; other unknown tags keep their text
 const OPAQUE_TAGS = ['script', 'style'];
-
-const CODE_STYLE: React.CSSProperties = {
-  fontFamily: 'monospace',
-  whiteSpace: 'nowrap', // launch flags; wrapping mid-token reads as a typo
-  background: 'var(--section-alt)',
-  borderRadius: '2px',
-  padding: '0 3px',
-};
-
-// colour comes from the global `a` rule
-const LINK_STYLE: React.CSSProperties = {
-  textDecoration: 'underline',
-  cursor: 'pointer',
-};
 
 function renderChildren(node: Node) {
   return Array.from(node.childNodes).map(renderNode);
@@ -61,7 +48,7 @@ function renderNode(node: Node, key: number): React.ReactNode {
         key={key}
         role="link"
         tabIndex={0}
-        style={LINK_STYLE}
+        className={styles.link}
         onClick={e => {
           e.preventDefault();
           open();
@@ -81,7 +68,7 @@ function renderNode(node: Node, key: number): React.ReactNode {
   if (INLINE_TAGS.includes(tag)) {
     return createElement(
       tag,
-      { key, style: tag === 'code' ? CODE_STYLE : undefined },
+      { key, className: tag === 'code' ? styles.code : undefined },
       renderChildren(node),
     );
   }

--- a/app/components-react/shared/ObsRichText.tsx
+++ b/app/components-react/shared/ObsRichText.tsx
@@ -11,7 +11,8 @@ export default function ObsRichText(p: { text: string }) {
     [p.text],
   );
 
-  return <span>{nodes.map(renderNode)}</span>;
+  // a block wrapper, not a span: it is a flex item and the allowlist permits <p>
+  return <div>{nodes.map(renderNode)}</div>;
 }
 
 const INLINE_TAGS = ['b', 'strong', 'i', 'em', 'code', 'span', 'p'];
@@ -53,13 +54,23 @@ function renderNode(node: Node, key: number): React.ReactNode {
       return <React.Fragment key={key}>{renderChildren(node)}</React.Fragment>;
     }
 
+    // no href, so it needs an explicit role and key handling to stay reachable
+    const open = () => remote.shell.openExternal(href);
     return (
       <a
         key={key}
+        role="link"
+        tabIndex={0}
         style={LINK_STYLE}
         onClick={e => {
           e.preventDefault();
-          remote.shell.openExternal(href);
+          open();
+        }}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            open();
+          }
         }}
       >
         {renderChildren(node)}

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -16,10 +16,10 @@ import * as ChildProcess from 'child_process';
 import fetch from 'node-fetch';
 import extract = require('extract-zip');
 
-const RELEASE_TAG = 'v0.3.0';
+const RELEASE_TAG = 'v0.3.2';
 const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
 const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
-const ZIP_SHA256 = 'de4b23dd02515d3d388bbede7689ecadf2378ca4f22bf9bbdd05c27d354a9448';
+const ZIP_SHA256 = '127720a401894c0f67ac99d3bb28ffd7555c524e7171903a75e76fdd0f670e46';
 
 // __dirname is test-dist/test/helpers at runtime
 const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -5,6 +5,9 @@
  * The binary is fetched from a pinned release and checksum-verified into the gitignored
  * `test-dist/`; set FAKEGAME_PATH to use a local build instead (offline, or when testing a
  * change to the tool itself).
+ *
+ * The target reports itself over NDJSON on stdout (`--events json`): a `ready` object, whether
+ * an armed capture block verified, and whether OBS actually hooked it.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,17 +16,17 @@ import * as ChildProcess from 'child_process';
 import fetch from 'node-fetch';
 import extract = require('extract-zip');
 
-const RELEASE_TAG = 'v0.1.0';
+const RELEASE_TAG = 'v0.2.0';
 const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
 const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
-const ZIP_SHA256 = 'a247b693adf2327d3c86947759fc9be42477ac118af9b5e8ce3d1c7da06461d6';
+const ZIP_SHA256 = 'f37e11c2c9624bf934657cec43ab576e5eafa07eae8d4df31cdf51b1e3246c6e';
 
 // __dirname is test-dist/test/helpers at runtime
 const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');
 const SPAWN_DIR = path.join(CACHE_DIR, '_spawn');
 const EXTRACT_DIR = path.join(CACHE_DIR, RELEASE_TAG);
 
-const WINDOW_READY_TIMEOUT = 30000;
+const READY_TIMEOUT = 30000;
 
 export interface IGameCaptureProfile {
   id: string;
@@ -31,32 +34,53 @@ export interface IGameCaptureProfile {
   exe: string;
   windowClass: string;
   windowTitle: string;
-  severity: number;
+  clientWidth: number;
+  clientHeight: number;
   severityName: 'Normal' | 'Warning' | 'Error';
   captureExpected: boolean;
   defaultBlock: string;
   notes: string;
 }
 
-export interface ILaunchedTarget extends IGameCaptureProfile {
-  pid: number;
-  hwnd: string;
-  /** value for the `window` property of a game/window capture source */
-  obsWindowSetting: string;
-  /**
-   * Client area the target reports for itself, e.g. "1280x720". Game Capture renders a
-   * placeholder at a different size when it is not capturing, so matching this exactly is the
-   * only reliable way to tell real capture from the placeholder.
-   */
-  clientSize: string;
+export interface ITargetEvent {
+  event: string;
+  ts: string;
+  [key: string]: any;
 }
 
-const running: ChildProcess.ChildProcess[] = [];
+export interface ILaunchedTarget {
+  profile: string;
+  pid: number;
+  hwnd: string;
+  exe: string;
+  windowClass: string;
+  windowTitle: string;
+  clientWidth: number;
+  clientHeight: number;
+  blockCapture: string;
+  captureExpected: boolean;
+  /** value for the `window` property of a game/window capture source, computed by the target */
+  obsWindowSetting: string;
+  /** "1280x720" — what the source reports once real frames arrive */
+  clientSize: string;
+  /** every event seen so far */
+  events: ITargetEvent[];
+  /** resolves with the first matching event, or null on timeout */
+  waitForEvent(name: string, timeoutMs?: number): Promise<ITargetEvent>;
+}
+
+interface ITargetState {
+  child: ChildProcess.ChildProcess;
+  events: ITargetEvent[];
+  waiters: { name: string; resolve: (e: ITargetEvent) => void }[];
+}
+
+const running: ITargetState[] = [];
 
 /**
- * `title:class:exe`, with `#` and `:` escaped the way libobs expects.
- * Mirrors encode_dstr/ms_build_window_strings in libobs/util/windows/window-helpers.c —
- * `#` must be escaped before `:` or the decode is ambiguous.
+ * `title:class:exe` with `#` and `:` escaped the way libobs expects (see encode_dstr in
+ * libobs/util/windows/window-helpers.c — `#` must be escaped first). Only needed for synthetic
+ * settings that never launch a target; a launched one reports its own `obsWindowSetting`.
  */
 export function buildWindowSetting(title: string, windowClass: string, exe: string) {
   const encode = (s: string) => s.replace(/#/g, '#22').replace(/:/g, '#3A');
@@ -73,9 +97,7 @@ async function download(url: string, dest: string) {
   fs.writeFileSync(dest, await res.buffer());
 }
 
-/**
- * Resolves fakegame.exe, downloading the pinned release if it is not already cached.
- */
+/** Resolves fakegame.exe, downloading the pinned release if it is not already cached. */
 export async function ensureBinary(): Promise<string> {
   const override = process.env.FAKEGAME_PATH;
   if (override) {
@@ -112,7 +134,6 @@ export async function ensureBinary(): Promise<string> {
     extract(zipPath, { dir: EXTRACT_DIR }, err => (err ? reject(err) : resolve()));
   });
 
-  // the zip has a single versioned folder; hoist the exe if it is nested
   if (!fs.existsSync(exePath)) {
     const nested = findExe(EXTRACT_DIR);
     if (!nested) throw new Error(`fakegame.exe not found after extracting ${ZIP_NAME}`);
@@ -148,84 +169,130 @@ export async function getProfile(id: string): Promise<IGameCaptureProfile> {
 
 /**
  * Copies the binary to the profile's executable name (the rename is what makes exe-matched
- * compatibility entries apply), launches it, and waits for its window to exist.
+ * compatibility entries apply), launches it and waits for its `ready` event.
  */
 export async function launchProfile(
   id: string,
-  opts: { api?: string; blockCapture?: string; extraArgs?: string[] } = {},
+  opts: { api?: string; blockCapture?: string; instance?: string; extraArgs?: string[] } = {},
 ): Promise<ILaunchedTarget> {
   const source = await ensureBinary();
   const profile = await getProfile(id);
 
-  const dir = path.join(SPAWN_DIR, id);
+  const dir = path.join(SPAWN_DIR, opts.instance ? `${id}-${opts.instance}` : id);
   fs.mkdirSync(dir, { recursive: true });
   const target = path.join(dir, profile.exe);
   fs.copyFileSync(source, target);
 
-  const args = ['--profile', id];
+  const args = ['--events', 'json', '--profile', id];
   if (opts.api) args.push('--api', opts.api);
   if (opts.blockCapture) args.push('--block-capture', opts.blockCapture);
+  if (opts.instance) args.push('--instance', opts.instance);
   if (opts.extraArgs) args.push(...opts.extraArgs);
 
   const child = ChildProcess.spawn(target, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-  running.push(child);
+  const state: ITargetState = { child, events: [], waiters: [] };
+  running.push(state);
 
-  const { hwnd, clientSize } = await waitForWindow(child, id);
+  const ready = await waitForReady(state, id, args);
 
   return {
-    ...profile,
-    pid: child.pid,
-    hwnd,
-    clientSize,
-    obsWindowSetting: buildWindowSetting(profile.windowTitle, profile.windowClass, profile.exe),
+    profile: ready.profile,
+    pid: ready.pid,
+    hwnd: ready.hwnd,
+    exe: ready.exe,
+    windowClass: ready.windowClass,
+    windowTitle: ready.windowTitle,
+    clientWidth: ready.clientWidth,
+    clientHeight: ready.clientHeight,
+    blockCapture: ready.blockCapture,
+    captureExpected: ready.captureExpected,
+    obsWindowSetting: ready.obsWindowSetting,
+    clientSize: `${ready.clientWidth}x${ready.clientHeight}`,
+    events: state.events,
+    waitForEvent: (name: string, timeoutMs = 20000) => waitForEvent(state, name, timeoutMs),
   };
 }
 
-function waitForWindow(child: ChildProcess.ChildProcess, id: string) {
-  return new Promise<{ hwnd: string; clientSize: string }>((resolve, reject) => {
-    let stdout = '';
+function waitForEvent(state: ITargetState, name: string, timeoutMs: number) {
+  const seen = state.events.find(e => e.event === name);
+  if (seen) return Promise.resolve(seen);
+
+  return new Promise<ITargetEvent>(resolve => {
+    const waiter = { name, resolve };
+    state.waiters.push(waiter);
+    setTimeout(() => {
+      state.waiters = state.waiters.filter(w => w !== waiter);
+      resolve(null);
+    }, timeoutMs);
+  });
+}
+
+function waitForReady(state: ITargetState, id: string, args: string[]) {
+  return new Promise<ITargetEvent>((resolve, reject) => {
+    let pending = '';
     let stderr = '';
     let settled = false;
 
-    const finish = (fn: Function, arg: any) => {
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(
+        new Error(`game capture target "${id}" was not ready in ${READY_TIMEOUT}ms
+args: ${args.join(' ')}
+stderr: ${stderr}`),
+      );
+    }, READY_TIMEOUT);
+
+    state.child.stdout.on('data', (d: Buffer) => {
+      // NDJSON: consume whole lines, keep any partial tail for the next chunk
+      const lines = (pending + d.toString()).split('\n');
+      pending = lines.pop();
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let parsed: ITargetEvent;
+        try {
+          parsed = JSON.parse(line);
+        } catch (e: unknown) {
+          continue; // not an event line
+        }
+
+        state.events.push(parsed);
+        state.waiters
+          .filter(w => w.name === parsed.event)
+          .forEach(w => {
+            state.waiters = state.waiters.filter(x => x !== w);
+            w.resolve(parsed);
+          });
+
+        if (parsed.event === 'ready' && !settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(parsed);
+        }
+      }
+    });
+
+    state.child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    state.child.on('exit', code => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      fn(arg);
-    };
-
-    const timer = setTimeout(() => {
-      finish(
-        reject,
-        new Error(`game capture target "${id}" did not open a window in ${WINDOW_READY_TIMEOUT}ms.
-stdout: ${stdout}
+      // exit codes: 2 args / 3 window / 4 renderer / 5 block could not be verified
+      reject(
+        new Error(`game capture target "${id}" exited early with code ${code}
+args: ${args.join(' ')}
 stderr: ${stderr}`),
       );
-    }, WINDOW_READY_TIMEOUT);
-
-    child.stdout.on('data', (d: Buffer) => {
-      stdout += d.toString();
-      const m = stdout.match(/app: hwnd=([0-9A-Fa-f]+)/);
-      // logged as e.g. "mode -> windowed client=1280x720", before the hwnd line
-      const size = stdout.match(/client=(\d+x\d+)/);
-      if (m) finish(resolve, { hwnd: m[1], clientSize: size ? size[1] : '' });
     });
-    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
-    child.on('exit', code =>
-      finish(
-        reject,
-        new Error(`game capture target "${id}" exited early (code ${code}).
-stdout: ${stdout}
-stderr: ${stderr}`),
-      ),
-    );
   });
 }
 
 /** Terminates every target launched by this process. Safe to call more than once. */
 export function stopAll() {
   while (running.length) {
-    const child = running.pop();
+    const state = running.pop();
+    const child = state && state.child;
     if (!child || child.killed || child.exitCode !== null) continue;
     try {
       // /T so any child processes go too; child.kill() alone is unreliable on Windows

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -16,10 +16,10 @@ import * as ChildProcess from 'child_process';
 import fetch from 'node-fetch';
 import extract = require('extract-zip');
 
-const RELEASE_TAG = 'v0.3.2';
+const RELEASE_TAG = 'v0.4.1';
 const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
 const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
-const ZIP_SHA256 = '127720a401894c0f67ac99d3bb28ffd7555c524e7171903a75e76fdd0f670e46';
+const ZIP_SHA256 = 'edc00d57cc6b1357b87c63f8a50eb00a8fd839f33aea707a634a72078ab86e66';
 
 // __dirname is test-dist/test/helpers at runtime
 const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');
@@ -65,8 +65,12 @@ export interface ILaunchedTarget {
   clientSize: string;
   /** every event seen so far */
   events: ITargetEvent[];
-  /** resolves with the first matching event, or null on timeout */
-  waitForEvent(name: string, timeoutMs?: number): Promise<ITargetEvent>;
+  /**
+   * Resolves with the first matching event, or null on timeout. `fromIndex` skips events already
+   * buffered, which is what makes a sequence like hooked -> recreated -> hooked assertable
+   * without matching an earlier occurrence.
+   */
+  waitForEvent(name: string, timeoutMs?: number, fromIndex?: number): Promise<ITargetEvent>;
 }
 
 interface ITargetState {
@@ -209,12 +213,13 @@ export async function launchProfile(
     obsWindowSetting: ready.obsWindowSetting,
     clientSize: `${ready.clientWidth}x${ready.clientHeight}`,
     events: state.events,
-    waitForEvent: (name: string, timeoutMs = 20000) => waitForEvent(state, name, timeoutMs),
+    waitForEvent: (name: string, timeoutMs = 20000, fromIndex = 0) =>
+      waitForEvent(state, name, timeoutMs, fromIndex),
   };
 }
 
-function waitForEvent(state: ITargetState, name: string, timeoutMs: number) {
-  const seen = state.events.find(e => e.event === name);
+function waitForEvent(state: ITargetState, name: string, timeoutMs: number, fromIndex = 0) {
+  const seen = state.events.find((e, i) => i >= fromIndex && e.event === name);
   if (seen) return Promise.resolve(seen);
 
   return new Promise<ITargetEvent>(resolve => {

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -16,10 +16,10 @@ import * as ChildProcess from 'child_process';
 import fetch from 'node-fetch';
 import extract = require('extract-zip');
 
-const RELEASE_TAG = 'v0.4.1';
+const RELEASE_TAG = 'v0.4.2';
 const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
 const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
-const ZIP_SHA256 = 'edc00d57cc6b1357b87c63f8a50eb00a8fd839f33aea707a634a72078ab86e66';
+const ZIP_SHA256 = '34a65310bf546983cd9f7b3fd4f366cc7fe0ba73541e47ac82d734606ebe07a2';
 
 // __dirname is test-dist/test/helpers at runtime
 const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -1,0 +1,239 @@
+/**
+ * Acquires and drives `fakegame.exe` from summeroff/game-capture-target — a renameable Win32
+ * capture target used to exercise Game Capture without owning the games it impersonates.
+ *
+ * The binary is fetched from a pinned release and checksum-verified into the gitignored
+ * `test-dist/`; set FAKEGAME_PATH to use a local build instead (offline, or when testing a
+ * change to the tool itself).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as ChildProcess from 'child_process';
+import fetch from 'node-fetch';
+import extract = require('extract-zip');
+
+const RELEASE_TAG = 'v0.1.0';
+const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
+const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
+const ZIP_SHA256 = 'a247b693adf2327d3c86947759fc9be42477ac118af9b5e8ce3d1c7da06461d6';
+
+// __dirname is test-dist/test/helpers at runtime
+const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');
+const SPAWN_DIR = path.join(CACHE_DIR, '_spawn');
+const EXTRACT_DIR = path.join(CACHE_DIR, RELEASE_TAG);
+
+const WINDOW_READY_TIMEOUT = 30000;
+
+export interface IGameCaptureProfile {
+  id: string;
+  displayName: string;
+  exe: string;
+  windowClass: string;
+  windowTitle: string;
+  severity: number;
+  severityName: 'Normal' | 'Warning' | 'Error';
+  captureExpected: boolean;
+  defaultBlock: string;
+  notes: string;
+}
+
+export interface ILaunchedTarget extends IGameCaptureProfile {
+  pid: number;
+  hwnd: string;
+  /** value for the `window` property of a game/window capture source */
+  obsWindowSetting: string;
+  /**
+   * Client area the target reports for itself, e.g. "1280x720". Game Capture renders a
+   * placeholder at a different size when it is not capturing, so matching this exactly is the
+   * only reliable way to tell real capture from the placeholder.
+   */
+  clientSize: string;
+}
+
+const running: ChildProcess.ChildProcess[] = [];
+
+/**
+ * `title:class:exe`, with `#` and `:` escaped the way libobs expects.
+ * Mirrors encode_dstr/ms_build_window_strings in libobs/util/windows/window-helpers.c —
+ * `#` must be escaped before `:` or the decode is ambiguous.
+ */
+export function buildWindowSetting(title: string, windowClass: string, exe: string) {
+  const encode = (s: string) => s.replace(/#/g, '#22').replace(/:/g, '#3A');
+  return `${encode(title)}:${encode(windowClass)}:${encode(exe)}`;
+}
+
+function sha256(file: string) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+async function download(url: string, dest: string) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status} ${res.statusText}`);
+  fs.writeFileSync(dest, await res.buffer());
+}
+
+/**
+ * Resolves fakegame.exe, downloading the pinned release if it is not already cached.
+ */
+export async function ensureBinary(): Promise<string> {
+  const override = process.env.FAKEGAME_PATH;
+  if (override) {
+    if (!fs.existsSync(override)) {
+      throw new Error(`FAKEGAME_PATH is set but does not exist: ${override}`);
+    }
+    return override;
+  }
+
+  const exePath = path.join(EXTRACT_DIR, 'fakegame.exe');
+  if (fs.existsSync(exePath)) return exePath;
+
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const zipPath = path.join(CACHE_DIR, ZIP_NAME);
+
+  if (!fs.existsSync(zipPath) || sha256(zipPath) !== ZIP_SHA256) {
+    try {
+      await download(ZIP_URL, zipPath);
+    } catch (e: unknown) {
+      throw new Error(
+        `Could not download the game capture target from ${ZIP_URL}: ${e}\n` +
+          'Set FAKEGAME_PATH to a local fakegame.exe to run offline.',
+      );
+    }
+  }
+
+  const actual = sha256(zipPath);
+  if (actual !== ZIP_SHA256) {
+    fs.unlinkSync(zipPath);
+    throw new Error(`Checksum mismatch for ${ZIP_NAME}: expected ${ZIP_SHA256}, got ${actual}`);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    extract(zipPath, { dir: EXTRACT_DIR }, err => (err ? reject(err) : resolve()));
+  });
+
+  // the zip has a single versioned folder; hoist the exe if it is nested
+  if (!fs.existsSync(exePath)) {
+    const nested = findExe(EXTRACT_DIR);
+    if (!nested) throw new Error(`fakegame.exe not found after extracting ${ZIP_NAME}`);
+    fs.copyFileSync(nested, exePath);
+  }
+  return exePath;
+}
+
+function findExe(dir: string): string {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const hit = findExe(full);
+      if (hit) return hit;
+    } else if (entry.name.toLowerCase() === 'fakegame.exe') {
+      return full;
+    }
+  }
+  return '';
+}
+
+export async function listProfiles(): Promise<IGameCaptureProfile[]> {
+  const exe = await ensureBinary();
+  const out = ChildProcess.execFileSync(exe, ['--list-profiles', '--json'], { encoding: 'utf8' });
+  return JSON.parse(out);
+}
+
+export async function getProfile(id: string): Promise<IGameCaptureProfile> {
+  const profile = (await listProfiles()).find(p => p.id === id);
+  if (!profile) throw new Error(`unknown game capture profile: ${id}`);
+  return profile;
+}
+
+/**
+ * Copies the binary to the profile's executable name (the rename is what makes exe-matched
+ * compatibility entries apply), launches it, and waits for its window to exist.
+ */
+export async function launchProfile(
+  id: string,
+  opts: { api?: string; blockCapture?: string; extraArgs?: string[] } = {},
+): Promise<ILaunchedTarget> {
+  const source = await ensureBinary();
+  const profile = await getProfile(id);
+
+  const dir = path.join(SPAWN_DIR, id);
+  fs.mkdirSync(dir, { recursive: true });
+  const target = path.join(dir, profile.exe);
+  fs.copyFileSync(source, target);
+
+  const args = ['--profile', id];
+  if (opts.api) args.push('--api', opts.api);
+  if (opts.blockCapture) args.push('--block-capture', opts.blockCapture);
+  if (opts.extraArgs) args.push(...opts.extraArgs);
+
+  const child = ChildProcess.spawn(target, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  running.push(child);
+
+  const { hwnd, clientSize } = await waitForWindow(child, id);
+
+  return {
+    ...profile,
+    pid: child.pid,
+    hwnd,
+    clientSize,
+    obsWindowSetting: buildWindowSetting(profile.windowTitle, profile.windowClass, profile.exe),
+  };
+}
+
+function waitForWindow(child: ChildProcess.ChildProcess, id: string) {
+  return new Promise<{ hwnd: string; clientSize: string }>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const finish = (fn: Function, arg: any) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(arg);
+    };
+
+    const timer = setTimeout(() => {
+      finish(
+        reject,
+        new Error(`game capture target "${id}" did not open a window in ${WINDOW_READY_TIMEOUT}ms.
+stdout: ${stdout}
+stderr: ${stderr}`),
+      );
+    }, WINDOW_READY_TIMEOUT);
+
+    child.stdout.on('data', (d: Buffer) => {
+      stdout += d.toString();
+      const m = stdout.match(/app: hwnd=([0-9A-Fa-f]+)/);
+      // logged as e.g. "mode -> windowed client=1280x720", before the hwnd line
+      const size = stdout.match(/client=(\d+x\d+)/);
+      if (m) finish(resolve, { hwnd: m[1], clientSize: size ? size[1] : '' });
+    });
+    child.stderr.on('data', (d: Buffer) => (stderr += d.toString()));
+    child.on('exit', code =>
+      finish(
+        reject,
+        new Error(`game capture target "${id}" exited early (code ${code}).
+stdout: ${stdout}
+stderr: ${stderr}`),
+      ),
+    );
+  });
+}
+
+/** Terminates every target launched by this process. Safe to call more than once. */
+export function stopAll() {
+  while (running.length) {
+    const child = running.pop();
+    if (!child || child.killed || child.exitCode !== null) continue;
+    try {
+      // /T so any child processes go too; child.kill() alone is unreliable on Windows
+      ChildProcess.execFileSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+    } catch (e: unknown) {
+      // already gone
+    }
+  }
+}

--- a/test/helpers/game-capture-target.ts
+++ b/test/helpers/game-capture-target.ts
@@ -16,10 +16,10 @@ import * as ChildProcess from 'child_process';
 import fetch from 'node-fetch';
 import extract = require('extract-zip');
 
-const RELEASE_TAG = 'v0.2.0';
+const RELEASE_TAG = 'v0.3.0';
 const ZIP_NAME = `fakegame-${RELEASE_TAG}-win-x64.zip`;
 const ZIP_URL = `https://github.com/summeroff/game-capture-target/releases/download/${RELEASE_TAG}/${ZIP_NAME}`;
-const ZIP_SHA256 = 'f37e11c2c9624bf934657cec43ab576e5eafa07eae8d4df31cdf51b1e3246c6e';
+const ZIP_SHA256 = 'de4b23dd02515d3d388bbede7689ecadf2378ca4f22bf9bbdd05c27d354a9448';
 
 // __dirname is test-dist/test/helpers at runtime
 const CACHE_DIR = path.resolve(__dirname, '..', '..', 'game-capture-target');
@@ -258,6 +258,13 @@ stderr: ${stderr}`),
         }
 
         state.events.push(parsed);
+
+        // e.g. exe_mismatch when the binary was not renamed, which silently stops the
+        // compatibility entry from matching. Surface it rather than leaving it buffered.
+        if (parsed.event === 'warning') {
+          console.log(`[game-capture-target:${id}] ${parsed.code}: ${parsed.detail}`);
+        }
+
         state.waiters
           .filter(w => w.name === parsed.event)
           .forEach(w => {

--- a/test/regular/game-capture.ts
+++ b/test/regular/game-capture.ts
@@ -280,6 +280,48 @@ captureTest('Game Capture lists and captures a live window', async t => {
   }
 });
 
+captureTest('Game Capture survives the target recreating its D3D device', async t => {
+  stopAll();
+  // scheduled relative to the hook: an absolute delay races OBS, which needs several seconds to
+  // inject, so the recreate would otherwise fire before there is anything to disturb
+  const target = await launchProfile('cs2', {
+    extraArgs: ['--recreate-device-after', 'hooked+3'],
+  });
+  const name = 'GC churn recovery';
+
+  await addSource('Game Capture', name);
+  try {
+    await updateSettings(name, { capture_mode: 'window', window: target.obsWindowSetting });
+
+    const hooked = await target.waitForEvent('hooked', 40000);
+    t.truthy(hooked, 'target was never hooked, so there was nothing to disturb');
+
+    const recreated = await target.waitForEvent(
+      'device_recreated',
+      30000,
+      target.events.indexOf(hooked) + 1,
+    );
+    t.truthy(recreated, 'the scheduled device recreate never fired');
+
+    // Frames must still be arriving afterwards. The placeholder has a different size, so
+    // matching the target's client area is the signal that they are real.
+    // Note: no `unhooked` fires here — the hook DLL stays loaded across in-process churn and
+    // re-acquires the new device, so don't expect an unhook/rehook cycle to assert on.
+    let dimensions = '0x0';
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const { width, height } = await readDimensions(name);
+      dimensions = `${width}x${height}`;
+      if (dimensions === target.clientSize) break;
+      await sleep(1000);
+    }
+    t.is(dimensions, target.clientSize, 'capture stopped after the device was recreated');
+  } finally {
+    await removeGameCapture(name);
+    stopAll();
+  }
+});
+
 captureTest('Game Capture warns and refuses capture when injection is blocked', async t => {
   // reproduces CS2 launched without -allow_third_party_software: the hook cannot load
   stopAll();

--- a/test/regular/game-capture.ts
+++ b/test/regular/game-capture.ts
@@ -222,23 +222,25 @@ captureTest('Game Capture lists and captures a live window', async t => {
     const listed = (windowProp.options || []).some((o: any) => o.value === target.obsWindowSetting);
     t.true(listed, 'the target window should appear in the window property options');
 
-    // poll with properties closed. Game Capture shows a placeholder at its own size when it is
-    // not capturing, so only an exact match with the target's client area proves real capture.
-    t.truthy(target.clientSize, 'target did not report its client size');
+    // the target reports the hook from inside its own process, which is unambiguous; Game
+    // Capture shows a placeholder at its own size when it is not capturing, so the source's
+    // dimensions alone cannot tell the two apart
+    const hooked = await target.waitForEvent('hooked', 30000);
+    t.truthy(
+      hooked,
+      'target never reported being hooked — the agent may lack a GPU or an interactive session',
+    );
+
+    // and the frames that arrive are actually its own
     let dimensions = '0x0';
-    const deadline = Date.now() + 30000;
+    const deadline = Date.now() + 15000;
     while (Date.now() < deadline) {
       const { width, height } = await readDimensions(name);
       dimensions = `${width}x${height}`;
       if (dimensions === target.clientSize) break;
       await sleep(1000);
     }
-    t.is(
-      dimensions,
-      target.clientSize,
-      `source never matched the target's ${target.clientSize} after 30s (saw ${dimensions}) — ` +
-        'the agent may lack a GPU or an interactive desktop session, or this is the placeholder',
-    );
+    t.is(dimensions, target.clientSize, `source never matched the target's ${target.clientSize}`);
   } finally {
     await removeGameCapture(name);
     stopAll();
@@ -246,31 +248,29 @@ captureTest('Game Capture lists and captures a live window', async t => {
 });
 
 captureTest('Game Capture warns and refuses capture when injection is blocked', async t => {
-  // reproduces CS2 launched without -allow_third_party_software: the hook cannot load.
-  // signature-policy is requested explicitly — the profile's default (squat-ipc) did not
-  // actually prevent capture when measured.
+  // reproduces CS2 launched without -allow_third_party_software: the hook cannot load
   stopAll();
-  const target = await launchProfile('cs2-blocked', { blockCapture: 'signature-policy' });
+  const target = await launchProfile('cs2-blocked');
   const name = 'GC blocked capture';
+
+  // the target self-verifies that the block is actually armed, so a block that silently stops
+  // working fails here instead of quietly turning this into a no-op test
+  const block = target.events.find(e => e.event === 'block_active');
+  t.truthy(block, 'target did not report an armed capture block');
+  t.true(block.verified, `block ${block.mode} could not be verified: ${block.detail}`);
 
   await addSource('Game Capture', name);
   try {
     await updateSettings(name, { capture_mode: 'window', window: target.obsWindowSetting });
 
-    // never matching the target's own size means the hook never delivered a frame; the source
-    // shows the placeholder instead
-    let dimensions = '0x0';
-    const deadline = Date.now() + 20000;
-    while (Date.now() < deadline) {
-      const { width, height } = await readDimensions(name);
-      dimensions = `${width}x${height}`;
-      if (dimensions === target.clientSize) break;
-      await sleep(1000);
-    }
+    const hooked = await target.waitForEvent('hooked', 20000);
+    t.falsy(hooked, 'a blocked target must never be hooked');
+
+    const { width, height } = await readDimensions(name);
     t.not(
-      dimensions,
+      `${width}x${height}`,
       target.clientSize,
-      `a blocked target must never produce frames, but the source matched ${target.clientSize}`,
+      'a blocked target must never produce frames',
     );
 
     const info = await readCompatInfoFor(name);

--- a/test/regular/game-capture.ts
+++ b/test/regular/game-capture.ts
@@ -41,6 +41,10 @@ const captureTest = skipCapture ? test.skip : test;
 const CS2 = buildWindowSetting('Counter-Strike 2', 'FakeGameWindowClass', 'cs2.exe');
 const DESTINY2 = buildWindowSetting('Destiny 2', 'FakeGameWindowClass', 'destiny2.exe');
 const TERRARIA = buildWindowSetting('Terraria', 'FakeGameWindowClass', 'terraria.exe');
+// matched on exe + a *prefix* of the title, so the version suffix must not prevent a match
+const MINECRAFT = buildWindowSetting('Minecraft 1.21', 'GLFW30', 'javaw.exe');
+// matched on window class alone; the executable deliberately matches nothing
+const CHROMIUM = buildWindowSetting('Some Chromium App', 'Chrome_WidgetWin_1', 'notagame.exe');
 
 const COMPAT_SELECTOR = '[data-name="compat_info"]';
 
@@ -190,6 +194,26 @@ test('Game Capture compat message uses Normal styling', async t => {
   t.is(info.iconClass, 'icon-question');
   t.is(info.severity, 'normal');
   t.not(info.borderColor, 'rgba(0, 0, 0, 0)', 'severity styling did not apply');
+});
+
+test('Game Capture compat matches on a title prefix', async t => {
+  const info = await probeCompat('GC title prefix', { capture_mode: 'window', window: MINECRAFT });
+
+  t.true(info.rendered, 'a title-prefix entry should still match with a version suffix');
+  t.true(info.text.includes('Minecraft'), info.text);
+  t.is(info.severity, 'normal');
+  t.false(info.rawMarkupVisible, info.text);
+});
+
+test('Game Capture compat matches on window class alone', async t => {
+  const info = await probeCompat('GC class match', { capture_mode: 'window', window: CHROMIUM });
+
+  t.true(info.rendered, 'a class-only entry should match even when the exe does not');
+  t.true(info.text.includes('Chromium'), info.text);
+  t.is(info.severity, 'error');
+  // this entry carries no URL, so the renderer must cope with a message that has no link
+  t.is(info.anchorCount, 0, 'entry has no URL, so no link should be rendered');
+  t.false(info.rawMarkupVisible, info.text);
 });
 
 test('Game Capture hides the transient hook status', async t => {

--- a/test/regular/game-capture.ts
+++ b/test/regular/game-capture.ts
@@ -49,7 +49,8 @@ test.after.always(() => stopAll());
 interface ICompatInfo {
   rendered: boolean;
   text: string;
-  frameStyle: string;
+  severity: string;
+  borderColor: string;
   iconClass: string;
   codeCount: number;
   anchorCount: number;
@@ -63,14 +64,19 @@ interface ICompatInfo {
 function readCompatInfo() {
   const box = document.querySelector('[data-name="compat_info"]') as HTMLElement;
   if (!box) return { rendered: false } as any;
-  const frame = box.querySelector('div[style*="border"]') as HTMLElement;
+  const frame = box.querySelector('[data-severity]') as HTMLElement;
   const icon = box.querySelector('i') as HTMLElement;
   const anchors = Array.prototype.slice.call(box.querySelectorAll('a')) as HTMLAnchorElement[];
   return {
     rendered: true,
     text: box.innerText,
-    frameStyle: frame ? frame.getAttribute('style') : null,
-    iconClass: icon ? icon.className : null,
+    severity: frame ? frame.getAttribute('data-severity') : null,
+    // a transparent border would mean the severity class never applied
+    borderColor: frame ? getComputedStyle(frame).borderTopColor : null,
+    // the icon also carries a hashed CSS-module class; only the icon-font one is semantic
+    iconClass: icon
+      ? Array.prototype.slice.call(icon.classList).find((c: string) => c.indexOf('icon-') === 0)
+      : null,
     codeCount: box.querySelectorAll('code').length,
     anchorCount: anchors.length,
     anchorHref: anchors.length ? anchors[0].getAttribute('href') : null,
@@ -164,7 +170,8 @@ test('Game Capture compat warning renders as rich text with an accessible link',
   t.is(info.anchorTabIndex, 0, 'link must be focusable');
 
   t.is(info.iconClass, 'icon-information', 'Warning severity uses the information icon');
-  t.true(info.frameStyle.includes('var(--info-border)'), info.frameStyle);
+  t.is(info.severity, 'warning');
+  t.not(info.borderColor, 'rgba(0, 0, 0, 0)', 'severity styling did not apply');
 });
 
 test('Game Capture compat message uses Error styling', async t => {
@@ -172,7 +179,8 @@ test('Game Capture compat message uses Error styling', async t => {
 
   t.true(info.rendered);
   t.is(info.iconClass, 'icon-error');
-  t.true(info.frameStyle.includes('var(--warning-border)'), info.frameStyle);
+  t.is(info.severity, 'error');
+  t.not(info.borderColor, 'rgba(0, 0, 0, 0)', 'severity styling did not apply');
 });
 
 test('Game Capture compat message uses Normal styling', async t => {
@@ -180,7 +188,8 @@ test('Game Capture compat message uses Normal styling', async t => {
 
   t.true(info.rendered);
   t.is(info.iconClass, 'icon-question');
-  t.true(info.frameStyle.includes('var(--callout-border)'), info.frameStyle);
+  t.is(info.severity, 'normal');
+  t.not(info.borderColor, 'rgba(0, 0, 0, 0)', 'severity styling did not apply');
 });
 
 test('Game Capture hides the transient hook status', async t => {

--- a/test/regular/game-capture.ts
+++ b/test/regular/game-capture.ts
@@ -1,0 +1,283 @@
+/**
+ * Game Capture compatibility UI and capture behaviour.
+ *
+ * The compatibility message is derived from the `window` setting string alone, so most of these
+ * are hermetic — no process, no GPU. The last two need a real capture target and use
+ * summeroff/game-capture-target, which is downloaded on demand (see helpers/game-capture-target).
+ *
+ * Each test keeps the properties window open for as short a time as possible: holding it open
+ * against a compat-matching window setting can wedge the app (see the tracking issue for the
+ * refresh storm). Frame polling therefore happens with properties closed.
+ *
+ * Set SLOBS_TEST_SKIP_GAME_CAPTURE=1 to skip the two capture tests on an agent with no GPU or
+ * interactive desktop session.
+ */
+import { useWebdriver, test } from '../helpers/webdriver';
+import {
+  addSource,
+  clickRemoveSource,
+  clickSourceProperties,
+  selectSource,
+} from '../helpers/modules/sources';
+import {
+  closeWindow,
+  focusChild,
+  focusMain,
+  getClient,
+  waitForDisplayed,
+} from '../helpers/modules/core';
+import { getApiClient } from '../helpers/api-client';
+import { SourcesService } from '../../app/services/api/external-api/sources';
+import { sleep } from '../helpers/sleep';
+import { buildWindowSetting, launchProfile, stopAll } from '../helpers/game-capture-target';
+
+useWebdriver({ restartAppAfterEachTest: false });
+
+const skipCapture = process.env.SLOBS_TEST_SKIP_GAME_CAPTURE === '1';
+const captureTest = skipCapture ? test.skip : test;
+
+// Real compatibility.json entries. These need no running process — window_changed_callback
+// matches on the setting string, not on a live window.
+const CS2 = buildWindowSetting('Counter-Strike 2', 'FakeGameWindowClass', 'cs2.exe');
+const DESTINY2 = buildWindowSetting('Destiny 2', 'FakeGameWindowClass', 'destiny2.exe');
+const TERRARIA = buildWindowSetting('Terraria', 'FakeGameWindowClass', 'terraria.exe');
+
+const COMPAT_SELECTOR = '[data-name="compat_info"]';
+
+test.after.always(() => stopAll());
+
+interface ICompatInfo {
+  rendered: boolean;
+  text: string;
+  frameStyle: string;
+  iconClass: string;
+  codeCount: number;
+  anchorCount: number;
+  anchorHref: string;
+  anchorRole: string;
+  anchorTabIndex: number;
+  rawMarkupVisible: boolean;
+}
+
+/** Reads the compat-info callout. Runs in the renderer, so it must not close over anything. */
+function readCompatInfo() {
+  const box = document.querySelector('[data-name="compat_info"]') as HTMLElement;
+  if (!box) return { rendered: false } as any;
+  const frame = box.querySelector('div[style*="border"]') as HTMLElement;
+  const icon = box.querySelector('i') as HTMLElement;
+  const anchors = Array.prototype.slice.call(box.querySelectorAll('a')) as HTMLAnchorElement[];
+  return {
+    rendered: true,
+    text: box.innerText,
+    frameStyle: frame ? frame.getAttribute('style') : null,
+    iconClass: icon ? icon.className : null,
+    codeCount: box.querySelectorAll('code').length,
+    anchorCount: anchors.length,
+    anchorHref: anchors.length ? anchors[0].getAttribute('href') : null,
+    anchorRole: anchors.length ? anchors[0].getAttribute('role') : null,
+    anchorTabIndex: anchors.length ? anchors[0].tabIndex : null,
+    // the regression this suite exists for: markup must never be visible as text
+    rawMarkupVisible: /<code>|<\/code>|<br>|<a href/.test(box.innerText),
+  };
+}
+
+/**
+ * Applies settings to a source through the external API.
+ * Never return an API proxy out of an async function — awaiting it invokes `then` on the proxy
+ * and the IPC layer answers METHOD_NOT_FOUND.
+ */
+async function updateSettings(name: string, settings: Dictionary<any>) {
+  const api = await getApiClient();
+  const sourcesService = api.getResource<SourcesService>('SourcesService');
+  sourcesService.getSourcesByName(name)[0].updateSettings(settings);
+}
+
+async function readDimensions(name: string) {
+  const api = await getApiClient();
+  const sourcesService = api.getResource<SourcesService>('SourcesService');
+  const source = sourcesService.getSourcesByName(name)[0];
+  return { width: source.width, height: source.height };
+}
+
+async function removeGameCapture(name: string) {
+  try {
+    await focusMain();
+    await clickRemoveSource(name);
+  } catch (e: unknown) {
+    console.log(`cleanup of "${name}" failed:`, e);
+  }
+}
+
+/**
+ * Opens the properties window, reads the callout, and closes it again immediately.
+ * `expectMessage` lets us wait on the element instead of sleeping when one is expected.
+ */
+async function readCompatInfoFor(name: string, expectMessage = true): Promise<ICompatInfo> {
+  await focusMain();
+  await selectSource(name);
+  await clickSourceProperties(name);
+  try {
+    await focusChild();
+    await waitForDisplayed('label=Mode');
+    if (expectMessage) {
+      await waitForDisplayed(COMPAT_SELECTOR, { timeout: 10000 });
+    } else {
+      await sleep(1500);
+    }
+    return (await getClient().execute(readCompatInfo)) as ICompatInfo;
+  } finally {
+    await closeWindow('child');
+    await focusMain();
+  }
+}
+
+/** Adds a Game Capture source, reads its callout once, and removes the source again. */
+async function probeCompat(
+  name: string,
+  settings: Dictionary<any>,
+  expectMessage = true,
+): Promise<ICompatInfo> {
+  await addSource('Game Capture', name);
+  try {
+    if (settings) {
+      await updateSettings(name, settings);
+      await sleep(1000);
+    }
+    return await readCompatInfoFor(name, expectMessage);
+  } finally {
+    await removeGameCapture(name);
+  }
+}
+
+test('Game Capture compat warning renders as rich text with an accessible link', async t => {
+  const info = await probeCompat('GC rich text', { capture_mode: 'window', window: CS2 });
+
+  t.true(info.rendered, 'compatibility message should be shown');
+  t.false(info.rawMarkupVisible, `raw markup visible as text: ${info.text}`);
+  t.is(info.codeCount, 1, 'launch option should render as a <code> element');
+  t.true(info.text.includes('-allow_third_party_software'), 'launch option should be present');
+
+  t.is(info.anchorCount, 1, 'help URL should render as a link');
+  // an href would let ctrl/middle-click navigate the properties window away
+  t.is(info.anchorHref, null, 'link must not carry an href');
+  t.is(info.anchorRole, 'link', 'link needs an explicit role without an href');
+  t.is(info.anchorTabIndex, 0, 'link must be focusable');
+
+  t.is(info.iconClass, 'icon-information', 'Warning severity uses the information icon');
+  t.true(info.frameStyle.includes('var(--info-border)'), info.frameStyle);
+});
+
+test('Game Capture compat message uses Error styling', async t => {
+  const info = await probeCompat('GC error sev', { capture_mode: 'window', window: DESTINY2 });
+
+  t.true(info.rendered);
+  t.is(info.iconClass, 'icon-error');
+  t.true(info.frameStyle.includes('var(--warning-border)'), info.frameStyle);
+});
+
+test('Game Capture compat message uses Normal styling', async t => {
+  const info = await probeCompat('GC normal sev', { capture_mode: 'window', window: TERRARIA });
+
+  t.true(info.rendered);
+  t.is(info.iconClass, 'icon-question');
+  t.true(info.frameStyle.includes('var(--callout-border)'), info.frameStyle);
+});
+
+test('Game Capture hides the transient hook status', async t => {
+  // libobs leaves "Attempting to hook process..." visible permanently because compat_info is
+  // registered twice in game-capture.c and the visibility logic no-ops on a NULL property
+  const info = await probeCompat('GC hook status', null, false);
+
+  if (info.rendered) {
+    t.false(
+      info.text.includes('Attempting to hook process'),
+      'the never-clearing hook placeholder should not be shown',
+    );
+  } else {
+    t.pass();
+  }
+});
+
+test('Game Capture hides an empty compat message', async t => {
+  // in any_fullscreen mode the property stays visible with an empty description
+  const info = await probeCompat('GC empty', { capture_mode: 'any_fullscreen' }, false);
+  t.false(info.rendered, 'an empty compatibility message should render nothing at all');
+});
+
+captureTest('Game Capture lists and captures a live window', async t => {
+  // cs2 and cs2-blocked are indistinguishable to OBS (same title, class and exe), so only one
+  // target may be running at a time or a test can hook the other one's window
+  stopAll();
+  const target = await launchProfile('cs2');
+  const name = 'GC live capture';
+
+  await addSource('Game Capture', name);
+  try {
+    await updateSettings(name, { capture_mode: 'window', window: target.obsWindowSetting });
+
+    const api = await getApiClient();
+    const sourcesService = api.getResource<SourcesService>('SourcesService');
+    const formData = sourcesService.getSourcesByName(name)[0].getPropertiesFormData() as any[];
+    const windowProp = formData.find(f => f.name === 'window');
+    const listed = (windowProp.options || []).some((o: any) => o.value === target.obsWindowSetting);
+    t.true(listed, 'the target window should appear in the window property options');
+
+    // poll with properties closed. Game Capture shows a placeholder at its own size when it is
+    // not capturing, so only an exact match with the target's client area proves real capture.
+    t.truthy(target.clientSize, 'target did not report its client size');
+    let dimensions = '0x0';
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const { width, height } = await readDimensions(name);
+      dimensions = `${width}x${height}`;
+      if (dimensions === target.clientSize) break;
+      await sleep(1000);
+    }
+    t.is(
+      dimensions,
+      target.clientSize,
+      `source never matched the target's ${target.clientSize} after 30s (saw ${dimensions}) — ` +
+        'the agent may lack a GPU or an interactive desktop session, or this is the placeholder',
+    );
+  } finally {
+    await removeGameCapture(name);
+    stopAll();
+  }
+});
+
+captureTest('Game Capture warns and refuses capture when injection is blocked', async t => {
+  // reproduces CS2 launched without -allow_third_party_software: the hook cannot load.
+  // signature-policy is requested explicitly — the profile's default (squat-ipc) did not
+  // actually prevent capture when measured.
+  stopAll();
+  const target = await launchProfile('cs2-blocked', { blockCapture: 'signature-policy' });
+  const name = 'GC blocked capture';
+
+  await addSource('Game Capture', name);
+  try {
+    await updateSettings(name, { capture_mode: 'window', window: target.obsWindowSetting });
+
+    // never matching the target's own size means the hook never delivered a frame; the source
+    // shows the placeholder instead
+    let dimensions = '0x0';
+    const deadline = Date.now() + 20000;
+    while (Date.now() < deadline) {
+      const { width, height } = await readDimensions(name);
+      dimensions = `${width}x${height}`;
+      if (dimensions === target.clientSize) break;
+      await sleep(1000);
+    }
+    t.not(
+      dimensions,
+      target.clientSize,
+      `a blocked target must never produce frames, but the source matched ${target.clientSize}`,
+    );
+
+    const info = await readCompatInfoFor(name);
+    t.true(info.rendered, 'the compatibility warning should still be shown while blocked');
+    t.false(info.rawMarkupVisible, 'raw markup visible as text');
+  } finally {
+    await removeGameCapture(name);
+    stopAll();
+  }
+});


### PR DESCRIPTION
Automated coverage for the Game Capture compatibility UI fixed in #6070, plus real capture behaviour.

**Depends on #6072** for a green run — without those harness fixes the app wedges after a few properties cycles and the log check fails on multi-line records.

## Tests

Hermetic (no process, no GPU, no download) — `window_changed_callback` matches on the `window` setting string, not a live window:

- compat warning renders as rich text, with a link that has no `href`, `role="link"` and `tabIndex=0`
- Error and Normal severities produce their own icon and frame tokens
- `Attempting to hook process...` is not shown
- an empty description renders nothing

Tool-backed, using `summeroff/game-capture-target` v0.3.0:

- a live window is listed in the `window` property options, reports being hooked, and delivers frames at its own size
- a target with injection blocked verifies its block, is never hooked, and never produces frames

## Helper

`test/helpers/game-capture-target.ts` fetches a pinned release, verifies SHA-256, extracts into gitignored `test-dist/`, copies to the profile's executable name (the rename is what makes exe-matched compatibility entries apply), and drives the target over its NDJSON event stream (`--events json`). `FAKEGAME_PATH` overrides for local or offline runs. No new dependencies — `node-fetch` and `extract-zip` are already present.

`SLOBS_TEST_SKIP_GAME_CAPTURE=1` skips the two capture tests on an agent with no GPU or interactive session.

## Notes

- **Capture is asserted from the target's `hooked` event, not from source dimensions.** Game Capture renders a placeholder at its own size when it is not capturing, so a dimensions check cannot distinguish the two — an earlier revision of this suite passed for that reason. The size match is kept only as confirmation the frames belong to the target.
- The blocked test asserts `block_active.verified`, so a capture block that silently stops working fails the test rather than turning it into a no-op.
- Window options are read from `getPropertiesFormData()`; the dropdown is virtualized and only holds ~10 entries.
- `cs2` and `cs2-blocked` are indistinguishable to OBS (same title, class, exe), so only one target runs at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
