### PR TITLE
Surface error when failing to set up patreon.

### DIFF
--- a/app/services/platforms/base-platform.ts
+++ b/app/services/platforms/base-platform.ts
@@ -160,8 +160,8 @@ export abstract class BasePlatformService<T extends IPlatformState> extends Stat
     e: any,
     platform: TPlatform,
     errorType: TStreamErrorType = 'PLATFORM_REQUEST_FAILED',
-  ): void {
-    console.warn(`Error starting ${platformLabels(platform)} stream: `, e);
+  ): never {
+    console.error(`${platformLabels(platform)} Error: `, e);
 
     const message =
       e.result?.data?.message ||

--- a/app/services/platforms/base-platform.ts
+++ b/app/services/platforms/base-platform.ts
@@ -7,6 +7,7 @@ import {
   TStartStreamOptions,
   TPlatformCapabilityMap,
   TLiveDockFeature,
+  platformLabels,
 } from './index';
 import { StreamingService } from 'services/streaming';
 import { UserService } from 'services/user';
@@ -18,6 +19,7 @@ import * as remote from '@electron/remote';
 import { VideoSettingsService } from 'services/settings-v2/video';
 import { ENotificationType, NotificationsService } from 'services/notifications';
 import { IJsonRpcRequest } from 'services/api/jsonrpc';
+import { throwStreamError, TStreamErrorType } from 'services/streaming/stream-error';
 
 const VIEWER_COUNT_UPDATE_INTERVAL = 60 * 1000;
 
@@ -152,6 +154,31 @@ export abstract class BasePlatformService<T extends IPlatformState> extends Stat
         mode,
       });
     }
+  }
+
+  formatError(
+    e: any,
+    platform: TPlatform,
+    errorType: TStreamErrorType = 'PLATFORM_REQUEST_FAILED',
+  ): void {
+    console.warn(`Error starting ${platformLabels(platform)} stream: `, e);
+
+    const message =
+      e.result?.data?.message ||
+      e.result?.message ||
+      e.statusText ||
+      e.message ||
+      `Unknown error starting ${platformLabels(platform)} stream`;
+
+    throwStreamError(
+      errorType,
+      {
+        status: e.status,
+        statusText: message,
+        platform,
+      },
+      message,
+    );
   }
 
   @mutation()

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -11,6 +11,7 @@ import { TDisplayType } from 'services/settings-v2';
 import { $t } from 'services/i18n';
 import { KickService, IKickStartStreamOptions } from './kick';
 import { PatreonService, IPatreonStartStreamOptions } from './patreon';
+import { TStreamErrorType } from 'services/streaming/stream-error';
 
 export type Tag = string;
 export interface IGame {
@@ -214,6 +215,8 @@ export interface IPlatformService {
   setupStreamShiftStream?: (options: IGoLiveSettings) => Promise<void>;
 
   postNotification?: (message: string) => void;
+
+  formatError?: (e: any, platform: TPlatform, errorType?: TStreamErrorType) => void;
 
   fetchNewToken: () => Promise<void>;
 

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -11,7 +11,7 @@ import { TDisplayType } from 'services/settings-v2';
 import { $t } from 'services/i18n';
 import { KickService, IKickStartStreamOptions } from './kick';
 import { PatreonService, IPatreonStartStreamOptions } from './patreon';
-import { TStreamErrorType } from 'services/streaming/stream-error';
+import type { TStreamErrorType } from 'services/streaming/stream-error';
 
 export type Tag = string;
 export interface IGame {
@@ -216,7 +216,7 @@ export interface IPlatformService {
 
   postNotification?: (message: string) => void;
 
-  formatError?: (e: any, platform: TPlatform, errorType?: TStreamErrorType) => void;
+  formatError?: (e: any, platform: TPlatform, errorType?: TStreamErrorType) => never;
 
   fetchNewToken: () => Promise<void>;
 

--- a/app/services/platforms/patreon.ts
+++ b/app/services/platforms/patreon.ts
@@ -291,7 +291,7 @@ export class PatreonService
         return res;
       })
       .catch(e => {
-        this.formatError(e, 'patreon');
+        return this.formatError(e, 'patreon');
       });
   }
 
@@ -312,7 +312,7 @@ export class PatreonService
         return res;
       })
       .catch(e => {
-        this.formatError(e, 'patreon');
+        return this.formatError(e, 'patreon');
       });
   }
 

--- a/app/services/platforms/patreon.ts
+++ b/app/services/platforms/patreon.ts
@@ -291,23 +291,7 @@ export class PatreonService
         return res;
       })
       .catch(e => {
-        console.warn('Error starting Patreon stream: ', e);
-
-        let message = e.message ?? 'Unknown error starting Patreon stream';
-        if (e.result) {
-          message = e.statusText || e.result.data.message;
-        }
-        const details = e.result?.data?.message ?? message;
-
-        throwStreamError(
-          'PLATFORM_REQUEST_FAILED',
-          {
-            status: e.status,
-            statusText: message,
-            platform: 'patreon',
-          },
-          details,
-        );
+        this.formatError(e, 'patreon');
       });
   }
 
@@ -328,23 +312,7 @@ export class PatreonService
         return res;
       })
       .catch(e => {
-        console.warn('Error ending Patreon stream: ', e);
-
-        let message = e.message ?? 'Unknown error ending Patreon stream';
-        if (e.result) {
-          message = e.statusText || e.result.data.message;
-        }
-        const details = e.result?.data?.message ?? message;
-
-        throwStreamError(
-          'PLATFORM_REQUEST_FAILED',
-          {
-            status: e.status,
-            statusText: message,
-            platform: 'patreon',
-          },
-          details,
-        );
+        this.formatError(e, 'patreon');
       });
   }
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -804,6 +804,7 @@ export class StreamingService
     platform: TPlatform,
     settings: IGoLiveSettings,
     unattendedMode: boolean,
+    failOnError: boolean = false,
   ) {
     const service = getPlatformService(platform);
 
@@ -874,7 +875,14 @@ export class StreamingService
       // To prevent users from being blocked by livestreaming from a single platform failing to
       // set up. Users can elect to bypass the error and go live anyways. To prevent the go live
       // checklist from being stopped too soon, only stop if no displays are multistreaming.
-      if (!this.views.shouldSetupRestream) {
+      //
+      // `failOnError` opts out of that for a target added mid-stream, where that platform is the
+      // whole operation rather than one of several going live. Continuing would add a restream
+      // target built from the stream key the failed `beforeGoLive` never set, leaving the user
+      // live to an address that goes nowhere with no indication anything went wrong.
+      // Rethrow the original error so the reason the platform failed survives to the user.
+      if (failOnError || !this.views.shouldSetupRestream) {
+        if (e instanceof StreamError) throw e;
         throwStreamError(errorType);
       }
     }
@@ -1041,9 +1049,10 @@ export class StreamingService
           await this.removeTargetsFromStream(updatePlatforms.stop, updateDestinations.stop);
         }
 
-        // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms
+        // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms.
+        // Fail on error so that a platform that could not be set up is never added as a target.
         for (const platform of updatePlatforms.start) {
-          await this.setPlatformSettings(platform, settings, false);
+          await this.setPlatformSettings(platform, settings, false, true);
         }
 
         // Save any settings updated during the `beforeGoLive` process for the platforms.


### PR DESCRIPTION
# Surface Platform Setup Errors

## Issues
A failed API call to Patreon swallowed errors without a message so the thrown `StreamError` carried `statusText: undefined` and `details: undefined`. There was nothing left to display.

## Fixes
Add a `formatError` to `BasePlatformService` to surface the error. Adding to the base platform service is the first step towards standardizing error handling across platforms.

<img width="300" height="290" alt="Screenshot 2026-08-10 150911" src="https://github.com/user-attachments/assets/923cddfc-99c4-4492-8d35-029aba30fe3e" />

**File(s) changed:**
- `app/services/platforms/base-platform.ts`
- `app/services/platforms/index.ts`
- `app/services/platforms/patreon.ts`
- `app/services/streaming/streaming.ts`


## TODO
Refactor error handling across platforms to use or extend this function, which will standardize error handling in the platform services and simplify debugging errors in the future.

## Performance Implications
None. No additional requests, state, or work on the success path — every change is on an error path.