### PR TITLE
[WIP] Add logging for non-bug-related test failures in automated tests.

### DIFF
--- a/test/helpers/runner.js
+++ b/test/helpers/runner.js
@@ -105,13 +105,13 @@ function readTestStats() {
  * @returns - An object with the test failure details
  */
 function readFailureReason() {
-  let failures = {};
   try {
-    failures = JSON.parse(fs.readFileSync(failureReasonsFile, 'utf8'));
+    const failures = JSON.parse(fs.readFileSync(failureReasonsFile, 'utf8'));
+    return { tests: failures?.tests || {}, job: failures?.job || [] };
   } catch (e) {
-    failures = {};
+    console.error('Failed to read the failure reasons file', e);
+    return { tests: {}, job: [] };
   }
-  return { tests: failures.tests || {}, job: failures.job || [] };
 }
 
 async function sendJobToAnalytics(failedTests) {

--- a/test/helpers/runner.js
+++ b/test/helpers/runner.js
@@ -13,6 +13,7 @@ const fetch = require('node-fetch');
 
 const failedTestsFile = 'test-dist/failed-tests.json';
 const testStatsFile = 'test-dist/test-stats.json';
+const accountFailuresFile = 'test-dist/account-failures.json';
 const args = process.argv.slice(2);
 const TIMEOUT = 3; // timeout in minutes
 const {
@@ -24,6 +25,16 @@ const {
   BUILD_DEFINITIONNAME,
   SLOBS_TEST_RUN_CHUNK,
 } = process.env;
+
+// Order the account failure errors from highest to lowest severity
+const ACCOUNT_FAILURE_SEVERITY = [
+  'NO_ACCOUNT_AVAILABLE',
+  'HEROKU_ANALYTICS_SEND_FAILED',
+  'YOUTUBE_ACCOUNT_FAILURE',
+  'YOUTUBE_ACCOUNT_RATE_LIMITED',
+  'YOUTUBE_STREAMING_DISABLED',
+];
+
 let retryingFailed = false;
 
 const RUN_TESTS_CMD = !args.length ? `yarn test --timeout=${TIMEOUT}m ` : args.join(' ') + ' ';
@@ -33,6 +44,7 @@ const RUN_TESTS_CMD = !args.length ? `yarn test --timeout=${TIMEOUT}m ` : args.j
   try {
     rimraf.sync(failedTestsFile);
     rimraf.sync(testStatsFile);
+    rimraf.sync(accountFailuresFile);
     await createTestTimingsFile();
     execSync(RUN_TESTS_CMD, { stdio: [0, 1, 2] });
   } catch (e) {
@@ -94,13 +106,46 @@ function readTestStats() {
   return stats;
 }
 
+/**
+ * Read recorded failures from user pool account failure reasons
+ * @remark Test failures may occur because of the user pool account instead of from a bug,
+ * which creates a false failure.
+ * - `tests` is keyed by test name and written by the test harness, `job` holds reasons
+ * - that belong to the run as a whole and is written here. See IAccountFailures.
+ * @returns - An object with the test failure details
+ */
+function readAccountFailures() {
+  let failures = {};
+  try {
+    failures = JSON.parse(fs.readFileSync(accountFailuresFile, 'utf8'));
+  } catch (e) {
+    failures = {};
+  }
+  return { tests: failures.tests || {}, job: failures.job || [] };
+}
+
+/**
+ * Roll the per-test and job-wide reasons up into a single reason for the job.
+ * A pool with no free accounts affects the whole run, so it wins over an account
+ * that just couldn't go live on YouTube.
+ */
+function getJobAccountFailure(testsToSend, jobReasons) {
+  const reasons = jobReasons.concat(
+    testsToSend.map(test => test.accountFailure).filter(reason => reason),
+  );
+  if (!reasons.length) return null;
+  return ACCOUNT_FAILURE_SEVERITY.find(reason => reasons.includes(reason)) || reasons[0];
+}
+
 async function sendJobToAnalytics(failedTests) {
   if (!BUILD_BUILDID) return; // do not send analytics for local builds
 
   const failedAfterRetryTests = getFailedTests();
+  const accountFailures = readAccountFailures();
   const testsToSend = failedTests.map(testName => ({
     name: testName,
     retrySucceeded: !failedAfterRetryTests.includes(testName),
+    accountFailure: accountFailures.tests[testName] || null,
   }));
   log('Sending analytics..');
   const body = {
@@ -114,12 +159,30 @@ async function sendJobToAnalytics(failedTests) {
     branch: BUILD_SOURCEBRANCH,
     slice: SLOBS_TEST_RUN_CHUNK,
     stats: readTestStats(),
+    accountFailure: getJobAccountFailure(testsToSend, accountFailures.job),
   };
   log(body);
   try {
     await requestUtilityServer('job', 'post', body);
   } catch (e) {
     console.error('failed to send analytics', e);
+    saveJobAccountFailure('HEROKU_ANALYTICS_SEND_FAILED');
+  }
+}
+
+/**
+ * The body never reached the server, so nothing in it was recorded - including the
+ * accountFailure we just worked out. Append the reason to the account failures file so the
+ * lost job is visible on the agent rather than only in the console. Reasons accumulate
+ * rather than overwrite, so an earlier one isn't lost behind a later one.
+ */
+function saveJobAccountFailure(reason) {
+  const failures = readAccountFailures();
+  failures.job.push(reason);
+  try {
+    fs.writeFileSync(accountFailuresFile, JSON.stringify(failures));
+  } catch (e) {
+    console.error('failed to record the account failure', e);
   }
 }
 

--- a/test/helpers/runner.js
+++ b/test/helpers/runner.js
@@ -13,7 +13,7 @@ const fetch = require('node-fetch');
 
 const failedTestsFile = 'test-dist/failed-tests.json';
 const testStatsFile = 'test-dist/test-stats.json';
-const accountFailuresFile = 'test-dist/account-failures.json';
+const failureReasonsFile = 'test-dist/failure-reasons.json';
 const args = process.argv.slice(2);
 const TIMEOUT = 3; // timeout in minutes
 const {
@@ -35,7 +35,7 @@ const RUN_TESTS_CMD = !args.length ? `yarn test --timeout=${TIMEOUT}m ` : args.j
   try {
     rimraf.sync(failedTestsFile);
     rimraf.sync(testStatsFile);
-    rimraf.sync(accountFailuresFile);
+    rimraf.sync(failureReasonsFile);
     await createTestTimingsFile();
     execSync(RUN_TESTS_CMD, { stdio: [0, 1, 2] });
   } catch (e) {
@@ -98,17 +98,16 @@ function readTestStats() {
 }
 
 /**
- * Read recorded failures from user pool account failure reasons
- * @remark Test failures may occur because of the user pool account instead of from a bug,
- * which creates a false failure.
+ * Read recorded failures reasons
+ * @remark Test failures may occur because of reasons other than bugs, such as the user pool account
  * - `tests` is keyed by test name and written by the test harness, `job` holds reasons
- * - that belong to the run as a whole and is written here. See IAccountFailures.
+ * - that belong to the run as a whole and is written here. See IFailureReasons.
  * @returns - An object with the test failure details
  */
-function readAccountFailures() {
+function readFailureReason() {
   let failures = {};
   try {
-    failures = JSON.parse(fs.readFileSync(accountFailuresFile, 'utf8'));
+    failures = JSON.parse(fs.readFileSync(failureReasonsFile, 'utf8'));
   } catch (e) {
     failures = {};
   }
@@ -119,15 +118,19 @@ async function sendJobToAnalytics(failedTests) {
   if (!BUILD_BUILDID) return; // do not send analytics for local builds
 
   const failedAfterRetryTests = getFailedTests();
-  const accountFailures = readAccountFailures();
-  const testsToSend = failedTests.map(testName => ({
-    name: testName,
-    retrySucceeded: !failedAfterRetryTests.includes(testName),
-    accountFailure:
-      !failedAfterRetryTests.includes(testName) && accountFailures.tests[testName]
-        ? accountFailures.tests[testName]
-        : undefined,
-  }));
+  const failureReasons = readFailureReason();
+  const testsToSend = failedTests.map(testName => {
+    const failureLog = {
+      name: testName,
+      retrySucceeded: !failedAfterRetryTests.includes(testName),
+    };
+
+    if (!failureLog.retrySucceeded && failureReasons.tests[testName]) {
+      failureLog.failureReason = failureReasons.tests[testName];
+    }
+
+    return failureLog;
+  });
   log('Sending analytics..');
   const body = {
     name: SYSTEM_JOBNAME,
@@ -146,22 +149,6 @@ async function sendJobToAnalytics(failedTests) {
     await requestUtilityServer('job', 'post', body);
   } catch (e) {
     console.error('failed to send analytics', e);
-  }
-}
-
-/**
- * The body never reached the server, so nothing in it was recorded - including the
- * accountFailure we just worked out. Append the reason to the account failures file so the
- * lost job is visible on the agent rather than only in the console. Reasons accumulate
- * rather than overwrite, so an earlier one isn't lost behind a later one.
- */
-function saveJobAccountFailure(reason) {
-  const failures = readAccountFailures();
-  failures.job.push(reason);
-  try {
-    fs.writeFileSync(accountFailuresFile, JSON.stringify(failures));
-  } catch (e) {
-    console.error('failed to record the account failure', e);
   }
 }
 

--- a/test/helpers/runner.js
+++ b/test/helpers/runner.js
@@ -26,15 +26,6 @@ const {
   SLOBS_TEST_RUN_CHUNK,
 } = process.env;
 
-// Order the account failure errors from highest to lowest severity
-const ACCOUNT_FAILURE_SEVERITY = [
-  'NO_ACCOUNT_AVAILABLE',
-  'HEROKU_ANALYTICS_SEND_FAILED',
-  'YOUTUBE_ACCOUNT_FAILURE',
-  'YOUTUBE_ACCOUNT_RATE_LIMITED',
-  'YOUTUBE_STREAMING_DISABLED',
-];
-
 let retryingFailed = false;
 
 const RUN_TESTS_CMD = !args.length ? `yarn test --timeout=${TIMEOUT}m ` : args.join(' ') + ' ';
@@ -124,19 +115,6 @@ function readAccountFailures() {
   return { tests: failures.tests || {}, job: failures.job || [] };
 }
 
-/**
- * Roll the per-test and job-wide reasons up into a single reason for the job.
- * A pool with no free accounts affects the whole run, so it wins over an account
- * that just couldn't go live on YouTube.
- */
-function getJobAccountFailure(testsToSend, jobReasons) {
-  const reasons = jobReasons.concat(
-    testsToSend.map(test => test.accountFailure).filter(reason => reason),
-  );
-  if (!reasons.length) return null;
-  return ACCOUNT_FAILURE_SEVERITY.find(reason => reasons.includes(reason)) || reasons[0];
-}
-
 async function sendJobToAnalytics(failedTests) {
   if (!BUILD_BUILDID) return; // do not send analytics for local builds
 
@@ -145,7 +123,10 @@ async function sendJobToAnalytics(failedTests) {
   const testsToSend = failedTests.map(testName => ({
     name: testName,
     retrySucceeded: !failedAfterRetryTests.includes(testName),
-    accountFailure: accountFailures.tests[testName] || null,
+    accountFailure:
+      !failedAfterRetryTests.includes(testName) && accountFailures.tests[testName]
+        ? accountFailures.tests[testName]
+        : undefined,
   }));
   log('Sending analytics..');
   const body = {
@@ -159,14 +140,12 @@ async function sendJobToAnalytics(failedTests) {
     branch: BUILD_SOURCEBRANCH,
     slice: SLOBS_TEST_RUN_CHUNK,
     stats: readTestStats(),
-    accountFailure: getJobAccountFailure(testsToSend, accountFailures.job),
   };
   log(body);
   try {
     await requestUtilityServer('job', 'post', body);
   } catch (e) {
     console.error('failed to send analytics', e);
-    saveJobAccountFailure('HEROKU_ANALYTICS_SEND_FAILED');
   }
 }
 

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -619,7 +619,9 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     return null;
   }
 
-  function detectAccountFailure(reason: TFailureReason): boolean {
+  function detectAccountFailure(reason?: TFailureReason): boolean {
+    if (!reason) return false;
+
     return (
       reason === 'NO_ACCOUNT_AVAILABLE' ||
       reason === 'YOUTUBE_STREAMING_DISABLED' ||

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -597,7 +597,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
       return 'YOUTUBE_ACCOUNT_FAILURE';
     }
 
-    return null;
+    return 'ACCOUNT_FAILURE';
   }
 
   /**

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -3,7 +3,7 @@
 import { ExecutionContext } from 'ava';
 import { getApiClient } from '../api-client';
 import { DismissablesService } from 'services/dismissables';
-import { getUser, logOut } from './user';
+import { getUser, logOut, resetUserPoolExhausted, userPoolIsExhausted } from './user';
 import { sleep } from '../sleep';
 import { remote, RemoteOptions } from 'webdriverio';
 import * as ChildProcess from 'child_process';
@@ -13,8 +13,10 @@ import {
   ITestStats,
   killElectronInstances,
   removeFailedTestFromFile,
+  saveAccountFailureToFile,
   saveFailedTestsToFile,
   saveTestStatsToFile,
+  TAccountFailure,
   testFn,
   waitForElectronInstancesExist,
 } from './runner-utils';
@@ -34,6 +36,7 @@ export const test = testFn; // the overridden "test" function
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const util = require('util');
 const rimraf = require('rimraf');
 
 const ALMOST_INFINITY = Math.pow(2, 31) - 1; // max 32bit int
@@ -44,6 +47,11 @@ const CHROMEDRIVER_PORT = 4444;
 // Enable Chromedriver logging to chromedriver.log
 // Enable Webdriver logging to test output
 const CHROMEDRIVER_DEBUG = false;
+
+// YouTube API logs the `reason`, which is the most reliable signal that YouTube rejected the account rather than that we have a bug
+const YOUTUBE_STREAMING_DISABLED_IN_LOG = /liveStreamingNotEnabled|YOUTUBE_STREAMING_DISABLED|YouTube account is not enabled for live streaming/;
+const YOUTUBE_RATE_LIMITED_IN_LOG = /userRequestsExceedRateLimit|User requests exceed the rate limit/;
+const YOUTUBE_ACCOUNT_FAILURE_IN_LOG = /YOUTUBE_TOKEN_EXPIRED|YouTube token has expired|Error validating YouTube platform/;
 
 const testStats: Record<string, ITestStats> = {};
 
@@ -213,6 +221,63 @@ export async function debugPause() {
   await new Promise(() => {});
 }
 
+/**
+ * For more specific logging of errors, attempt to parse errors into readable strings
+ * @param e - The error that was thrown
+ * @returns - A string representation of the error
+ */
+function parseErrorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  if (e && typeof e === 'object' && typeof (e as { message?: unknown }).message === 'string') {
+    return (e as { message: string }).message;
+  }
+  // Unlike `JSON.stringify`, util.inspect handles cycles and always returns a string.
+  // This matches how the app itself serializes unknown values into the log
+  return util.inspect(e);
+}
+
+/**
+ * Identify the reason for a shutdown failure
+ * @remark Shutdown can fail for several unrelated reasons. Specify the reason for the failure
+ * for improved logging and debugging.
+ * @param e - The error that was thrown during shutdown
+ */
+function formatShutdownError(e: unknown): string {
+  const message = parseErrorMessage(e);
+
+  // waitForElectronInstancesExist() gave up: the app is still running
+  if (message.match(/Timed out waiting for Electron instances to exit/)) {
+    return `The app did not exit within the shutdown timeout: ${message}`;
+  }
+
+  // chromedriver no longer has a session, which means the app already went away
+  if (message.match(/invalid session id|no such session|session deleted|session not created/i)) {
+    return `The app exited before shutdown, the webdriver session is gone: ${message}`;
+  }
+
+  // the window we asked to close isn't there anymore
+  if (message.match(/no such window|target window already closed|window was already closed/i)) {
+    return `The window disappeared before shutdown completed: ${message}`;
+  }
+
+  // we lost the connection to the app's api server or to chromedriver
+  if (
+    message.match(
+      /ECONNREFUSED|ECONNRESET|EPIPE|socket hang up|Socket is not writeable|not reachable/i,
+    )
+  ) {
+    return `Lost the connection to the app during shutdown: ${message}`;
+  }
+
+  // closeWindow() or an api call hung
+  if (message.match(/timeout|timed out/i)) {
+    return `Shutdown timed out: ${message}`;
+  }
+
+  return `Crash on shutdown: ${message}`;
+}
+
 export function useWebdriver(options: ITestRunnerOptions = {}) {
   // tslint:disable-next-line:no-parameter-reassignment TODO
   options = Object.assign({}, DEFAULT_OPTIONS, options);
@@ -224,6 +289,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
   let logFileLastReadingPos = 0;
   let lastCacheDir: string;
   let lastLogs: string;
+  let logsFromCurrentTest = '';
 
   startAppFn = async function startApp(
     t: TExecutionContext,
@@ -332,7 +398,8 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
 
       await app.stop();
     } catch (e: unknown) {
-      fail('Crash on shutdown');
+      const shutdownError = formatShutdownError(e);
+      fail(shutdownError);
       console.error(e);
     }
     await killElectronInstances();
@@ -357,6 +424,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     const logs: string = await readLogs();
     if (!logs) return;
     lastLogs = logs;
+    logsFromCurrentTest += logs.slice(logFileLastReadingPos);
     let ignoringErrors = false;
     const errors = logs
       .slice(logFileLastReadingPos)
@@ -389,7 +457,10 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
         // RxJS Subscriber.unsubscribe null-dereference during React passive effect cleanup
         // on app shutdown. This is a teardown race condition triggered by the test harness
         // forcibly closing the app and is not indicative of a test failure.
-        if (process.platform === 'darwin' && record.match(/Cannot read properties of null \(reading 'closed'\)/)) {
+        if (
+          process.platform === 'darwin' &&
+          record.match(/Cannot read properties of null \(reading 'closed'\)/)
+        ) {
           ignoringErrors = true;
           return false;
         }
@@ -424,6 +495,8 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     testName = t.title.replace('beforeEach hook for ', '');
     testPassed = false;
     skipCheckingErrorsInLogFlag = false;
+    logsFromCurrentTest = '';
+    resetUserPoolExhausted();
 
     t.context.app = app;
     setContext(t);
@@ -478,8 +551,18 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
       };
     } else {
       fail();
+
       const user = getUser();
-      if (user) console.log(`Test failed for the account: ${user.type} ${user.email}`);
+      if (user) {
+        console.log(`Test failed for the account: ${user.type} ${user.email}`);
+      }
+
+      const accountFailure = detectAccountFailure();
+      if (accountFailure) {
+        console.log(`Test failed because of account failure: ${accountFailure}`);
+        saveAccountFailureToFile(testName, accountFailure);
+      }
+
       t.fail(failMsg);
     }
   });
@@ -489,6 +572,33 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     if (!testPassed) saveFailedTestsToFile([testName]);
     await saveTestStatsToFile(testStats);
   });
+
+  /**
+   * Explicitly identify if the test failed because of the account instead of the app.
+   * This is important because it indicates that the test failure is not a bug in the app.
+   * @returns - The type for the account reason the test failed
+   */
+  function detectAccountFailure(): TAccountFailure {
+    const noAccountAvailable = userPoolIsExhausted();
+
+    if (noAccountAvailable) {
+      return 'NO_ACCOUNT_AVAILABLE';
+    }
+
+    if (logsFromCurrentTest.match(YOUTUBE_STREAMING_DISABLED_IN_LOG)) {
+      return 'YOUTUBE_STREAMING_DISABLED';
+    }
+
+    if (logsFromCurrentTest.match(YOUTUBE_RATE_LIMITED_IN_LOG)) {
+      return 'YOUTUBE_ACCOUNT_RATE_LIMITED';
+    }
+
+    if (logsFromCurrentTest.match(YOUTUBE_ACCOUNT_FAILURE_IN_LOG)) {
+      return 'YOUTUBE_ACCOUNT_FAILURE';
+    }
+
+    return null;
+  }
 
   /**
    * mark tests as failed

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -13,10 +13,10 @@ import {
   ITestStats,
   killElectronInstances,
   removeFailedTestFromFile,
-  saveAccountFailureToFile,
+  saveFailureReasonToFile,
   saveFailedTestsToFile,
   saveTestStatsToFile,
-  TAccountFailure,
+  TFailureReason,
   testFn,
   waitForElectronInstancesExist,
 } from './runner-utils';
@@ -47,6 +47,12 @@ const CHROMEDRIVER_PORT = 4444;
 // Enable Chromedriver logging to chromedriver.log
 // Enable Webdriver logging to test output
 const CHROMEDRIVER_DEBUG = false;
+
+// Failures that are frequently not related to bugs in the app
+const MISSING_TRANSLATIONS_IN_LOG = /Missing translation/;
+const UNMOUNTED_REACT_UPDATE_IN_LOG = /Tried to update component state before component has been mounted\./;
+const NO_ACCOUNT_AVAILABLE_IN_LOG = /No users available/;
+const UTILITY_SERVER_FAILURE_IN_LOG = /Unable to request the utility server/;
 
 // YouTube API logs the `reason`, which is the most reliable signal that YouTube rejected the account rather than that we have a bug
 const YOUTUBE_STREAMING_DISABLED_IN_LOG = /liveStreamingNotEnabled|YOUTUBE_STREAMING_DISABLED|YouTube account is not enabled for live streaming/;
@@ -557,11 +563,11 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
         console.log(`Test failed for the account: ${user.type} ${user.email}`);
       }
 
-      const accountFailure = detectAccountFailure();
-      if (accountFailure) {
-        console.log(`Test failed because of account failure: ${accountFailure}`);
-        saveAccountFailureToFile(testName, accountFailure);
+      const failureReason = detectFailureReason();
+      if (detectAccountFailure(failureReason)) {
+        console.log(`Test failed because of failure reason: ${failureReason}`);
       }
+      saveFailureReasonToFile(testName, failureReason);
 
       t.fail(failMsg);
     }
@@ -574,14 +580,23 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
   });
 
   /**
-   * Explicitly identify if the test failed because of the account instead of the app.
+   * Explicitly identify if the test failed because of a frequently identified non-bug reason.
    * This is important because it indicates that the test failure is not a bug in the app.
-   * @returns - The type for the account reason the test failed
+   * @returns - The type for the reason the test failed
    */
-  function detectAccountFailure(): TAccountFailure {
+  function detectFailureReason(): TFailureReason | null {
+    // Check for known app-related failures frequently not related to bugs
+    if (logsFromCurrentTest.match(MISSING_TRANSLATIONS_IN_LOG)) {
+      return 'MISSING_TRANSLATIONS';
+    }
+
+    if (logsFromCurrentTest.match(UNMOUNTED_REACT_UPDATE_IN_LOG)) {
+      return 'UNMOUNTED_REACT_UPDATE';
+    }
+
     const noAccountAvailable = userPoolIsExhausted();
 
-    if (noAccountAvailable) {
+    if (noAccountAvailable || logsFromCurrentTest.match(NO_ACCOUNT_AVAILABLE_IN_LOG)) {
       return 'NO_ACCOUNT_AVAILABLE';
     }
 
@@ -597,7 +612,20 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
       return 'YOUTUBE_ACCOUNT_FAILURE';
     }
 
-    return 'ACCOUNT_FAILURE';
+    if (logsFromCurrentTest.match(UTILITY_SERVER_FAILURE_IN_LOG)) {
+      return 'UTILITY_SERVER_FAILURE';
+    }
+
+    return null;
+  }
+
+  function detectAccountFailure(reason: TFailureReason): boolean {
+    return (
+      reason === 'NO_ACCOUNT_AVAILABLE' ||
+      reason === 'YOUTUBE_STREAMING_DISABLED' ||
+      reason === 'YOUTUBE_ACCOUNT_RATE_LIMITED' ||
+      reason === 'YOUTUBE_ACCOUNT_FAILURE'
+    );
   }
 
   /**

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -28,14 +28,13 @@ export interface IAccountFailures {
 
 /**
  * Reasons a test failed because of the account it was given, rather than because of a bug.
- * HEROKU_ANALYTICS_SEND_FAILED is job-wide and written by the runner, not by a test.
  */
 export type TAccountFailure =
   | 'NO_ACCOUNT_AVAILABLE'
   | 'YOUTUBE_STREAMING_DISABLED'
   | 'YOUTUBE_ACCOUNT_RATE_LIMITED'
   | 'YOUTUBE_ACCOUNT_FAILURE'
-  | 'HEROKU_ANALYTICS_SEND_FAILED';
+  | 'ACCOUNT_FAILURE';
 
 const {
   BUILD_BUILDID,

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -16,6 +16,27 @@ export interface ITestStats {
   syncIPCCalls: number;
 }
 
+/**
+ * Contents of ACCOUNT_FAILURES_PATH
+ *  - `tests` is keyed by test name.
+ *  - `job` holds reasons that belong to the run as a whole and is written by the runner.
+ */
+export interface IAccountFailures {
+  tests: Record<string, TAccountFailure>;
+  job: TAccountFailure[];
+}
+
+/**
+ * Reasons a test failed because of the account it was given, rather than because of a bug.
+ * HEROKU_ANALYTICS_SEND_FAILED is job-wide and written by the runner, not by a test.
+ */
+export type TAccountFailure =
+  | 'NO_ACCOUNT_AVAILABLE'
+  | 'YOUTUBE_STREAMING_DISABLED'
+  | 'YOUTUBE_ACCOUNT_RATE_LIMITED'
+  | 'YOUTUBE_ACCOUNT_FAILURE'
+  | 'HEROKU_ANALYTICS_SEND_FAILED';
+
 const {
   BUILD_BUILDID,
   SYSTEM_JOBID,
@@ -31,6 +52,7 @@ const USER_POOL_URL = 'https://slobs-users-pool.herokuapp.com'; // 'http://local
 const FAILED_TESTS_PATH = 'test-dist/failed-tests.json'; // failed will be written down to this file
 const TESTS_TIMINGS_PATH = 'test-dist/test-timings.json'; // a known timings for tests should be provided in this file
 const TEST_STATS_PATH = 'test-dist/test-stats.json'; // each successfully completed tests save stats like duration, syncIPCCalls in this file
+const ACCOUNT_FAILURES_PATH = 'test-dist/account-failures.json'; // failures because of the user pool account
 
 // save names of all running tests in this array to use them in the retrying mechanism
 const pendingTests: string[] = [];
@@ -91,6 +113,29 @@ export function removeFailedTestFromFile(testName: string) {
     failedTests.splice(failedTests.indexOf(testName), 1);
     fs.writeFileSync(FAILED_TESTS_PATH, JSON.stringify(failedTests));
   }
+}
+
+/**
+ * Parse the account failure details for logging purposes
+ * @returns - An object with the test failure details
+ */
+function readAccountFailures(): IAccountFailures {
+  const failures = fs.existsSync(ACCOUNT_FAILURES_PATH)
+    ? JSON.parse(fs.readFileSync(ACCOUNT_FAILURES_PATH, 'utf8'))
+    : {};
+  return { tests: failures.tests ?? {}, job: failures.job ?? [] };
+}
+
+/**
+ * Write to the logs test failure that was caused by the test account to indicate that
+ * the failure is not from a bug
+ * @param testName - Name of the test with the failure
+ * @param reason - The account failure reason
+ */
+export function saveAccountFailureToFile(testName: string, reason: TAccountFailure) {
+  const failures = readAccountFailures();
+  failures.tests[testName] = reason;
+  fs.writeFileSync(ACCOUNT_FAILURES_PATH, JSON.stringify(failures));
 }
 
 /**
@@ -195,7 +240,7 @@ export async function waitForElectronInstancesExist() {
     timeleft -= interval;
     tasks = await getElectronInstances();
   }
-   if (tasks.length > 0) {
-     throw new Error('Timed out waiting for Electron instances to exit');
-   }
+  if (tasks.length > 0) {
+    throw new Error('Timed out waiting for Electron instances to exit');
+  }
 }

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -17,24 +17,26 @@ export interface ITestStats {
 }
 
 /**
- * Contents of ACCOUNT_FAILURES_PATH
+ * Contents of FAILURE_REASONS_PATH
  *  - `tests` is keyed by test name.
  *  - `job` holds reasons that belong to the run as a whole and is written by the runner.
  */
-export interface IAccountFailures {
-  tests: Record<string, TAccountFailure>;
-  job: TAccountFailure[];
+export interface IFailureReasons {
+  tests: Record<string, TFailureReason>;
+  job: TFailureReason[];
 }
 
 /**
- * Reasons a test failed because of the account it was given, rather than because of a bug.
+ * Reasons a test failed because of a frequently identified non-bug reason.
  */
-export type TAccountFailure =
+export type TFailureReason =
+  | 'MISSING_TRANSLATIONS'
+  | 'UNMOUNTED_REACT_UPDATE'
   | 'NO_ACCOUNT_AVAILABLE'
   | 'YOUTUBE_STREAMING_DISABLED'
   | 'YOUTUBE_ACCOUNT_RATE_LIMITED'
   | 'YOUTUBE_ACCOUNT_FAILURE'
-  | 'ACCOUNT_FAILURE';
+  | 'UTILITY_SERVER_FAILURE';
 
 const {
   BUILD_BUILDID,
@@ -51,7 +53,7 @@ const USER_POOL_URL = 'https://slobs-users-pool.herokuapp.com'; // 'http://local
 const FAILED_TESTS_PATH = 'test-dist/failed-tests.json'; // failed will be written down to this file
 const TESTS_TIMINGS_PATH = 'test-dist/test-timings.json'; // a known timings for tests should be provided in this file
 const TEST_STATS_PATH = 'test-dist/test-stats.json'; // each successfully completed tests save stats like duration, syncIPCCalls in this file
-const ACCOUNT_FAILURES_PATH = 'test-dist/account-failures.json'; // failures because of the user pool account
+const FAILURE_REASONS_PATH = 'test-dist/failure-reasons.json'; // failures because of known frequent non-bug reasons (like account issues) should be written in this file
 
 // save names of all running tests in this array to use them in the retrying mechanism
 const pendingTests: string[] = [];
@@ -115,26 +117,32 @@ export function removeFailedTestFromFile(testName: string) {
 }
 
 /**
- * Parse the account failure details for logging purposes
+ * Parse the failure details for logging purposes
  * @returns - An object with the test failure details
  */
-function readAccountFailures(): IAccountFailures {
-  const failures = fs.existsSync(ACCOUNT_FAILURES_PATH)
-    ? JSON.parse(fs.readFileSync(ACCOUNT_FAILURES_PATH, 'utf8'))
-    : {};
-  return { tests: failures.tests ?? {}, job: failures.job ?? [] };
+function readFailureReason(): IFailureReasons {
+  try {
+    if (fs.existsSync(FAILURE_REASONS_PATH)) {
+      const failures = JSON.parse(fs.readFileSync(FAILURE_REASONS_PATH, 'utf8'));
+      return { tests: failures.tests || {}, job: failures.job || [] };
+    }
+  } catch (e) {
+    console.error('Failed to read the failure reasons file', e);
+  }
+
+  return { tests: {}, job: [] };
 }
 
 /**
- * Write to the logs test failure that was caused by the test account to indicate that
- * the failure is not from a bug
+ * Write to the logs test failure that was caused by a frequently identified non-bug reason,
+ * such as an issue with the test account to indicate that the failure is not from a bug
  * @param testName - Name of the test with the failure
- * @param reason - The account failure reason
+ * @param reason - The failure reason
  */
-export function saveAccountFailureToFile(testName: string, reason: TAccountFailure) {
-  const failures = readAccountFailures();
+export function saveFailureReasonToFile(testName: string, reason: TFailureReason) {
+  const failures = readFailureReason();
   failures.tests[testName] = reason;
-  fs.writeFileSync(ACCOUNT_FAILURES_PATH, JSON.stringify(failures));
+  fs.writeFileSync(FAILURE_REASONS_PATH, JSON.stringify(failures));
 }
 
 /**

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -140,6 +140,11 @@ function readFailureReason(): IFailureReasons {
  * @param reason - The failure reason
  */
 export function saveFailureReasonToFile(testName: string, reason: TFailureReason) {
+  if (!reason) {
+    console.log('Expected failure reason but none provided for test', testName);
+    return;
+  }
+
   const failures = readFailureReason();
   failures.tests[testName] = reason;
   fs.writeFileSync(FAILURE_REASONS_PATH, JSON.stringify(failures));

--- a/test/helpers/webdriver/user.ts
+++ b/test/helpers/webdriver/user.ts
@@ -11,6 +11,7 @@ import { getDummyUser, IDummyTestUser, TTestDummyUserPlatforms } from '../../dat
 import { TTikTokLiveScopeTypes } from 'services/platforms/tiktok/api';
 
 let user: ITestUser; // keep user's name if SLOBS is logged-in
+let userPoolExhausted = false; // set if the pool could not give us an account for the current test
 
 export interface ITestUser {
   email: string;
@@ -319,7 +320,10 @@ export async function reserveUserFromPool(
       }
     }
   }
-  if (!reservedUser) throw new Error(`Unable to reserve a user after ${maxAttempts} attempts`);
+  if (!reservedUser) {
+    userPoolExhausted = true;
+    throw new Error(`Unable to reserve a user after ${maxAttempts} attempts`);
+  }
   return reservedUser;
 }
 
@@ -332,4 +336,12 @@ async function requestUserPool(path: string): Promise<any> {
 
 export function getUser(): ITestUser {
   return user;
+}
+
+export function userPoolIsExhausted(): boolean {
+  return userPoolExhausted;
+}
+
+export function resetUserPoolExhausted() {
+  userPoolExhausted = false;
 }


### PR DESCRIPTION
# Specify details for automated test failure cases

Automated test failure logs were too generic to rule out non-bug related failures.

---

## Issues

**Every shutdown failure reported the same message.**Errors arrive as `unknown` causing webdriver to reject with `Error` objects when sometimes the api-client rejects with plain strings and with serialized error objects. The `catch` in `stopApp` emitted a blanket `'Crash on shutdown'` regardless of what was thrown. That one message covers at least four unrelated conditions:

1. The app never exited when `waitForElectronInstancesExist` timed out.
2. The app exited early so the webdriver session was already gone.
3. The window disappeared before `closeWindow` reached it.
4. the connection to the app's api server dropped. Only this last one is a crash.

**Account-caused failures looked identical to app bugs.**
Failures due to issues from the user pool accounts, rather than app-related bugs, were logged the same in summary, requiring triage by hand in the logs for the specific test failure. This is unnecessarily time consuming. Specific cases:

1. The test failed to obtain an account from the user pool after all retries completed.
2. An account with YouTube is not enabled for live streaming.
3. An account with YouTube cannot stream due to rate limiting.
4. An account with YouTube failed for another account-related reason.

**3. The analytics POST failing was silent.**
`sendJobToAnalytics` wraps its request in a `catch` that logs and swallows it, so the entire body, including failed tests and stats, was discarded with no trace beyond one console line. This meant that test failures due to failure to post analytics was logged as `ECONNABORTED` and not distinguished from test failures due to app bugs.

## Fixes

**Shutdown errors are classified** An error is passed as `unknown` and is now identified so it can be logged in a readable way. Note: the fallback case uses `util.inspect` rather than `String()` or `JSON.stringify`. `String()` renders any object without a `.message` as `[object Object]`, so the message will not actually be logged. `JSON.stringify` is unsafe because it returns the value `undefined` for `undefined`/symbols, and it throws outright on circular references. `util.inspect` handles both and matches how `main.js` and `app/app.ts` already serialize unknown values into the log.

**Account failures are detected and recorded.** A new `TAccountFailure` union names the reasons a run failed because of its accounts:

| Reason                         | Detected from                                                        |
| ------------------------------ | -------------------------------------------------------------------- |
| `NO_ACCOUNT_AVAILABLE`         | flag set in `reserveUserFromPool` where it gives up after 5 attempts |
| `YOUTUBE_STREAMING_DISABLED`   | `liveStreamingNotEnabled` in the app log                             |
| `YOUTUBE_ACCOUNT_RATE_LIMITED` | `userRequestsExceedRateLimit` in the app log                         |
| `YOUTUBE_ACCOUNT_FAILURE`      | token expired / platform validation failure in the app log           |
| `HEROKU_ANALYTICS_SEND_FAILED` | the analytics POST giving up                                         |

The user pool case `NO_ACCOUNT_AVAILABLE` is flagged at its source rather than string-matched because the harness never sees the AVA error. The YouTube cases come from the log because that is the only place the reason surfaces.

Detection reads `currentTestLogs`, which accumulates only the slice written since the current test began because the pre-existing `lastLogs` holds the whole file and leaks across tests whenever the cache directory is reused.

**Results are written to `test-dist/account-failures.json`** For extensibility, write results under a shape shared by both writers, described by the exported `IAccountFailures`:

```json
{
  "tests": { "Go live to YouTube": "YOUTUBE_ACCOUNT_RATE_LIMITED" },
  "job": ["HEROKU_ANALYTICS_SEND_FAILED"]
}
```

`tests` is keyed by test name and written by the harness; `job` holds run-wide reasons and is written by the runner. Both sides read through a normalizer that fills in the missing halves, so an absent, empty, or older flat-shaped file degrades to empty instead of throwing. Job reasons are appended rather than assigned, so an earlier reason is not lost behind a later one.

**Analytics carries the reason.** Each entry in `failedTests` gains an `accountFailure` field, and the body gains a job-level `accountFailure` chosen off an explicit `ACCOUNT_FAILURE_SEVERITY` ordering rather than first-seen.

**File(s) changed:** `test/helpers/webdriver/index.ts`, `test/helpers/webdriver/runner-utils.ts`, `test/helpers/webdriver/user.ts`, `test/helpers/runner.js`

## Performance Implications

None. All work happens in `afterEach.always` on the failure path only, after the test has already failed. Detection is a few regex matches over a string already held in memory, and the file write is a few hundred bytes to `test-dist/`. No change to the passing path.