### PR TITLE
More selectively kick off CI runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,22 @@ trigger:
   - staging
   - master
 
+pr:
+  branches:
+    include:
+      - staging
+      - master
+  paths:
+    include:
+      - '*'
+    exclude:
+      - package.json
+      - yarn.lock
+      - app/i18n/*
+      - .github/*
+      - '*.md'
+      - '*.yml'
+
 variables:
   CI: true
 
@@ -45,7 +61,7 @@ jobs:
           SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)
           BROWSER_SOURCE_HARDWARE_ACCELERATION: 'OFF'
           SLOBS_TEST_STREAM_KEY: $(twitchStreamKey)
-          SLOBS_TEST_RUN_CHUNK: "$(System.JobPositionInPhase)/$(System.TotalJobsInPhase)"
+          SLOBS_TEST_RUN_CHUNK: '$(System.JobPositionInPhase)/$(System.TotalJobsInPhase)'
 
   - job: Check_eslint_and_strict_nulls_regression
 
@@ -56,7 +72,6 @@ jobs:
       clean: resources
 
     steps:
-
       - powershell: echo "IP for RDP connections:" $(Invoke-RestMethod ipinfo.io/ip)
         displayName: 'Get RDP address'
 


### PR DESCRIPTION
This PR intends to limit automated CI runs of somethings, notably renovate PRs which we can manually run before merging and Crowdin PRs as well as changes to config files which do not cause changes to the outcome of tests