### PR TITLE
Bring the 1.21.9 hotfix back into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "1.21.8",
+  "version": "1.21.9",
   "main": "main.js",
   "macVirtualCamUrl": "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/slobs-vcam-installer-1.0.16-release-osx-[ARCH].tar.gz",
   "scripts": {

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.29b18",
+      "version": "0.26.29b19",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
1.21.9 shipped from `hotfix/1.21.9`. The hotfix release path deliberately skips the merge into master, so master's tree is not the tree that shipped: it was bumped to 1.21.9 by hand but still pins obs-studio-node `0.26.29b18`.

This merges the hotfix branch in. Net effect on master is one line — `scripts/repositories.json` osn `0.26.29b18` → `0.26.29b19` (libobs `31.1.2sl19b5`, the patched FFmpeg deps that 1.21.9 shipped with). `package.json` already reads 1.21.9 on both sides.

No user-visible change. Master now reflects the released build, so bundle releases that read master's version and tree match what 1.21.9 users are running.

Verified: `git merge-tree` reports a clean merge, no conflicts; resulting tree differs from master by that single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)