### PR TITLE
Onboarding tests- Fix RxJS unsubscribe crash, missing React keys in onboarding, and cherry-pick other test fixes

### DIFF
--- a/app/components-react/modals/onboarding/Themes.tsx
+++ b/app/components-react/modals/onboarding/Themes.tsx
@@ -108,7 +108,7 @@ export function Themes(p: IOnboardingStepProps) {
         setProgress(progress.percent * 100),
       );
 
-      return sub.unsubscribe;
+      return () => sub.unsubscribe();
     }
   }, [installing]);
 
@@ -168,7 +168,11 @@ export function Themes(p: IOnboardingStepProps) {
             arrows={false}
           >
             {idList.map(id => (
-              <PreviewCard metadata={themeMetadata.current![id]} installOverlay={installOverlay} />
+              <PreviewCard
+                key={id}
+                metadata={themeMetadata.current![id]}
+                installOverlay={installOverlay}
+              />
             ))}
           </Carousel>
           <a style={{ marginTop: 80, display: 'block' }} onClick={browseOverlays}>
@@ -223,7 +227,7 @@ function PreviewCard(p: {
         {!isVideo(selectedImage) && <img src={selectedImage} className={themeS.bigPreview} />}
         <div className={themeS.imgColumn}>
           {previews.slice(0, 3).map(url => (
-            <div onClick={() => setSelectedImage(url)}>
+            <div key={url} onClick={() => setSelectedImage(url)}>
               {isVideo(url) && <video src={url} controls={false} loop />}
               {!isVideo(url) && <img src={url} />}
             </div>

--- a/app/components-react/modals/onboarding/Ultra.tsx
+++ b/app/components-react/modals/onboarding/Ultra.tsx
@@ -12,7 +12,7 @@ export function Ultra(p: IOnboardingStepProps) {
     const sub = UserService.subscribedToPrime.subscribe(() => {
       OnboardingV2Service.actions.takeStep();
     });
-    return sub.unsubscribe;
+    return () => sub.unsubscribe();
   }, []);
 
   function clickFree() {

--- a/app/components-react/pages/onboarding/MacPermissions.tsx
+++ b/app/components-react/pages/onboarding/MacPermissions.tsx
@@ -19,7 +19,7 @@ export function MacPermissions() {
 
     MacPermissionsService.requestPermissions();
 
-    return sub.unsubscribe;
+    return () => sub.unsubscribe();
   }, []);
 
   return (

--- a/app/components-react/windows/EditTransform.tsx
+++ b/app/components-react/windows/EditTransform.tsx
@@ -28,7 +28,7 @@ export default function EditTransform() {
 
   useEffect(() => {
     const subscription = SourcesService.sourceRemoved.subscribe(cancel);
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, []);
 
   async function invalidForm() {

--- a/app/components-react/windows/PlatformAppPopOut.tsx
+++ b/app/components-react/windows/PlatformAppPopOut.tsx
@@ -16,7 +16,7 @@ export default function PlatformAppPopOut() {
       }
     });
 
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, []);
 
   return (

--- a/app/components-react/windows/Troubleshooter.tsx
+++ b/app/components-react/windows/Troubleshooter.tsx
@@ -36,7 +36,7 @@ export default function Troubleshooter() {
       .pipe(debounceTime(500), tap(SettingsService.actions.loadSettingsIntoStore))
       .subscribe();
 
-    return subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, []);
 
   function hideParamsForCategory(category: ISettingsSubCategory) {

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -49,6 +49,13 @@ import { NavigationService } from 'services/navigation';
 import { StreamingService } from 'services/streaming';
 import { VirtualWebcamService } from 'services/virtual-webcam';
 import { WebsocketService } from 'services/websocket';
+import {
+  executeImmediateShutdownSteps,
+  IWorkerShutdownPlan,
+  runWorkerShutdown,
+} from 'util/worker-shutdown';
+
+const SHUTDOWN_ANALYTICS_TIMEOUT_MS = 3 * 1000;
 
 interface IAppState {
   loading: boolean;
@@ -206,34 +213,168 @@ export class AppService extends StatefulService<IAppState> {
   private shutdownHandler() {
     this.START_LOADING();
     this.loadingChanged.next(true);
-    this.tcpServerService.stopListening();
+
+    // Stop external callers before yielding or starting the delayed teardown. This prevents API
+    // mutations from racing the final scene snapshot.
+    const ingressReport = executeImmediateShutdownSteps([
+      {
+        name: 'TcpServerService.stopListening',
+        criticality: 'required',
+        run: () => this.tcpServerService.stopListening(),
+      },
+      {
+        name: 'IpcServerService.stopListening',
+        criticality: 'required',
+        run: () => this.ipcServerService.stopListening(),
+      },
+    ]);
+
     window.setTimeout(async () => {
-      obs.NodeObs.InitShutdownSequence();
-      this.streamAvatarService.stopAvatarProcess();
-      this.crashReporterService.beginShutdown();
-      this.shutdownStarted.next();
-      this.recentEventsService.shutdown();
-      this.websocketService.disconnect();
-      this.keyListenerService.shutdown();
-      this.platformAppsService.unloadAllApps();
-      await this.usageStatisticsService.flushEvents();
-      await this.streamingService.shutdown();
-      this.windowsService.shutdown();
-      this.ipcServerService.stopListening();
-      await this.userService.flushUserSession();
-      await this.sceneCollectionsService.deinitialize();
-      this.performanceService.stop();
-      this.transitionsService.shutdown();
-      this.videoSettingsService.shutdown();
-      await this.gameOverlayService.destroy();
-      await this.fileManagerService.flushAll();
-      obs.NodeObs.RemoveSourceCallback();
-      obs.NodeObs.RemoveTransitionCallback();
-      obs.NodeObs.RemoveVolmeterCallback();
-      obs.NodeObs.OBS_service_removeCallback();
-      obs.IPC.disconnect();
-      this.crashReporterService.endShutdown();
-      electron.ipcRenderer.send('shutdownComplete');
+      const plan: IWorkerShutdownPlan = {
+        persistence: [
+          {
+            name: 'CrashReporterService.beginShutdown',
+            criticality: 'required',
+            run: () => this.crashReporterService.beginShutdown(),
+          },
+          {
+            name: 'SceneCollectionsService.persistForShutdown',
+            criticality: 'required',
+            run: () => this.sceneCollectionsService.persistForShutdown(),
+          },
+          {
+            name: 'UserService.flushUserSession',
+            criticality: 'required',
+            run: () => this.userService.flushUserSession(),
+          },
+          {
+            name: 'FileManagerService.flushAllBeforeTeardown',
+            criticality: 'required',
+            run: () => this.fileManagerService.flushAll(),
+          },
+        ],
+        teardown: [
+          {
+            name: 'AppService.shutdownStarted',
+            criticality: 'required',
+            run: () => this.shutdownStarted.next(),
+          },
+          {
+            name: 'NodeObs.InitShutdownSequence',
+            criticality: 'required',
+            run: () => obs.NodeObs.InitShutdownSequence(),
+          },
+          {
+            name: 'StreamAvatarService.stopAvatarProcess',
+            criticality: 'best-effort',
+            run: () => this.streamAvatarService.stopAvatarProcess(),
+          },
+          {
+            name: 'RecentEventsService.shutdown',
+            criticality: 'best-effort',
+            run: () => this.recentEventsService.shutdown(),
+          },
+          {
+            name: 'WebsocketService.disconnect',
+            criticality: 'best-effort',
+            run: () => this.websocketService.disconnect(),
+          },
+          {
+            name: 'KeyListenerService.shutdown',
+            criticality: 'best-effort',
+            run: () => this.keyListenerService.shutdown(),
+          },
+          {
+            name: 'PlatformAppsService.unloadAllApps',
+            criticality: 'best-effort',
+            run: () => this.platformAppsService.unloadAllApps(),
+          },
+          {
+            name: 'StreamingService.shutdown',
+            criticality: 'required',
+            run: () => this.streamingService.shutdown(),
+          },
+          {
+            name: 'WindowsService.shutdown',
+            criticality: 'best-effort',
+            run: () => this.windowsService.shutdown(),
+          },
+          {
+            name: 'SceneCollectionsService.deinitialize',
+            criticality: 'required',
+            run: () => this.sceneCollectionsService.deinitialize({ persist: false }),
+          },
+          {
+            name: 'PerformanceService.stop',
+            criticality: 'best-effort',
+            run: () => this.performanceService.stop(),
+          },
+          {
+            name: 'TransitionsService.shutdown',
+            criticality: 'required',
+            run: () => this.transitionsService.shutdown(),
+          },
+          {
+            name: 'VideoSettingsService.shutdown',
+            criticality: 'required',
+            run: () => this.videoSettingsService.shutdown(),
+          },
+          {
+            name: 'GameOverlayService.destroy',
+            criticality: 'required',
+            run: () => this.gameOverlayService.destroy(),
+          },
+          {
+            name: 'FileManagerService.flushAllAfterTeardown',
+            criticality: 'required',
+            run: () => this.fileManagerService.flushAll(),
+          },
+          {
+            name: 'NodeObs.RemoveSourceCallback',
+            criticality: 'required',
+            run: () => obs.NodeObs.RemoveSourceCallback(),
+          },
+          {
+            name: 'NodeObs.RemoveTransitionCallback',
+            criticality: 'required',
+            run: () => obs.NodeObs.RemoveTransitionCallback(),
+          },
+          {
+            name: 'NodeObs.RemoveVolmeterCallback',
+            criticality: 'required',
+            run: () => obs.NodeObs.RemoveVolmeterCallback(),
+          },
+          {
+            name: 'NodeObs.OBS_service_removeCallback',
+            criticality: 'required',
+            run: () => obs.NodeObs.OBS_service_removeCallback(),
+          },
+          {
+            name: 'OBS IPC disconnect',
+            criticality: 'required',
+            run: () => obs.IPC.disconnect(),
+          },
+        ],
+        bestEffort: [
+          {
+            name: 'UsageStatisticsService.flushEvents',
+            criticality: 'best-effort',
+            timeoutMs: SHUTDOWN_ANALYTICS_TIMEOUT_MS,
+            run: signal => this.usageStatisticsService.flushEvents(signal),
+          },
+        ],
+      };
+
+      await runWorkerShutdown(plan, {
+        initialReport: ingressReport,
+        markClean: () => this.crashReporterService.endShutdown(),
+        onComplete: report => {
+          electron.ipcRenderer.send('shutdownComplete', {
+            clean: report.clean,
+            failedSteps: report.failures.map(failure => failure.name),
+          });
+        },
+      });
     }, 300);
   }
 

--- a/app/services/crash-reporter.ts
+++ b/app/services/crash-reporter.ts
@@ -95,14 +95,18 @@ export class CrashReporterService extends Service {
 
   beginShutdown() {
     this.streamingSubscription.unsubscribe();
-    this.writeStateFile(EAppState.Closing);
+    if (!this.writeStateFile(EAppState.Closing)) {
+      throw new Error('Unable to persist application closing state');
+    }
   }
 
   endShutdown() {
-    this.writeStateFile(EAppState.CleanExit);
+    if (!this.writeStateFile(EAppState.CleanExit)) {
+      throw new Error('Unable to persist clean application exit state');
+    }
   }
 
-  private writeStateFile(code: EAppState) {
+  private writeStateFile(code: EAppState): boolean {
     this.appState = this.readStateFile();
     this.appState.code = code;
     if (this.appState.code === EAppState.Starting) {
@@ -110,11 +114,13 @@ export class CrashReporterService extends Service {
       this.appState.version = this.version;
     }
 
-    if (process.env.NODE_ENV !== 'production') return;
+    if (process.env.NODE_ENV !== 'production') return true;
     try {
       fs.writeFileSync(this.appStateFile, JSON.stringify(this.appState));
+      return true;
     } catch (e: unknown) {
       console.error('Error writing app state file', e);
+      return false;
     }
   }
 

--- a/app/services/file-manager.ts
+++ b/app/services/file-manager.ts
@@ -1,6 +1,11 @@
-import { Service } from 'services/core/service';
+import { Service } from './core/service';
 import path from 'path';
 import fs from 'fs';
+
+interface IFlushWaiter {
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
 
 interface IFile {
   data: string;
@@ -12,7 +17,7 @@ interface IFile {
    * Used during shutdown to coordinate flushing fully finished
    * before shutting down.
    */
-  flushFinished?: () => void;
+  flushWaiters?: IFlushWaiter[];
 }
 
 export interface IFileReadOptions {
@@ -125,15 +130,59 @@ export class FileManagerService extends Service {
    * be called before shutdown.
    */
   async flushAll() {
-    const promises = Object.values(this.files)
-      .filter(file => file.dirty)
-      .map(file => {
-        return new Promise<void>(resolve => {
-          file.flushFinished = resolve;
-        });
-      });
+    const attemptedVersions: Dictionary<number> = {};
+    const failures: { filePath: string; error: unknown }[] = [];
 
-    await Promise.all(promises);
+    while (true) {
+      const dirtyFiles = Object.entries(this.files).filter(([, file]) => file.dirty);
+      if (!dirtyFiles.length) return;
+
+      // Revisit the file list after every batch. This catches files created or rewritten while
+      // another file was still flushing, without retrying the same failed version forever.
+      const pendingFiles = dirtyFiles.filter(
+        ([filePath, file]) => file.locked || attemptedVersions[filePath] !== file.version,
+      );
+      if (!pendingFiles.length) break;
+
+      await Promise.all(
+        pendingFiles.map(async ([filePath, file]) => {
+          const version = file.version;
+          attemptedVersions[filePath] = version;
+
+          try {
+            await this.waitForFlush(filePath, file);
+            const previousFailure = failures.findIndex(failure => failure.filePath === filePath);
+            if (previousFailure !== -1) failures.splice(previousFailure, 1);
+          } catch (error: unknown) {
+            const previousFailure = failures.find(failure => failure.filePath === filePath);
+            if (previousFailure) {
+              previousFailure.error = error;
+            } else {
+              failures.push({ filePath, error });
+            }
+          }
+        }),
+      );
+    }
+
+    if (failures.length) {
+      throw new Error(
+        `Failed to flush ${failures.length} file(s): ${failures
+          .map(failure => failure.filePath)
+          .join(', ')}`,
+      );
+    }
+  }
+
+  private waitForFlush(filePath: string, file: IFile): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!file.flushWaiters) file.flushWaiters = [];
+      file.flushWaiters.push({ resolve, reject });
+
+      // A previous background flush may already have exhausted its retries before shutdown
+      // began. Restart it now that flushAll has installed completion observers.
+      if (!file.locked) this.flush(filePath);
+    });
   }
 
   private async flush(filePath: string, tries = 10) {
@@ -155,17 +204,27 @@ export class FileManagerService extends Service {
 
       file.locked = false;
       file.dirty = false;
-      if (file.flushFinished) file.flushFinished();
+      this.notifyFlushFinished(file);
       console.debug(`Wrote file ${filePath} version ${version}`);
     } catch (e: unknown) {
       if (tries > 0) {
         file.locked = false;
         await this.flush(filePath, tries - 1);
       } else {
-        if (file.flushFinished) file.flushFinished();
-        console.error(`Ran out of retries writing ${filePath}`);
+        file.locked = false;
+        this.notifyFlushFinished(file, e);
+        console.error(`Ran out of retries writing ${filePath}`, e);
       }
     }
+  }
+
+  private notifyFlushFinished(file: IFile, error?: unknown) {
+    const flushWaiters = file.flushWaiters || [];
+    file.flushWaiters = [];
+
+    flushWaiters.forEach(waiter => {
+      error === undefined ? waiter.resolve() : waiter.reject(error);
+    });
   }
 
   /**

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -174,14 +174,22 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   }
 
   /**
-   * Generally called on application shutdown.
+   * Persists the current collection and manifest before shutdown starts destroying OBS state.
+   * FileManagerService.flushAll() must be awaited by the caller to make these queued writes durable.
    */
-  async deinitialize() {
+  async persistForShutdown() {
     await this.disableAutoSave();
     await this.save();
-    await this.deloadCurrentApplicationState();
-    await this.safeSync();
-    await this.stateService.flushManifestFile();
+    this.stateService.flushManifestFile();
+  }
+
+  /**
+   * Generally called on application shutdown after persistForShutdown has completed.
+   * Cloud synchronization is intentionally left to startup so network stalls cannot block exit.
+   */
+  async deinitialize({ persist = true }: { persist?: boolean } = {}) {
+    if (persist) await this.persistForShutdown();
+    await this.deloadCurrentApplicationState({ save: false });
   }
 
   /**
@@ -760,13 +768,15 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * ready to load a new config file.  This should only ever be
    * performed while the application is already in a "LOADING" state.
    */
-  private async deloadCurrentApplicationState() {
+  private async deloadCurrentApplicationState({ save = true }: { save?: boolean } = {}) {
     this.tcpServerService.stopRequestsHandling();
 
     this.collectionWillSwitch.next();
 
     await this.disableAutoSave();
-    await this.save();
+    if (save) await this.save();
+
+    let deloadError: unknown;
 
     // we should remove inactive scenes first to avoid the switching between scenes
     try {
@@ -789,10 +799,13 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       this.streamingService.setSelectiveRecording(false);
     } catch (e: unknown) {
       console.error('Error deloading application state', e);
+      deloadError = e;
     }
 
     this.hotkeysService.clearAllHotkeys();
     this.collectionLoaded = false;
+
+    if (deloadError) throw deloadError;
   }
 
   /**

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -4266,6 +4266,8 @@ export class StreamingService
    * even if one fails. This prevents orphan contexts that can leave phantom processes or create errors on next startup.
    */
   async shutdown() {
+    const failures: string[] = [];
+
     // InitShutdownSequence is called before this method, so OBS outputs are
     // already being torn down. Skip .stop() calls and directly destroy factory
     // instances to avoid blocking on native calls that may never return.
@@ -4282,10 +4284,15 @@ export class StreamingService
           this.destroyFactoryInstance(type, instance);
         } catch (e: unknown) {
           console.error(`Error destroying ${type} for ${context} during shutdown:`, e);
+          failures.push(`${context}.${type}`);
         }
 
         this.contexts[context][type] = null;
       }
+    }
+
+    if (failures.length) {
+      throw new Error(`Failed to destroy output contexts during shutdown: ${failures.join(', ')}`);
     }
   }
 

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -284,7 +284,7 @@ export class UsageStatisticsService extends Service {
   /**
    * Should be called on shutdown to flush all events in the pipeline
    */
-  async flushEvents() {
+  async flushEvents(signal?: AbortSignal) {
     // Correctly handle unsubscribing to prevent memory leaks
     this.ultraSubscription.unsubscribe();
 
@@ -300,7 +300,7 @@ export class UsageStatisticsService extends Service {
     this.recordAnalyticsEvent('Session', session);
 
     // Unthrottled version
-    await this.sendAnalytics();
+    await this.sendAnalytics(signal);
   }
 
   // We can't fetch this before app startup like the rest of sysInfo since it
@@ -350,7 +350,7 @@ export class UsageStatisticsService extends Service {
   /**
    * Should not be called directly except during shutdown.
    */
-  private async sendAnalytics() {
+  private async sendAnalytics(signal?: AbortSignal) {
     if (!this.analyticsEvents.length) return;
 
     const data = { analyticsTokens: [...this.analyticsEvents] };
@@ -364,10 +364,11 @@ export class UsageStatisticsService extends Service {
       method: 'post',
       body: JSON.stringify(data || {}),
     });
-    await fetch(request)
+    await fetch(request, { signal })
       .then(handleResponse)
-      .catch(e => {
+      .catch((e: unknown) => {
         console.error('Error sending analytics events', e);
+        if (signal) throw e;
       });
   }
 

--- a/app/util/shutdown-coordinator.js
+++ b/app/util/shutdown-coordinator.js
@@ -1,0 +1,164 @@
+// Grace period for the worker to acknowledge shutdown.
+const SHUTDOWN_ACK_TIMEOUT_MS = 10 * 1000;
+
+// The teardown window after the worker has acknowledged shutdown.
+const SHUTDOWN_COMPLETE_TIMEOUT_MS = 30 * 1000;
+
+// Grace period for Electron to flush session data and finish exiting after worker teardown.
+const SHUTDOWN_EXIT_TIMEOUT_MS = 10 * 1000;
+
+function writeLog(logger, level, message) {
+  try {
+    if (logger && typeof logger[level] === 'function') {
+      logger[level](message);
+      return;
+    }
+
+    if (logger && typeof logger.log === 'function') {
+      logger.log(message);
+    }
+  } catch (e) {
+    // Logging must never interrupt application teardown.
+  }
+}
+
+function createShutdownCoordinator(options) {
+  const setTimeoutFn = options.setTimeoutFn || setTimeout;
+  const clearTimeoutFn = options.clearTimeoutFn || clearTimeout;
+  const logger = options.logger || console;
+  const onForceShutdown = options.onForceShutdown || (() => {});
+  const onRelaunch = options.onRelaunch || (() => {});
+
+  let ackTimer = null;
+  let completionTimer = null;
+  let exitTimer = null;
+  let shutdownStarted = false;
+  let shutdownAcknowledged = false;
+  let shutdownCompleted = false;
+  let shutdownFinished = false;
+  let forced = false;
+  let relaunchScheduled = false;
+
+  function clearAckTimer() {
+    if (!ackTimer) return;
+    clearTimeoutFn(ackTimer);
+    ackTimer = null;
+  }
+
+  function clearCompletionTimer() {
+    if (!completionTimer) return;
+    clearTimeoutFn(completionTimer);
+    completionTimer = null;
+  }
+
+  function clearExitTimer() {
+    if (!exitTimer) return;
+    clearTimeoutFn(exitTimer);
+    exitTimer = null;
+  }
+
+  function clearTimers() {
+    clearAckTimer();
+    clearCompletionTimer();
+    clearExitTimer();
+  }
+
+  // Clears pending shutdown timers and delegates the actual application teardown.
+  function forceShutdown(reason) {
+    if (forced || shutdownFinished) return false;
+
+    forced = true;
+    clearTimers();
+    writeLog(logger, 'warn', `[Shutdown] Forcing shutdown: ${reason}`);
+    onForceShutdown(reason);
+    return true;
+  }
+
+  // Starts shutdown and waits for the worker renderer to acknowledge the request.
+  function beginShutdown() {
+    if (shutdownStarted || forced || shutdownFinished) return false;
+
+    shutdownStarted = true;
+    ackTimer = setTimeoutFn(() => {
+      forceShutdown('worker did not acknowledge shutdown');
+    }, SHUTDOWN_ACK_TIMEOUT_MS);
+
+    writeLog(logger, 'log', '[Shutdown] Waiting for worker shutdown acknowledgement');
+    return true;
+  }
+
+  // Records that the worker accepted shutdown and starts waiting for completion.
+  function acknowledgeShutdown() {
+    if (
+      !shutdownStarted ||
+      shutdownAcknowledged ||
+      shutdownCompleted ||
+      forced ||
+      shutdownFinished
+    ) {
+      return false;
+    }
+
+    shutdownAcknowledged = true;
+    clearAckTimer();
+
+    completionTimer = setTimeoutFn(() => {
+      forceShutdown('worker acknowledged shutdown but did not complete');
+    }, SHUTDOWN_COMPLETE_TIMEOUT_MS);
+
+    writeLog(logger, 'log', '[Shutdown] Worker acknowledged shutdown');
+    return true;
+  }
+
+  // Records clean worker teardown and starts waiting for Electron itself to exit.
+  function completeShutdown() {
+    if (!shutdownStarted || shutdownCompleted || forced || shutdownFinished) return false;
+
+    shutdownCompleted = true;
+    clearAckTimer();
+    clearCompletionTimer();
+
+    exitTimer = setTimeoutFn(() => {
+      forceShutdown('worker completed shutdown but application did not exit');
+    }, SHUTDOWN_EXIT_TIMEOUT_MS);
+
+    writeLog(logger, 'log', '[Shutdown] Worker completed shutdown');
+    return true;
+  }
+
+  // Clears the final watchdog once Electron reaches its committed quit event.
+  function finishShutdown() {
+    if (!shutdownStarted || shutdownFinished || forced) return false;
+
+    shutdownFinished = true;
+    clearTimers();
+    writeLog(logger, 'log', '[Shutdown] Application is exiting');
+    return true;
+  }
+
+  // Schedules at most one replacement process without interrupting healthy teardown.
+  function scheduleRelaunch(args) {
+    if (relaunchScheduled || forced || shutdownFinished) return false;
+
+    relaunchScheduled = true;
+    onRelaunch(args);
+    writeLog(logger, 'log', '[Shutdown] Application relaunch scheduled');
+    return true;
+  }
+
+  return {
+    beginShutdown,
+    acknowledgeShutdown,
+    completeShutdown,
+    finishShutdown,
+    forceShutdown,
+    scheduleRelaunch,
+  };
+}
+
+module.exports = {
+  createShutdownCoordinator,
+  SHUTDOWN_ACK_TIMEOUT_MS,
+  SHUTDOWN_COMPLETE_TIMEOUT_MS,
+  SHUTDOWN_EXIT_TIMEOUT_MS,
+};

--- a/app/util/worker-shutdown.ts
+++ b/app/util/worker-shutdown.ts
@@ -1,0 +1,234 @@
+export type TShutdownStepCriticality = 'required' | 'best-effort';
+
+export interface IShutdownStep {
+  name: string;
+  criticality: TShutdownStepCriticality;
+  run: (signal?: AbortSignal) => Promise<unknown> | unknown;
+  timeoutMs?: number;
+}
+
+export interface IShutdownFailure {
+  name: string;
+  criticality: TShutdownStepCriticality;
+  error: unknown;
+}
+
+export interface IShutdownReport {
+  clean: boolean;
+  failures: IShutdownFailure[];
+}
+
+export interface IShutdownLogger {
+  log(message: string, error?: unknown): void;
+  error(message: string, error?: unknown): void;
+}
+
+export interface IShutdownRunnerOptions {
+  logger?: IShutdownLogger;
+  setTimeoutFn?: (callback: () => void, delay: number) => unknown;
+  clearTimeoutFn?: (timer: unknown) => void;
+}
+
+export interface IWorkerShutdownPlan {
+  persistence: IShutdownStep[];
+  teardown: IShutdownStep[];
+  bestEffort: IShutdownStep[];
+}
+
+export interface IWorkerShutdownOptions extends IShutdownRunnerOptions {
+  initialReport?: IShutdownReport;
+  markClean: () => Promise<unknown> | unknown;
+  onComplete: (report: IShutdownReport) => void;
+}
+
+const defaultLogger: IShutdownLogger = {
+  log(message: string) {
+    console.log(message);
+  },
+  error(message: string, error?: unknown) {
+    console.error(message, error);
+  },
+};
+
+function createReport(failures: IShutdownFailure[] = []): IShutdownReport {
+  return {
+    failures,
+    clean: !failures.some(failure => failure.criticality === 'required'),
+  };
+}
+
+export function mergeShutdownReports(...reports: IShutdownReport[]): IShutdownReport {
+  return createReport(
+    reports.reduce<IShutdownFailure[]>((all, report) => {
+      all.push(...report.failures);
+      return all;
+    }, []),
+  );
+}
+
+function writeLog(
+  logger: IShutdownLogger,
+  level: 'log' | 'error',
+  message: string,
+  error?: unknown,
+) {
+  try {
+    logger[level](message, error);
+  } catch (e: unknown) {
+    // Logging must never interrupt application teardown.
+  }
+}
+
+function executeStepWithTimeout(
+  step: IShutdownStep,
+  options: IShutdownRunnerOptions,
+): Promise<unknown> {
+  const abortController = step.timeoutMs && step.timeoutMs > 0 ? new AbortController() : undefined;
+  let stepPromise: Promise<unknown>;
+
+  try {
+    stepPromise = Promise.resolve(step.run(abortController?.signal));
+  } catch (error: unknown) {
+    stepPromise = Promise.reject(error);
+  }
+
+  if (!step.timeoutMs || step.timeoutMs <= 0) return stepPromise;
+
+  const setTimeoutFn = options.setTimeoutFn || ((callback, delay) => setTimeout(callback, delay));
+  const clearTimeoutFn =
+    options.clearTimeoutFn ||
+    ((timer: unknown) => clearTimeout(timer as ReturnType<typeof setTimeout>));
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeoutFn(() => {
+      if (settled) return;
+      settled = true;
+      abortController?.abort();
+      reject(new Error(`${step.name} timed out after ${step.timeoutMs}ms`));
+    }, step.timeoutMs!);
+
+    stepPromise.then(
+      value => {
+        if (settled) return;
+        settled = true;
+        clearTimeoutFn(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeoutFn(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function executeShutdownSteps(
+  steps: IShutdownStep[],
+  options: IShutdownRunnerOptions = {},
+): Promise<IShutdownReport> {
+  const logger = options.logger || defaultLogger;
+  const failures: IShutdownFailure[] = [];
+
+  for (const step of steps) {
+    writeLog(logger, 'log', `[Shutdown] Starting ${step.name}`);
+
+    try {
+      await executeStepWithTimeout(step, options);
+      writeLog(logger, 'log', `[Shutdown] Completed ${step.name}`);
+    } catch (error: unknown) {
+      failures.push({ name: step.name, criticality: step.criticality, error });
+      writeLog(logger, 'error', `[Shutdown] Failed ${step.name}`, error);
+    }
+  }
+
+  return createReport(failures);
+}
+
+/**
+ * Executes synchronous ingress shutdown without yielding to the renderer event loop.
+ */
+export function executeImmediateShutdownSteps(
+  steps: IShutdownStep[],
+  options: IShutdownRunnerOptions = {},
+): IShutdownReport {
+  const logger = options.logger || defaultLogger;
+  const failures: IShutdownFailure[] = [];
+
+  for (const step of steps) {
+    writeLog(logger, 'log', `[Shutdown] Starting ${step.name}`);
+
+    try {
+      const result = step.run();
+      if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+        // The step is invalid, but still observe its eventual rejection so an accidental async
+        // ingress implementation cannot surface as an unhandled rejection during shutdown.
+        void Promise.resolve(result).catch(() => undefined);
+        throw new Error(`${step.name} must be synchronous when used as an immediate shutdown step`);
+      }
+      writeLog(logger, 'log', `[Shutdown] Completed ${step.name}`);
+    } catch (error: unknown) {
+      failures.push({ name: step.name, criticality: step.criticality, error });
+      writeLog(logger, 'error', `[Shutdown] Failed ${step.name}`, error);
+    }
+  }
+
+  return createReport(failures);
+}
+
+/**
+ * Runs shutdown in ordered phases. Local persistence always settles before destructive teardown,
+ * and best-effort work only starts after teardown has been attempted.
+ */
+export async function runWorkerShutdown(
+  plan: IWorkerShutdownPlan,
+  options: IWorkerShutdownOptions,
+): Promise<IShutdownReport> {
+  const runnerOptions: IShutdownRunnerOptions = options;
+  let report = options.initialReport || createReport();
+
+  try {
+    for (const steps of [plan.persistence, plan.teardown, plan.bestEffort]) {
+      report = mergeShutdownReports(report, await executeShutdownSteps(steps, runnerOptions));
+    }
+
+    if (report.clean) {
+      report = mergeShutdownReports(
+        report,
+        await executeShutdownSteps(
+          [
+            {
+              name: 'CrashReporterService.endShutdown',
+              criticality: 'required',
+              run: options.markClean,
+            },
+          ],
+          runnerOptions,
+        ),
+      );
+    }
+  } catch (error: unknown) {
+    report = mergeShutdownReports(
+      report,
+      createReport([
+        {
+          name: 'WorkerShutdown.unexpectedFailure',
+          criticality: 'required',
+          error,
+        },
+      ]),
+    );
+    writeLog(
+      options.logger || defaultLogger,
+      'error',
+      '[Shutdown] Unexpected shutdown failure',
+      error,
+    );
+  } finally {
+    options.onComplete(report);
+  }
+
+  return report;
+}

--- a/electron-builder/base.config.js
+++ b/electron-builder/base.config.js
@@ -14,6 +14,7 @@ const base = {
     'node_modules',
     'vendor',
     'app/i18n',
+    'app/util/shutdown-coordinator.js',
     'media/images/game-capture',
     'updater/build/bootstrap.js',
     'updater/build/bundle-updater.js',

--- a/main.js
+++ b/main.js
@@ -76,7 +76,9 @@ if (process.argv.includes('--clearCacheDir')) {
 }
 
 // This ensures that only one copy of our app can run at once.
-const gotTheLock = app.requestSingleInstanceLock();
+// additionalData preserves the secondary process arguments exactly; Electron's argv event may
+// reorder them or append Chromium switches.
+const gotTheLock = app.requestSingleInstanceLock({ relaunchArgs: process.argv.slice(1) });
 
 if (!gotTheLock) {
   app.quit();
@@ -85,6 +87,7 @@ if (!gotTheLock) {
 
 const bootstrap = require('./updater/build/bootstrap.js');
 const bundleUpdater = require('./updater/build/bundle-updater.js');
+const { createShutdownCoordinator } = require('./app/util/shutdown-coordinator');
 const uuid = require('uuid/v4');
 const semver = require('semver');
 const windowStateKeeper = require('electron-window-state');
@@ -272,9 +275,20 @@ app.on('ready', () => {
 // closing the windows before exit.
 let allowMainWindowClose = false;
 let shutdownStarted = false;
-let appShutdownTimeout;
+let shutdownCoordinator;
 
 global.indexUrl = `file://${__dirname}/index.html`;
+
+function forceShutdown(reason) {
+  console.warn(`[Shutdown] Force exiting application: ${reason}`);
+  allowMainWindowClose = true;
+
+  BrowserWindow.getAllWindows().forEach(window => {
+    if (!window.isDestroyed()) window.destroy();
+  });
+
+  app.exit(0);
+}
 
 function openDevTools() {
   childWindow.webContents.openDevTools({ mode: 'detach' });
@@ -291,6 +305,18 @@ async function startApp() {
   const crashHandler = require('crash-handler');
   const isDevMode = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
   const crashHandlerLogPath = app.getPath('userData');
+
+  shutdownCoordinator = createShutdownCoordinator({
+    logger: console,
+    onForceShutdown: forceShutdown,
+    onRelaunch: args => {
+      if (args) {
+        app.relaunch({ args });
+      } else {
+        app.relaunch();
+      }
+    },
+  });
 
   if (process.platform === 'win32') {
     overlay = require('game_overlay');
@@ -430,15 +456,8 @@ async function startApp() {
   mainWindow.on('close', e => {
     if (!shutdownStarted) {
       shutdownStarted = true;
+      shutdownCoordinator.beginShutdown();
       workerWindow.send('shutdown');
-
-      // We give the worker window 10 seconds to acknowledge a request
-      // to shut down.  Otherwise, we just close it.
-      appShutdownTimeout = setTimeout(() => {
-        allowMainWindowClose = true;
-        if (!mainWindow.isDestroyed()) mainWindow.close();
-        if (!workerWindow.isDestroyed()) workerWindow.close();
-      }, 10 * 1000);
     }
 
     if (!allowMainWindowClose) e.preventDefault();
@@ -462,11 +481,24 @@ async function startApp() {
     }
   });
 
+  app.on('quit', () => {
+    shutdownCoordinator.finishShutdown();
+  });
+
   ipcMain.on('acknowledgeShutdown', () => {
-    if (appShutdownTimeout) clearTimeout(appShutdownTimeout);
+    shutdownCoordinator.acknowledgeShutdown();
   });
 
   ipcMain.on('shutdownComplete', () => {
+    // OBS initialization can fail before the normal close path starts shutdown.
+    // Enter the coordinator state before recording completion so the final exit is bounded too.
+    if (!shutdownStarted) {
+      shutdownStarted = true;
+      shutdownCoordinator.beginShutdown();
+    }
+
+    if (!shutdownCoordinator.completeShutdown()) return;
+
     allowMainWindowClose = true;
     mainWindow.close();
     workerWindow.close();
@@ -474,7 +506,10 @@ async function startApp() {
 
   workerWindow.on('closed', () => {
     session.defaultSession.flushStorageData();
-    session.defaultSession.cookies.flushStore().then(() => app.quit());
+    session.defaultSession.cookies
+      .flushStore()
+      .catch(error => console.log('[Shutdown] Failed to flush cookie store', error))
+      .finally(() => app.quit());
   });
 
   // Pre-initialize the child window
@@ -597,7 +632,18 @@ if (fs.existsSync(haDisableFile)) app.disableHardwareAcceleration();
 
 app.setAsDefaultProtocolClient('slobs');
 
-app.on('second-instance', (event, argv, cwd) => {
+app.on('second-instance', (event, argv, cwd, additionalData) => {
+  if (shutdownStarted) {
+    // The triggering process has already failed to acquire the single-instance lock and will exit.
+    // Schedule one replacement with its arguments, then let the watchdog arbitrate this shutdown.
+    const relaunchArgs =
+      additionalData && Array.isArray(additionalData.relaunchArgs)
+        ? additionalData.relaunchArgs
+        : argv.slice(1);
+    if (shutdownCoordinator) shutdownCoordinator.scheduleRelaunch(relaunchArgs);
+    return;
+  }
+
   // Check for protocol links in the argv of the other process
   argv.forEach(arg => {
     if (arg.match(/^slobs:\/\//)) {
@@ -727,7 +773,7 @@ ipcMain.on('vuex-mutation', (event, mutation) => {
 });
 
 ipcMain.on('restartApp', () => {
-  app.relaunch();
+  shutdownCoordinator.scheduleRelaunch();
   // Closing the main window starts the shut down sequence
   mainWindow.close();
 });

--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -212,7 +212,7 @@ export class ApiClient {
     socket.on('data', (data: Buffer) => {
       chunks.push(data);
       if (data.toString().includes('\x0a')) {
-        socket.destroy();
+        socket.end();
         result = Buffer.concat(chunks as Uint8Array[]);
         done = true;
       }

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -393,14 +393,6 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
           return false;
         }
 
-        // RxJS Subscriber.unsubscribe null-dereference during React passive effect cleanup
-        // on app shutdown. This is a teardown race condition triggered by the test harness
-        // forcibly closing the app and is not indicative of a test failure.
-        if (process.platform === 'darwin' && record.match(/Cannot read properties of null \(reading 'closed'\)/)) {
-          ignoringErrors = true;
-          return false;
-        }
-
         const isError = !!record.match(/\[error\]/);
 
         if (isError) {

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -21,6 +21,7 @@ import {
 import { skipOnboarding } from '../modules/onboarding';
 import {
   clickButton,
+  clickIfDisplayed,
   closeWindow,
   focusChild,
   focusMain,
@@ -302,7 +303,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
 
     if (platform() === 'darwin') {
       // Select the "Continue" button on the macOS permissions page (MacPermissions.tsx), if it exists.
-      await clickButton('Continue');
+      await clickIfDisplayed('button=Continue');
     }
     // Pretty much all tests except for onboarding-specific
     // tests will want to skip this flow, so we do it automatically.

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -11,6 +11,7 @@ import fetch from 'node-fetch';
 
 import {
   ITestStats,
+  killChromedriverOnPort,
   killElectronInstances,
   removeFailedTestFromFile,
   saveFailedTestsToFile,
@@ -239,6 +240,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     if (options.networkLogging) appArgs.push('--network-logging');
     if (options.noSync) appArgs.push('--nosync');
 
+    killChromedriverOnPort(CHROMEDRIVER_PORT);
     await killElectronInstances();
 
     app = t.context.app = new Application({

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -183,6 +183,40 @@ export async function killElectronInstances() {
   tasks.forEach((task: any) => kill(task.pid));
 }
 
+export function killChromedriverOnPort(port: number) {
+  const { execSync } = require('child_process');
+
+  const p = Number(port);
+  if (!Number.isInteger(p) || p <= 0 || p > 65535) return;
+
+  try {
+    if (process.platform === 'win32') {
+      const output = execSync(`netstat -ano -p tcp | findstr LISTENING | findstr :${p}`).toString();
+      const pids = new Set<number>();
+      output.split('\n').forEach((line: string) => {
+        const parts = line.trim().split(/\s+/);
+        // Proto LocalAddress ForeignAddress State PID
+        if (parts.length >= 5 && parts[1].endsWith(`:${p}`) && parts[3] === 'LISTENING') {
+          const pid = parseInt(parts[4], 10);
+          if (Number.isFinite(pid)) pids.add(pid);
+        }
+      });
+      pids.forEach(pid => kill(pid));
+    } else {
+      const output = execSync(`lsof -nP -iTCP:${p} -sTCP:LISTEN -t`).toString().trim();
+      if (output) {
+        output
+          .split('\n')
+          .map((pidStr: string) => parseInt(pidStr, 10))
+          .filter((pid: number) => Number.isFinite(pid))
+          .forEach((pid: number) => kill(pid));
+      }
+    }
+  } catch (e: unknown) {
+    // Nothing is found
+  }
+}
+
 export async function waitForElectronInstancesExist() {
   const interval = 1000;
   const timeout = 10000;

--- a/test/regular/app-shutdown.ts
+++ b/test/regular/app-shutdown.ts
@@ -1,0 +1,185 @@
+import test from 'ava';
+import {
+  createShutdownCoordinator,
+  SHUTDOWN_ACK_TIMEOUT_MS,
+  SHUTDOWN_COMPLETE_TIMEOUT_MS,
+  SHUTDOWN_EXIT_TIMEOUT_MS,
+} from '../../app/util/shutdown-coordinator';
+
+type Timer = {
+  callback: () => void;
+  delay: number;
+  cleared: boolean;
+};
+
+function createHarness() {
+  const timers: Timer[] = [];
+  const forceReasons: string[] = [];
+  const logMessages: string[] = [];
+  const relaunchRequests: Array<string[] | undefined> = [];
+
+  const coordinator = createShutdownCoordinator({
+    setTimeoutFn(callback: () => void, delay: number) {
+      const timer = { callback, delay, cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeoutFn(timer: Timer) {
+      timer.cleared = true;
+    },
+    logger: {
+      log(...args: string[]) {
+        logMessages.push(args.join(' '));
+      },
+      warn(...args: string[]) {
+        logMessages.push(args.join(' '));
+      },
+    },
+    onForceShutdown(reason: string) {
+      forceReasons.push(reason);
+    },
+    onRelaunch(args?: string[]) {
+      relaunchRequests.push(args);
+    },
+  });
+
+  function fireTimer(delay: number) {
+    const timer = timers.find(timer => timer.delay === delay && !timer.cleared);
+    if (!timer) throw new Error(`No active timer for ${delay}ms`);
+    timer.callback();
+  }
+
+  return { coordinator, timers, forceReasons, logMessages, relaunchRequests, fireTimer };
+}
+
+test('Forces shutdown when the worker does not acknowledge shutdown', t => {
+  const { coordinator, timers, forceReasons, fireTimer } = createHarness();
+
+  coordinator.beginShutdown();
+
+  t.is(timers.length, 1);
+  t.is(timers[0].delay, SHUTDOWN_ACK_TIMEOUT_MS);
+
+  fireTimer(SHUTDOWN_ACK_TIMEOUT_MS);
+
+  t.deepEqual(forceReasons, ['worker did not acknowledge shutdown']);
+});
+
+test('Forces shutdown when the worker acknowledges shutdown but does not complete it', t => {
+  const { coordinator, timers, forceReasons, fireTimer } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.acknowledgeShutdown();
+
+  t.is(timers.length, 2);
+  t.true(timers[0].cleared);
+  t.is(timers[1].delay, SHUTDOWN_COMPLETE_TIMEOUT_MS);
+
+  fireTimer(SHUTDOWN_COMPLETE_TIMEOUT_MS);
+
+  t.deepEqual(forceReasons, ['worker acknowledged shutdown but did not complete']);
+});
+
+test('Starts a final exit watchdog when the worker completes shutdown', t => {
+  const { coordinator, timers, forceReasons } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.acknowledgeShutdown();
+  coordinator.completeShutdown();
+
+  t.true(timers[0].cleared);
+  t.true(timers[1].cleared);
+  t.is(timers[2].delay, SHUTDOWN_EXIT_TIMEOUT_MS);
+  t.false(timers[2].cleared);
+  t.deepEqual(forceReasons, []);
+});
+
+test('Forces shutdown when Electron does not exit after worker completion', t => {
+  const { coordinator, forceReasons, fireTimer } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.acknowledgeShutdown();
+  coordinator.completeShutdown();
+
+  fireTimer(SHUTDOWN_EXIT_TIMEOUT_MS);
+
+  t.deepEqual(forceReasons, ['worker completed shutdown but application did not exit']);
+});
+
+test('Clears the final exit watchdog when Electron reaches quit', t => {
+  const { coordinator, timers, forceReasons } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.acknowledgeShutdown();
+  coordinator.completeShutdown();
+
+  t.true(coordinator.finishShutdown());
+  t.true(timers[2].cleared);
+  t.deepEqual(forceReasons, []);
+});
+
+test('Does not extend the completion watchdog for duplicate acknowledgements', t => {
+  const { coordinator, timers } = createHarness();
+
+  coordinator.beginShutdown();
+  t.true(coordinator.acknowledgeShutdown());
+  const completionTimer = timers[1];
+
+  t.false(coordinator.acknowledgeShutdown());
+  t.is(timers.length, 2);
+  t.is(timers[1], completionTimer);
+  t.false(completionTimer.cleared);
+});
+
+test('Does not re-arm a watchdog for an acknowledgement after completion', t => {
+  const { coordinator, timers } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.completeShutdown();
+
+  t.false(coordinator.acknowledgeShutdown());
+  t.is(timers.length, 2);
+  t.is(timers[1].delay, SHUTDOWN_EXIT_TIMEOUT_MS);
+  t.false(timers[1].cleared);
+});
+
+test('Does not replace the final exit watchdog for duplicate completion', t => {
+  const { coordinator, timers } = createHarness();
+
+  coordinator.beginShutdown();
+  coordinator.acknowledgeShutdown();
+  t.true(coordinator.completeShutdown());
+  const exitTimer = timers[2];
+
+  t.false(coordinator.completeShutdown());
+  t.is(timers.length, 3);
+  t.is(timers[2], exitTimer);
+  t.false(exitTimer.cleared);
+});
+
+test('Schedules exactly one relaunch and preserves its arguments', t => {
+  const { coordinator, relaunchRequests } = createHarness();
+  const args = ['--skip-update', 'slobs://connect/account'];
+
+  t.true(coordinator.scheduleRelaunch(args));
+  t.false(coordinator.scheduleRelaunch(['slobs://ignored']));
+
+  t.deepEqual(relaunchRequests, [args]);
+});
+
+test('Scheduling a relaunch does not force or replace the active shutdown watchdog', t => {
+  const { coordinator, timers, forceReasons, relaunchRequests, fireTimer } = createHarness();
+
+  coordinator.beginShutdown();
+  const ackTimer = timers[0];
+  coordinator.scheduleRelaunch(['slobs://connect/account']);
+
+  t.is(timers[0], ackTimer);
+  t.false(ackTimer.cleared);
+  t.deepEqual(forceReasons, []);
+  t.deepEqual(relaunchRequests, [['slobs://connect/account']]);
+
+  fireTimer(SHUTDOWN_ACK_TIMEOUT_MS);
+
+  t.deepEqual(forceReasons, ['worker did not acknowledge shutdown']);
+});

--- a/test/regular/file-manager-shutdown.ts
+++ b/test/regular/file-manager-shutdown.ts
@@ -1,0 +1,139 @@
+import test from 'ava';
+import { FileManagerService } from '../../app/services/file-manager';
+
+interface ITestFile {
+  data: string;
+  locked: boolean;
+  version: number;
+  dirty: boolean;
+  flushWaiters?: Array<{
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }>;
+}
+
+interface IPendingWrite {
+  filePath: string;
+  data: string;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+const fileManagerPrototype = FileManagerService.prototype as any;
+
+function createFile(data = 'data'): ITestFile {
+  return { data, locked: false, version: 0, dirty: true };
+}
+
+function createControlledService(files: Dictionary<ITestFile>) {
+  const pendingWrites: IPendingWrite[] = [];
+  const service = {
+    files,
+    flush: fileManagerPrototype.flush,
+    waitForFlush: fileManagerPrototype.waitForFlush,
+    notifyFlushFinished: fileManagerPrototype.notifyFlushFinished,
+    writeFile(filePath: string, data: string) {
+      return new Promise<void>((resolve, reject) => {
+        pendingWrites.push({ filePath, data, resolve, reject });
+      });
+    },
+  };
+
+  return { service, pendingWrites };
+}
+
+async function waitUntil(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 20 && !predicate(); attempt += 1) {
+    await Promise.resolve();
+  }
+}
+
+test('Concurrent flushAll calls wait for the same in-flight write', async t => {
+  const file = createFile();
+  const { service, pendingWrites } = createControlledService({ file });
+
+  const firstFlush = fileManagerPrototype.flushAll.call(service) as Promise<void>;
+  const secondFlush = fileManagerPrototype.flushAll.call(service) as Promise<void>;
+
+  t.is(pendingWrites.length, 1);
+  t.is(file.flushWaiters!.length, 2);
+
+  pendingWrites[0].resolve();
+  await Promise.all([firstFlush, secondFlush]);
+
+  t.false(file.dirty);
+  t.false(file.locked);
+  t.is(file.flushWaiters!.length, 0);
+});
+
+test('File manager flushAll waits for rewrites and new files that race an in-flight flush', async t => {
+  const firstFile = createFile('first-v1');
+  const { service, pendingWrites } = createControlledService({ first: firstFile });
+  let settled = false;
+
+  const flushAll = (fileManagerPrototype.flushAll.call(service) as Promise<void>).then(() => {
+    settled = true;
+  });
+
+  t.deepEqual(
+    pendingWrites.map(write => [write.filePath, write.data]),
+    [['first', 'first-v1']],
+  );
+
+  firstFile.data = 'first-v2';
+  firstFile.version += 1;
+  firstFile.dirty = true;
+  service.flush('first');
+
+  const secondFile = createFile('second-v1');
+  service.files.second = secondFile;
+  service.flush('second');
+
+  pendingWrites[0].resolve();
+  await waitUntil(() => pendingWrites.length === 3);
+
+  t.deepEqual(
+    pendingWrites.map(write => [write.filePath, write.data]),
+    [
+      ['first', 'first-v1'],
+      ['second', 'second-v1'],
+      ['first', 'first-v2'],
+    ],
+  );
+  t.false(settled);
+
+  pendingWrites[2].resolve();
+  await waitUntil(() => secondFile.flushWaiters?.length === 1);
+  t.false(settled);
+
+  pendingWrites[1].resolve();
+  await flushAll;
+
+  t.true(settled);
+  t.false(firstFile.dirty);
+  t.false(secondFile.dirty);
+});
+
+test('File manager flushAll rejects after write retries are exhausted', async t => {
+  const file = createFile();
+  let attempts = 0;
+  const service = {
+    files: { file },
+    flush: fileManagerPrototype.flush,
+    waitForFlush: fileManagerPrototype.waitForFlush,
+    notifyFlushFinished: fileManagerPrototype.notifyFlushFinished,
+    async writeFile() {
+      attempts += 1;
+      throw new Error('disk full');
+    },
+  };
+
+  await t.throwsAsync(fileManagerPrototype.flushAll.call(service), {
+    message: /Failed to flush 1 file\(s\): file/,
+  });
+
+  t.is(attempts, 11);
+  t.true(file.dirty);
+  t.false(file.locked);
+  t.is(file.flushWaiters!.length, 0);
+});

--- a/test/regular/obs-importer.ts
+++ b/test/regular/obs-importer.ts
@@ -9,6 +9,7 @@ import { ExecutionContext } from 'ava';
 import {
   click,
   clickIfDisplayed,
+  clickWhenDisplayed,
   focusChild,
   focusMain,
   isDisplayed,
@@ -46,10 +47,12 @@ test('OBS Importer', async t => {
 
   const client = t.context.app.client;
 
-  if (!(await isDisplayed('h2=Live Streaming'))) return;
-  await click('h2=Live Streaming');
-  await click('button=Continue');
-  await click('button=Skip');
+  if (!(await isDisplayed('h1=Welcome to Streamlabs Desktop', { timeout: 15000 }))) {
+    t.fail('Onboarding welcome page not shown');
+    return;
+  }
+  await clickWhenDisplayed('a=Log In', { timeout: 15000 });
+  await waitForDisplayed('button=Twitch');
 
   await logIn(t, 'twitch', { prime: false }, false, true);
   await sleep(1000);

--- a/test/regular/onboarding.ts
+++ b/test/regular/onboarding.ts
@@ -22,7 +22,7 @@ import { ScenesService } from '../../app/services/api/external-api/scenes';
  * CASE 2: Old user logged in during onboarding, theme installed (Go through onboarding and install theme)
  * CASE 3: New user logged in during onboarding, no theme installed (Go through onboarding as a new user)
  * CASE 4: New user logged in during onboarding, theme installed (Go through onboarding as a new user and install theme)
- * CASE 5: No user logged in during onboarding, no theme installed, then log in new user (Login new user after onboarding skipped)
+ * CASE 5: New user, no theme installed, skip hardware config
  * CASE 6: No user logged in during onboarding, theme installed, then log in new user (Login new user after onboarding skipped and theme installed)
  * CASE 7: No user logged in during onboarding, no theme installed, then log in an old user (Scene-collections cloud-backup) <- tested in the cloud-backup test
  */
@@ -31,10 +31,24 @@ import { ScenesService } from '../../app/services/api/external-api/scenes';
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver({ skipOnboarding: false, noSync: true });
 
-async function confirmDefaultSources(t: TExecutionContext, hasDefaultSources = true) {
+enum HardwareConfigButtons {
+  Continue = 'Continue',
+  Skip = 'Skip',
+}
+
+enum DefaultSourcesCheck {
+  HasDefaultSources,
+  CheckOverlaySources,
+  NoDefaultSources,
+}
+
+async function confirmDefaultSources(
+  t: TExecutionContext,
+  defaultSourcesCheck = DefaultSourcesCheck.HasDefaultSources,
+) {
   const api = await getApiClient();
   const scenesService = api.getResource<ScenesService>('ScenesService');
-  const defaultSources = ['Game Capture', 'Webcam', 'Alert Box'];
+  const defaultSources = ['Webcam'];
   const numDefaultSources = defaultSources.length;
 
   const numSceneItems = scenesService.activeScene
@@ -50,22 +64,34 @@ async function confirmDefaultSources(t: TExecutionContext, hasDefaultSources = t
       return sources;
     }, {} as { [sourceId: string]: number });
 
-  if (hasDefaultSources) {
-    // confirm this is a single output scene collection by confirming that each source
-    // is only used by a single scene item. This is because dual output scene collection
-    // scene items share a single source.
-    for (const [sourceId, count] of Object.entries(numSceneItems)) {
-      t.is(count, 1, `Scene has only once scene item with source ${sourceId}`);
-    }
+  switch (defaultSourcesCheck) {
+    case DefaultSourcesCheck.HasDefaultSources:
+      // confirm this is a single output scene collection by confirming that each source
+      // is only used by a single scene item. This is because dual output scene collection
+      // scene items share a single source.
+      for (const [sourceId, count] of Object.entries(numSceneItems)) {
+        t.is(count, 1, `Scene has only once scene item with source ${sourceId}`);
+      }
 
-    t.is(Object.keys(numSceneItems).length, numDefaultSources, 'Scene has correct default sources');
-  } else {
-    // overlays installed during onboarding should have default sources more or less sources than the defaults
-    const numDefaultSources = Object.keys(numSceneItems).filter(
-      name => defaultSources.includes(name) && numSceneItems[name] > 1,
-    ).length;
+      t.is(
+        Object.keys(numSceneItems).length,
+        numDefaultSources,
+        'Scene has correct default sources',
+      );
+      break;
+    case DefaultSourcesCheck.CheckOverlaySources:
+      {
+        // overlays installed during onboarding should have default sources more or less sources than the defaults
+        const numDefaultSources = Object.keys(numSceneItems).filter(
+          name => defaultSources.includes(name) && numSceneItems[name] > 1,
+        ).length;
 
-    t.not(Object.keys(numSceneItems).length, numDefaultSources, 'Scene has no default sources');
+        t.not(Object.keys(numSceneItems).length, numDefaultSources, 'Scene has no default sources');
+      }
+      break;
+    case DefaultSourcesCheck.NoDefaultSources:
+      t.is(Object.keys(numSceneItems).length, 0, 'Scene should have no default sources');
+      break;
   }
 }
 
@@ -80,36 +106,37 @@ async function goThroughOnboarding(
   t: TExecutionContext,
   login = false,
   newUser = false,
-  installTheme = false,
   fn: () => Promise<void>,
 ) {
   await focusMain();
 
-  if (!(await isDisplayed('h2=Live Streaming'))) return;
-
-  await click('h2=Live Streaming');
-  await click('button=Continue');
-
-  await click('a=Login');
+  if (!(await isDisplayed('h1=Welcome to Streamlabs Desktop'))) {
+    t.fail('Onboarding welcome page not shown');
+    return;
+  }
+  await clickWhenDisplayed('a=Log In', { timeout: 5000 });
 
   // Complete login
   if (login) {
-    await isDisplayed('button=Log in with Twitch');
+    await isDisplayed('button=Twitch');
     const user = await logIn(t, 'twitch', { prime: false }, false, true, newUser);
     await sleep(1000);
 
     // We seem to skip the login step after login internally
     await clickIfDisplayed('button=Skip');
 
+    await waitForDisplayed('h1=Connect Platforms');
+    await clickIfDisplayed('button=Skip');
+
+    await waitForDisplayed('h1=Choose Your Plan');
+    await clickIfDisplayed('button=Skip');
     // Finish onboarding flow
     await withPoolUser(user, async () => {
-      await finishOnboarding(installTheme);
       await fn();
     });
   } else {
     // skip login
     await clickIfDisplayed('button=Skip');
-    await finishOnboarding(installTheme);
     await fn();
   }
 
@@ -120,23 +147,27 @@ async function goThroughOnboarding(
  * Helper function to go through the onboarding flow from the login step to the end
  * @param installTheme - Whether to install a theme during onboarding
  */
-async function finishOnboarding(installTheme = false) {
-  // Skip hardware config
-  await waitForDisplayed('h1=Set up your mic & webcam');
-  await clickIfDisplayed('button=Skip');
+async function finishOnboarding(
+  installTheme = false,
+  HardwareConfigButton: HardwareConfigButtons = HardwareConfigButtons.Continue,
+) {
+  await waitForDisplayed('h1=Set Up Your Mic & Webcam');
+  await clickIfDisplayed(`button=${HardwareConfigButton}`);
 
-  // Theme install
-  if (installTheme) {
-    await waitForDisplayed('h1=Add your first theme');
-    await clickWhenDisplayed('button=Install');
-    await waitForDisplayed('span=100%');
-  } else {
-    await waitForDisplayed('h1=Add your first theme');
-    await clickIfDisplayed('button=Skip');
+  if (HardwareConfigButton !== HardwareConfigButtons.Skip) {
+    // Theme install
+    if (installTheme) {
+      await waitForDisplayed('h1=Choose Your Overlay');
+      await clickWhenDisplayed(
+        '//div[contains(@class,"slick-active")]//button[normalize-space(.)="Install"]',
+        { timeout: 15000 },
+      );
+      await waitForDisplayed('span=100%');
+    } else {
+      await waitForDisplayed('h1=Choose Your Overlay');
+      await clickIfDisplayed('button=Skip');
+    }
   }
-
-  // Skip purchasing prime
-  await clickWhenDisplayed('div[data-testid=choose-free-plan-btn]', { timeout: 60000 });
 
   await isDisplayed('span=Sources');
 }
@@ -145,31 +176,38 @@ async function finishOnboarding(installTheme = false) {
 test('Go through onboarding', async t => {
   await focusMain();
 
-  if (!(await isDisplayed('h2=Live Streaming'))) return;
-
-  await click('h2=Live Streaming');
-  await click('button=Continue');
+  if (!(await isDisplayed('h1=Welcome to Streamlabs Desktop'))) {
+    t.fail('Onboarding welcome page not shown');
+    return;
+  }
+  // Click on Login on the signup page, then wait for the auth screen to appear
+  await clickWhenDisplayed('a=Log In', { timeout: 5000 });
 
   // Signup page
-  t.true(await isDisplayed('h1=Sign Up'), 'Shows signup page by default');
-  t.true(await isDisplayed('button=Create a Streamlabs ID'), 'Has a create Streamlabs ID button');
+  t.true(await isDisplayed('h1=Log In'), 'Shows login page by default');
+  t.true(
+    await isDisplayed('button*=Log in with Streamlabs ID'),
+    'Has a log in with Streamlabs ID button',
+  );
+  // "Or log in with a platform" is a <span>, not a <button>
+  t.true(
+    await isDisplayed('span=Or log in with a platform'),
+    'Has an "Or log in with a platform" label',
+  );
 
-  // Click on Login on the signup page, then wait for the auth screen to appear
-  await click('a=Login');
+  t.true(await isDisplayed('button=Twitch'), 'Shows Twitch button');
+  t.true(await isDisplayed('button=YouTube'), 'Shows YouTube button');
+  t.true(await isDisplayed('button=Facebook'), 'Shows Facebook button');
+  t.true(await isDisplayed('button=TikTok'), 'Shows TikTok button');
+  t.true(await isDisplayed('button=Instagram'), 'Shows Instagram button');
+  t.true(await isDisplayed('button=X'), 'Shows X (Twitter) button');
+  t.true(await isDisplayed('button=Kick'), 'Shows Kick button');
+  t.true(await isDisplayed('button=NimoTV'), 'Shows NimoTV button');
 
-  // Check for all the login buttons
-  t.true(await isDisplayed('button=Log in with Twitch'), 'Shows Twitch button');
-  t.true(await isDisplayed('button=Log in with YouTube'), 'Shows YouTube button');
-  t.true(await isDisplayed('button=Log in with Facebook'), 'Shows Facebook button');
-  t.true(await isDisplayed('button=Log in with TikTok'), 'Shows TikTok button');
-
-  // Check for all the login icons
-  t.true(await isDisplayed('[data-testid=platform-icon-button-nimotv]'), 'Shows NimoTV button');
-
-  t.true(await isDisplayed('a=Sign up'), 'Has a link to go back to Sign Up');
+  t.true(await isDisplayed('button=Back'), 'Has a link to go back to Sign Up');
 
   // Complete login
-  await isDisplayed('button=Log in with Twitch');
+  await waitForDisplayed('button=Twitch');
   const user = await logIn(t, 'twitch', { prime: false }, false, true);
   await sleep(1000);
   // We seem to skip the login step after login internally
@@ -177,16 +215,13 @@ test('Go through onboarding', async t => {
 
   // Finish onboarding flow
   await withPoolUser(user, async () => {
-    // Skip hardware config
-    await waitForDisplayed('h1=Set up your mic & webcam');
+    await waitForDisplayed('h1=Connect Platforms');
     await clickIfDisplayed('button=Skip');
 
-    // Skip picking a theme
-    await waitForDisplayed('h1=Add your first theme');
+    await waitForDisplayed('h1=Choose Your Plan');
     await clickIfDisplayed('button=Skip');
 
-    // Skip purchasing prime
-    await clickWhenDisplayed('div[data-testid=choose-free-plan-btn]', { timeout: 60000 });
+    await waitForDisplayed('h1=Set Up Your Mic & Webcam');
 
     t.true(await isDisplayed('span=Sources'), 'Sources selector is visible');
 
@@ -208,9 +243,8 @@ test('Go through onboarding', async t => {
 test.skip('Go through onboarding and install theme', async t => {
   const login = false;
   const newUser = true;
-  const installTheme = true;
 
-  await goThroughOnboarding(t, login, newUser, installTheme, async () => {
+  await goThroughOnboarding(t, login, newUser, async () => {
     // Confirm sources and dual output status
     t.not(await getNumElements('div[data-role=source]'), 0, 'Theme installed before login');
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled');
@@ -236,7 +270,8 @@ test('Go through onboarding as a new user', async t => {
   const newUser = true;
   const installTheme = false;
 
-  await goThroughOnboarding(t, login, newUser, installTheme, async () => {
+  await goThroughOnboarding(t, login, newUser, async () => {
+    await finishOnboarding(installTheme);
     // Confirm sources and dual output status
     await confirmDefaultSources(t);
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
@@ -251,33 +286,28 @@ test.skip('Go through onboarding as a new user and install theme', async t => {
   const login = true;
   const newUser = true;
   const installTheme = true;
-  const hasDefaultSources = false;
 
-  await goThroughOnboarding(t, login, newUser, installTheme, async () => {
+  await goThroughOnboarding(t, login, newUser, async () => {
+    await finishOnboarding(installTheme);
     // Confirm sources and dual output status
-    await confirmDefaultSources(t, hasDefaultSources);
+    await confirmDefaultSources(t, DefaultSourcesCheck.CheckOverlaySources);
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
 });
 
-// CASE 5: No user logged in during onboarding, no theme installed, then log in new user
+// CASE 5: New user, no theme installed, skip hardware config
 test('Login new user after onboarding skipped', async t => {
   const login = false;
   const newUser = false;
   const installTheme = false;
 
-  await goThroughOnboarding(t, login, newUser, installTheme, async () => {
-    // login new user after onboarding
-    await clickIfDisplayed('li[data-testid=nav-auth]');
-
-    await isDisplayed('button=Log in with Twitch');
-    await logIn(t, 'twitch', { prime: false }, false, false, true);
-    await sleep(1000);
+  await goThroughOnboarding(t, login, newUser, async () => {
+    await finishOnboarding(installTheme, HardwareConfigButtons.Skip);
 
     // Confirm switched to scene with default sources and dual output status
-    await confirmDefaultSources(t);
+    await confirmDefaultSources(t, DefaultSourcesCheck.NoDefaultSources);
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Dual output not enabled.');
   });
 

--- a/test/regular/worker-shutdown.ts
+++ b/test/regular/worker-shutdown.ts
@@ -1,0 +1,274 @@
+import test from 'ava';
+import {
+  executeImmediateShutdownSteps,
+  IShutdownLogger,
+  runWorkerShutdown,
+} from '../../app/util/worker-shutdown';
+
+const silentLogger: IShutdownLogger = {
+  log() {},
+  error() {},
+};
+
+test('Stops immediate ingress steps synchronously and reports failures', t => {
+  const order: string[] = [];
+
+  const report = executeImmediateShutdownSteps(
+    [
+      {
+        name: 'tcp',
+        criticality: 'required',
+        run: () => order.push('tcp'),
+      },
+      {
+        name: 'ipc',
+        criticality: 'required',
+        run: () => {
+          order.push('ipc');
+          throw new Error('ipc failed');
+        },
+      },
+    ],
+    { logger: silentLogger },
+  );
+
+  t.deepEqual(order, ['tcp', 'ipc']);
+  t.false(report.clean);
+  t.deepEqual(
+    report.failures.map(failure => failure.name),
+    ['ipc'],
+  );
+});
+
+test('Persists before teardown and best-effort work', async t => {
+  const order: string[] = [];
+  let releasePersistence: () => void;
+  const persistencePending = new Promise<void>(resolve => {
+    releasePersistence = resolve;
+  });
+
+  const shutdown = runWorkerShutdown(
+    {
+      persistence: [
+        {
+          name: 'persist',
+          criticality: 'required',
+          run: () => {
+            order.push('persist');
+            return persistencePending;
+          },
+        },
+        {
+          name: 'flush',
+          criticality: 'required',
+          run: () => order.push('flush'),
+        },
+      ],
+      teardown: [
+        {
+          name: 'teardown',
+          criticality: 'required',
+          run: () => order.push('teardown'),
+        },
+      ],
+      bestEffort: [
+        {
+          name: 'analytics',
+          criticality: 'best-effort',
+          run: () => order.push('analytics'),
+        },
+      ],
+    },
+    {
+      logger: silentLogger,
+      markClean: () => order.push('clean'),
+      onComplete: () => order.push('complete'),
+    },
+  );
+
+  await Promise.resolve();
+  t.deepEqual(order, ['persist']);
+
+  releasePersistence!();
+  const report = await shutdown;
+
+  t.true(report.clean);
+  t.deepEqual(order, ['persist', 'flush', 'teardown', 'analytics', 'clean', 'complete']);
+});
+
+test('Required failure runs remaining phases but does not mark a clean exit', async t => {
+  const order: string[] = [];
+  let completedReportClean: boolean | undefined;
+
+  const report = await runWorkerShutdown(
+    {
+      persistence: [
+        {
+          name: 'persist',
+          criticality: 'required',
+          run: () => {
+            order.push('persist');
+            throw new Error('disk failure');
+          },
+        },
+        {
+          name: 'flush',
+          criticality: 'required',
+          run: () => order.push('flush'),
+        },
+      ],
+      teardown: [
+        {
+          name: 'teardown',
+          criticality: 'required',
+          run: () => order.push('teardown'),
+        },
+      ],
+      bestEffort: [
+        {
+          name: 'analytics',
+          criticality: 'best-effort',
+          run: () => order.push('analytics'),
+        },
+      ],
+    },
+    {
+      logger: silentLogger,
+      markClean: () => order.push('clean'),
+      onComplete: completedReport => {
+        order.push('complete');
+        completedReportClean = completedReport.clean;
+      },
+    },
+  );
+
+  t.false(report.clean);
+  t.false(completedReportClean);
+  t.deepEqual(order, ['persist', 'flush', 'teardown', 'analytics', 'complete']);
+  t.deepEqual(
+    report.failures.map(failure => failure.name),
+    ['persist'],
+  );
+});
+
+test('Required immediate failure prevents a clean-exit marker', async t => {
+  let markedClean = false;
+  let completionCount = 0;
+  const initialReport = executeImmediateShutdownSteps(
+    [
+      {
+        name: 'ingress',
+        criticality: 'required',
+        run() {
+          throw new Error('could not stop ingress');
+        },
+      },
+    ],
+    { logger: silentLogger },
+  );
+
+  const report = await runWorkerShutdown(
+    { persistence: [], teardown: [], bestEffort: [] },
+    {
+      initialReport,
+      logger: silentLogger,
+      markClean() {
+        markedClean = true;
+      },
+      onComplete() {
+        completionCount += 1;
+      },
+    },
+  );
+
+  t.false(report.clean);
+  t.false(markedClean);
+  t.is(completionCount, 1);
+  t.deepEqual(
+    report.failures.map(failure => failure.name),
+    ['ingress'],
+  );
+});
+
+test('Times out and aborts best-effort work without making shutdown unclean', async t => {
+  let timerCallback: () => void;
+  let timerDelay = 0;
+  let receivedSignal: AbortSignal | undefined;
+  let markedClean = false;
+  let completionCount = 0;
+
+  const shutdown = runWorkerShutdown(
+    {
+      persistence: [],
+      teardown: [],
+      bestEffort: [
+        {
+          name: 'analytics',
+          criticality: 'best-effort',
+          timeoutMs: 3000,
+          run: signal => {
+            receivedSignal = signal;
+            return new Promise<void>((resolve, reject) => {
+              signal!.addEventListener('abort', () => reject(new Error('aborted')));
+            });
+          },
+        },
+      ],
+    },
+    {
+      logger: silentLogger,
+      setTimeoutFn(callback, delay) {
+        timerCallback = callback;
+        timerDelay = delay;
+        return callback;
+      },
+      clearTimeoutFn() {},
+      markClean() {
+        markedClean = true;
+      },
+      onComplete() {
+        completionCount += 1;
+      },
+    },
+  );
+
+  for (let i = 0; i < 4 && !receivedSignal; i++) await Promise.resolve();
+  t.is(timerDelay, 3000);
+  t.false(receivedSignal!.aborted);
+
+  timerCallback!();
+  const report = await shutdown;
+
+  t.true(receivedSignal!.aborted);
+  t.true(report.clean);
+  t.true(markedClean);
+  t.is(completionCount, 1);
+  t.deepEqual(
+    report.failures.map(failure => failure.name),
+    ['analytics'],
+  );
+});
+
+test('Clean-exit marker failure is reported and completion still runs', async t => {
+  let completionCount = 0;
+
+  const report = await runWorkerShutdown(
+    { persistence: [], teardown: [], bestEffort: [] },
+    {
+      logger: silentLogger,
+      markClean() {
+        throw new Error('state file failure');
+      },
+      onComplete() {
+        completionCount += 1;
+      },
+    },
+  );
+
+  t.false(report.clean);
+  t.is(completionCount, 1);
+  t.deepEqual(
+    report.failures.map(failure => failure.name),
+    ['CrashReporterService.endShutdown'],
+  );
+});


### PR DESCRIPTION
* Resolved merge conflicts after running `git cherry-pick` 352d44654 and fixed test to work
* removed dlive button test (this UI element was removed in branch)
* This command now completes successfully: `yarn test:file test-dist/test/regular/onboarding.js` on both platforms.
* onboarding.ts - fix false positive by removing the invalid early return.
* run `git cherry-pick` 03d2bff to get shutdown-watchdog (proper shutdown after each test)
* run `git cherry-pick` 20c47b3f5 to get the 'Kill ChromeDriver port' and a MacOS test fix

Below is React errors in which I enlisted Claude to assist with:
Six components returned `sub.unsubscribe` directly as their useEffect
cleanup. React invokes cleanups as bare function calls, so the method
was detached from its Subscriber and reading `this.closed` threw:

  Uncaught TypeError: Cannot read properties of null (reading 'closed')
      at Subscriber.unsubscribe
      at flushPassiveEffectsImpl

Because unsubscribe() threw before doing any work, these subscriptions
were never actually torn down either. Return `() => sub.unsubscribe()`
so the call keeps its receiver.

Affected: Themes, Ultra, MacPermissions, EditTransform,
PlatformAppPopOut, Troubleshooter.

Also add the two missing `key` props in Themes.tsx -- on the PreviewCard
carousel children, and on the thumbnail column inside PreviewCard. Both
were logging "Each child in a list should have a unique key prop" at
error level, which fails the log check.

Remove the darwin-gated filter for this error from the webdriver log
check. It was hiding the bug above on macOS, and because it set
`ignoringErrors = true` it also swallowed every subsequent error record
until the next non-error line, masking unrelated failures.

## Regression Tests for QA

* Onboarding flow still works
* Scene Saving should work on app close
