### PR TITLE
Update obs-studio-node to 0.27.3

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.29b18",
+      "version": "0.27.3",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
## Summary

- Update the `obs-studio-node` package pin from `0.26.29b18` to `0.27.3`.
- Use the released OSN contract containing backend-owned encoder metadata and backend recording format/encoder validation.

## Validation

- Parsed `scripts/repositories.json` successfully.
- `git diff --check` passed.
- Verified OSN `0.27.3` contains the encoder metadata and save-validation commits.
- Verified the Windows x64 `0.27.3` package is published. The macOS x64 and ARM64 package URLs returned HTTP 403 when checked on 2026-08-12.
