### PR TITLE
Migrate layouts to relative coordinates

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -300,12 +300,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     await obsUserPluginsService.initialize();
 
     // Initialize OBS API
-    const apiResult = obs.NodeObs.OBS_API_initAPI(
-      'en-US',
-      appService.appDataDirectory,
-      remote.process.env.SLOBS_VERSION,
-      isPreview ? SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL : SLD_SENTRY_BACKEND_SERVER_URL,
-    );
+    const apiResult = obs.NodeObs.OBS_API_initAPI({
+      language: 'en-US',
+      appDataPath: appService.appDataDirectory,
+      version: remote.process.env.SLOBS_VERSION,
+      crashServerUrl: isPreview
+        ? SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL
+        : SLD_SENTRY_BACKEND_SERVER_URL,
+    });
 
     if (apiResult !== obs.EVideoCodes.Success) {
       const message = apiInitErrorResultToMessage(apiResult);

--- a/app/components-react/windows/settings/Video.tsx
+++ b/app/components-react/windows/settings/Video.tsx
@@ -60,6 +60,7 @@ class VideoSettingsModule {
   userService = Services.UserService;
   dualOutputService = Services.DualOutputService;
   streamingService = Services.StreamingService;
+  virtualWebcamService = Services.VirtualWebcamService;
   tiktokService = Services.TikTokService;
 
   get display(): TDisplayType {
@@ -67,7 +68,12 @@ class VideoSettingsModule {
   }
 
   get cantEditFields(): boolean {
-    return this.streamingService.views.isStreaming || this.streamingService.views.isRecording;
+    return (
+      this.streamingService.views.isStreaming ||
+      this.streamingService.views.isRecording ||
+      this.streamingService.views.isReplayBufferActive ||
+      this.virtualWebcamService.views.running
+    );
   }
 
   get values(): Dictionary<TInputValue> {
@@ -342,7 +348,14 @@ class VideoSettingsModule {
           settings[`${otherPrefix}Height`] = Number(height);
         }
       }
-      this.service.actions.setSettings(settings, display);
+      Promise.resolve(this.service.actions.setSettings(settings, display)).catch(
+        (error: unknown) => {
+          message.error({
+            content:
+              error instanceof Error ? error.message : $t('Failed to update the video resolution.'),
+          });
+        },
+      );
     }
   }
 

--- a/app/components-react/windows/settings/Video.tsx
+++ b/app/components-react/windows/settings/Video.tsx
@@ -336,14 +336,12 @@ class VideoSettingsModule {
           settings[`${otherPrefix}Height`] = Number(height);
         }
       }
-      Promise.resolve(this.service.actions.setSettings(settings, display)).catch(
-        (error: unknown) => {
-          message.error({
-            content:
-              error instanceof Error ? error.message : $t('Failed to update the video resolution.'),
-          });
-        },
-      );
+      this.service.actions.return.setSettings(settings, display).catch((error: unknown) => {
+        message.error({
+          content:
+            error instanceof Error ? error.message : $t('Failed to update the video resolution.'),
+        });
+      });
     }
   }
 

--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -39,6 +39,7 @@
   "Name Folder": "Name Folder",
   "Switch Scenes": "Switch Scenes",
   "Failed to load scene collection.  A new one will be created instead.": "Failed to load scene collection.  A new one will be created instead.",
+  "This scene collection could not be upgraded. To prevent data loss, changes to it will not be saved until it can be loaded completely.": "This scene collection could not be upgraded. To prevent data loss, changes to it will not be saved until it can be loaded completely.",
   "New Scene": "New Scene",
   "Projector": "Projector",
   "Your Scene Collections:": "Your Scene Collections:",

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -256,6 +256,7 @@
   "FPS Denominator": "FPS Denominator",
   "FPS Value": "FPS Value",
   "The resolution must be in the format [width]x[height] (i.e. 1920x1080)": "The resolution must be in the format [width]x[height] (i.e. 1920x1080)",
+  "Failed to update the video resolution.": "Failed to update the video resolution.",
   "Custom": "Custom",
   "Custom Base Resolution": "Custom Base Resolution",
   "Custom Output Resolution": "Custom Output Resolution",

--- a/app/services/scene-collections/errors.ts
+++ b/app/services/scene-collections/errors.ts
@@ -1,0 +1,29 @@
+export class SceneCollectionOperationalError extends Error {
+  readonly operational = true;
+
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'SceneCollectionOperationalError';
+  }
+}
+
+export class SceneCollectionMigrationError extends Error {
+  readonly migration = true;
+
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = 'SceneCollectionMigrationError';
+  }
+}
+
+export function isSceneCollectionOperationalError(
+  error: unknown,
+): error is SceneCollectionOperationalError {
+  return error instanceof SceneCollectionOperationalError;
+}
+
+export function isSceneCollectionMigrationError(
+  error: unknown,
+): error is SceneCollectionMigrationError {
+  return error instanceof SceneCollectionMigrationError;
+}

--- a/app/services/scene-collections/nodes/array-node.ts
+++ b/app/services/scene-collections/nodes/array-node.ts
@@ -1,5 +1,6 @@
 import { Node } from './node';
 import compact from 'lodash/compact';
+import { ISceneCollectionLoadContext } from './load-session';
 
 interface IArraySchema<TSchema> {
   items: TSchema[];
@@ -36,6 +37,7 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<
       try {
         afterLoadItemsCallbacks.push(await this.loadItem(item, context));
       } catch (e: unknown) {
+        if (this.isStrictCoordinateMigration(context)) throw e;
         console.error('Array node step failed', e);
       }
     }
@@ -45,6 +47,7 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<
         try {
           await cb();
         } catch (e: unknown) {
+          if (this.isStrictCoordinateMigration(context)) throw e;
           console.error('Array node callback failed', e);
         }
       }
@@ -64,4 +67,9 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<
    * @param context the context
    */
   async afterLoad(context: TContext): Promise<void> {}
+
+  private isStrictCoordinateMigration(context: TContext): boolean {
+    return !!(context as TContext & ISceneCollectionLoadContext)?.loadSession
+      ?.strictCoordinateMigration;
+  }
 }

--- a/app/services/scene-collections/nodes/hotkeys.ts
+++ b/app/services/scene-collections/nodes/hotkeys.ts
@@ -1,8 +1,9 @@
 import { ArrayNode } from './array-node';
 import { HotkeysService, IHotkey, Hotkey } from '../../hotkeys';
 import { Inject } from '../../core/injector';
+import { ISceneCollectionLoadContext } from './load-session';
 
-interface IContext {
+interface IContext extends ISceneCollectionLoadContext {
   sceneId?: string;
   sceneItemId?: string;
   sourceId?: string;
@@ -40,7 +41,9 @@ export class HotkeysNode extends ArrayNode<IHotkey, IContext, Hotkey> {
   }
 
   loadItem(obj: IHotkey, context: IContext): Promise<void> {
-    this.hotkeysService.addHotkey({ ...obj, ...context });
+    const hotkeyContext = { ...context };
+    delete hotkeyContext.loadSession;
+    this.hotkeysService.addHotkey({ ...obj, ...hotkeyContext });
     return Promise.resolve();
   }
 

--- a/app/services/scene-collections/nodes/load-session.ts
+++ b/app/services/scene-collections/nodes/load-session.ts
@@ -1,0 +1,11 @@
+export interface ISceneCollectionLoadSession {
+  /**
+   * Legacy absolute-coordinate collections must load completely before they
+   * can be persisted in the relative-coordinate schema.
+   */
+  strictCoordinateMigration: boolean;
+}
+
+export interface ISceneCollectionLoadContext {
+  loadSession?: ISceneCollectionLoadSession;
+}

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -5,16 +5,16 @@ import { TransitionsNode } from './transitions';
 import { HotkeysNode } from './hotkeys';
 import { NodeMapNode } from './node-map';
 import { Inject } from 'services/core';
-import { VideoService } from 'services/video';
 import { StreamingService } from 'services/streaming';
 import { OS } from 'util/operating-systems';
 import { GuestCamNode } from './guest-cam';
 import { VideoSettingsService } from 'services/settings-v2/video';
 import { DualOutputService } from 'services/dual-output';
-import { SettingsService } from 'services/settings';
-import { SceneCollectionsService } from '../scene-collections';
+import { ISceneCollectionLoadContext } from './load-session';
+import { SceneCollectionOperationalError } from '../errors';
 
 interface ISchema {
+  relativeCoordinates: boolean;
   /**
    * this is for backward compatibility with single output collections
    */
@@ -52,15 +52,13 @@ interface ISchema {
 /**
  * This is the root node of the config file
  */
-export class RootNode extends Node<ISchema, {}> {
-  schemaVersion = 4;
+export class RootNode extends Node<ISchema, ISceneCollectionLoadContext> {
+  schemaVersion = 5;
+  private coordinateMigrationRequired = false;
 
-  @Inject() videoService: VideoService;
   @Inject() streamingService: StreamingService;
   @Inject() videoSettingsService: VideoSettingsService;
   @Inject() dualOutputService: DualOutputService;
-  @Inject() settingsService: SettingsService;
-  @Inject() sceneCollectionsService: SceneCollectionsService;
 
   async save(): Promise<void> {
     const nodeMap = new NodeMapNode();
@@ -84,6 +82,7 @@ export class RootNode extends Node<ISchema, {}> {
       hotkeys,
       guestCam,
       nodeMap,
+      relativeCoordinates: true,
       baseResolution: this.videoSettingsService.baseResolutions?.horizontal,
       baseResolutions: this.videoSettingsService.baseResolutions,
       selectiveRecording: this.streamingService.state.selectiveRecording,
@@ -96,56 +95,43 @@ export class RootNode extends Node<ISchema, {}> {
    * there must be at least one video context established.
    * This if/else prevents an error by guaranteeing a video context exists.
    */
-  async load(): Promise<void> {
-    if (!this.videoSettingsService.contexts.horizontal) {
-      const establishedContext = this.videoSettingsService.establishedContext.subscribe(
-        async () => {
-          this.videoService.setBaseResolution(this.data.baseResolutions);
-          this.streamingService.setSelectiveRecording(!!this.data.selectiveRecording);
-          this.streamingService.setDualOutputMode(this.data.dualOutputMode);
-
-          await this.data.transitions.load();
-          await this.data.sources.load({});
-          await this.data.scenes.load({});
-
-          if (this.data.nodeMap) {
-            await this.data.nodeMap.load();
-          }
-
-          if (this.data.hotkeys) {
-            await this.data.hotkeys.load({});
-          }
-
-          if (this.data.guestCam) {
-            await this.data.guestCam.load();
-          }
-          establishedContext.unsubscribe();
-        },
+  async load(context: ISceneCollectionLoadContext = {}): Promise<void> {
+    try {
+      await this.videoSettingsService.applyCollectionBaseResolutions(this.data.baseResolutions);
+    } catch (error: unknown) {
+      throw new SceneCollectionOperationalError(
+        'Failed to apply the scene collection canvas resolutions.',
+        error,
       );
-    } else {
-      this.videoService.setBaseResolution(this.data.baseResolutions);
-      this.streamingService.setSelectiveRecording(!!this.data.selectiveRecording);
-      this.streamingService.setDualOutputMode(this.data.dualOutputMode);
+    }
 
-      if (this.data.nodeMap) {
-        await this.data.nodeMap.load();
-      }
+    this.streamingService.setSelectiveRecording(!!this.data.selectiveRecording);
+    this.streamingService.setDualOutputMode(this.data.dualOutputMode);
 
-      await this.data.transitions.load();
-      await this.data.sources.load({});
-      await this.data.scenes.load({});
+    if (this.data.nodeMap) {
+      await this.data.nodeMap.load();
+    }
 
-      if (this.data.hotkeys) {
-        await this.data.hotkeys.load({});
-      }
+    await this.data.transitions.load();
+    await this.data.sources.load(context);
+    await this.data.scenes.load(context);
 
-      if (this.data.guestCam) {
-        await this.data.guestCam.load();
-      }
+    if (this.data.hotkeys) {
+      await this.data.hotkeys.load({ loadSession: context.loadSession });
+    }
+
+    if (this.data.guestCam) {
+      await this.data.guestCam.load();
     }
   }
 
+  get requiresCoordinateMigration() {
+    return this.coordinateMigrationRequired;
+  }
+
   migrate(version: number) {
+    this.coordinateMigrationRequired = version < 5 || this.data.relativeCoordinates !== true;
+
     // Changed name of transition node in version 2
     if (version < 2) {
       // TODO: index
@@ -159,7 +145,21 @@ export class RootNode extends Node<ISchema, {}> {
     }
     // Added multiple displays with individual base resolutions in version 4
     if (version < 4) {
-      this.data.baseResolutions = this.videoSettingsService.baseResolutions;
+      this.data.baseResolutions = {
+        horizontal:
+          this.data.baseResolution ?? this.videoSettingsService.baseResolutions.horizontal,
+        vertical: this.videoSettingsService.baseResolutions.vertical,
+      };
     }
+
+    this.data.baseResolutions = {
+      horizontal:
+        this.data.baseResolutions?.horizontal ??
+        this.data.baseResolution ??
+        this.videoSettingsService.baseResolutions.horizontal,
+      vertical:
+        this.data.baseResolutions?.vertical ?? this.videoSettingsService.baseResolutions.vertical,
+    };
+    if (this.data.relativeCoordinates == null) this.data.relativeCoordinates = false;
   }
 }

--- a/app/services/scene-collections/nodes/scene-filters.ts
+++ b/app/services/scene-collections/nodes/scene-filters.ts
@@ -2,8 +2,9 @@ import { ArrayNode } from './array-node';
 import { Inject } from '../../core/injector';
 import { ISourceFilter, SourceFiltersService, TSourceFilterType } from 'services/source-filters';
 import { TObsValue } from 'components/obs/inputs/ObsInput';
+import { ISceneCollectionLoadContext } from './load-session';
 
-interface IContext {
+interface IContext extends ISceneCollectionLoadContext {
   sceneId: string;
 }
 

--- a/app/services/scene-collections/nodes/scene-items.ts
+++ b/app/services/scene-collections/nodes/scene-items.ts
@@ -5,6 +5,9 @@ import { SourcesService } from '../../sources';
 import { Inject } from '../../core/injector';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
 import { DualOutputService } from 'services/dual-output';
+import { ISceneCollectionLoadContext } from './load-session';
+import { SceneCollectionMigrationError } from '../errors';
+import * as obs from '../../../../obs-api';
 
 interface ISchema {
   items: TSceneNodeInfo[];
@@ -17,7 +20,7 @@ export interface ISceneItemInfo extends ISceneNodeInfo {
   scaleX: number;
   scaleY: number;
   visible: boolean;
-  crop: ICrop;
+  crop: ICrop & Pick<obs.ICropInfo, 'referenceWidth' | 'referenceHeight'>;
   hotkeys?: HotkeysNode;
   locked?: boolean;
   rotation?: number;
@@ -43,11 +46,11 @@ interface ISceneNodeInfo {
 
 export type TSceneNodeInfo = ISceneItemInfo | ISceneItemFolderInfo;
 
-interface IContext {
+interface IContext extends ISceneCollectionLoadContext {
   scene: Scene;
 }
 
-export class SceneItemsNode extends Node<ISchema, {}> {
+export class SceneItemsNode extends Node<ISchema, IContext> {
   schemaVersion = 1;
 
   @Inject('SourcesService')
@@ -75,6 +78,7 @@ export class SceneItemsNode extends Node<ISchema, {}> {
 
           hotkeys.save({ sceneItemId: sceneItem.sceneItemId }).then(() => {
             const transform = sceneItem.transform;
+            const persistedCrop = sceneItem.getObsSceneItem().crop;
             resolve({
               hotkeys,
               id: sceneItem.sceneItemId,
@@ -84,7 +88,7 @@ export class SceneItemsNode extends Node<ISchema, {}> {
               scaleX: transform.scale.x,
               scaleY: transform.scale.y,
               visible: sceneItem.visible,
-              crop: transform.crop,
+              crop: persistedCrop,
               locked: sceneItem.locked,
               rotation: transform.rotation,
               streamVisible: sceneItem.streamVisible,
@@ -165,11 +169,21 @@ export class SceneItemsNode extends Node<ISchema, {}> {
       });
     }
 
+    const sources = this.sourcesService.state.sources;
+    const missingSourceIds = this.data.items
+      .filter((item): item is ISceneItemInfo => item.sceneNodeType === 'item')
+      .filter(item => !sources[item.sourceId])
+      .map(item => item.sourceId);
+
+    if (missingSourceIds.length && context.loadSession?.strictCoordinateMigration) {
+      throw new SceneCollectionMigrationError(
+        `Scene items reference sources that were not created: ${missingSourceIds.join(', ')}`,
+      );
+    }
+
     context.scene.addSources(this.data.items);
 
     const promises: Promise<void>[] = [];
-
-    const sources = this.sourcesService.state.sources;
 
     this.data.items.forEach(item => {
       if (item.sceneNodeType === 'folder') return;
@@ -177,11 +191,11 @@ export class SceneItemsNode extends Node<ISchema, {}> {
       if (!sources[item.sourceId]) return;
 
       const hotkeys = item.hotkeys;
-      if (hotkeys) promises.push(hotkeys.load({ sceneItemId: item.id }));
+      if (hotkeys) {
+        promises.push(hotkeys.load({ sceneItemId: item.id, loadSession: context.loadSession }));
+      }
     });
 
-    return new Promise(resolve => {
-      Promise.all(promises).then(() => resolve());
-    });
+    return Promise.all(promises).then(() => undefined);
   }
 }

--- a/app/services/scene-collections/nodes/scene-items.ts
+++ b/app/services/scene-collections/nodes/scene-items.ts
@@ -137,7 +137,7 @@ export class SceneItemsNode extends Node<ISchema, IContext> {
     });
   }
 
-  load(context: IContext): Promise<void> {
+  async load(context: IContext): Promise<void> {
     this.sanitizeIds();
 
     // on first load, a dual output scene needs to assign displays and contexts to the scene items
@@ -196,6 +196,6 @@ export class SceneItemsNode extends Node<ISchema, IContext> {
       }
     });
 
-    return Promise.all(promises).then(() => undefined);
+    await Promise.all(promises);
   }
 }

--- a/app/services/scene-collections/nodes/scenes.ts
+++ b/app/services/scene-collections/nodes/scenes.ts
@@ -5,6 +5,7 @@ import { SourcesService } from '../../sources';
 import { VideoSettingsService } from '../../settings-v2/video';
 import { HotkeysNode } from './hotkeys';
 import { SceneFiltersNode } from './scene-filters';
+import { ISceneCollectionLoadContext } from './load-session';
 
 export interface ISceneSchema {
   id: string;
@@ -15,7 +16,7 @@ export interface ISceneSchema {
   filters?: SceneFiltersNode;
 }
 
-export class ScenesNode extends ArrayNode<ISceneSchema, {}, Scene> {
+export class ScenesNode extends ArrayNode<ISceneSchema, ISceneCollectionLoadContext, Scene> {
   schemaVersion = 1;
 
   scenesService: ScenesService = ScenesService.instance;
@@ -71,26 +72,24 @@ export class ScenesNode extends ArrayNode<ISceneSchema, {}, Scene> {
     this.videoSettingsService.validateVideoContext('vertical');
   }
 
-  loadItem(obj: ISceneSchema): Promise<() => Promise<void>> {
-    return new Promise(resolve => {
-      const scene = this.scenesService.createScene(obj.name, { sceneId: obj.id });
+  async loadItem(
+    obj: ISceneSchema,
+    context: ISceneCollectionLoadContext,
+  ): Promise<() => Promise<void>> {
+    const scene = this.scenesService.createScene(obj.name, { sceneId: obj.id });
 
-      if (obj.filters) obj.filters.load({ sceneId: scene.id });
+    if (obj.filters) {
+      await obj.filters.load({ sceneId: scene.id, loadSession: context.loadSession });
+    }
 
-      resolve(() => {
-        return new Promise(resolve => {
-          obj.sceneItems.load({ scene }).then(() => {
-            if (obj.active) this.scenesService.makeSceneActive(scene.id);
+    return async () => {
+      await obj.sceneItems.load({ scene, loadSession: context.loadSession });
+      if (obj.active) this.scenesService.makeSceneActive(scene.id);
 
-            if (obj.hotkeys) {
-              obj.hotkeys.load({ sceneId: scene.id }).then(() => resolve());
-            } else {
-              resolve();
-            }
-          });
-        });
-      });
-    });
+      if (obj.hotkeys) {
+        await obj.hotkeys.load({ sceneId: scene.id, loadSession: context.loadSession });
+      }
+    };
   }
 
   async afterLoad() {

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -17,6 +17,8 @@ import defaultTo from 'lodash/defaultTo';
 import { byOS, OS } from 'util/operating-systems';
 import { UsageStatisticsService } from 'services/usage-statistics';
 import { EFilterDisplayType, ISourceFilter, SourceFiltersService } from 'services/source-filters';
+import { ISceneCollectionLoadContext } from './load-session';
+import { SceneCollectionMigrationError } from '../errors';
 
 interface ISchema {
   items: ISourceInfo[];
@@ -49,7 +51,7 @@ export interface ISourceInfo {
   propertiesManagerSettings?: Dictionary<any>;
 }
 
-export class SourcesNode extends Node<ISchema, {}> {
+export class SourcesNode extends Node<ISchema, ISceneCollectionLoadContext> {
   schemaVersion = 5;
 
   @Inject() private sourcesService: SourcesService;
@@ -219,7 +221,7 @@ export class SourcesNode extends Node<ISchema, {}> {
     return removed;
   }
 
-  load(context: {}): Promise<void> {
+  load(context: ISceneCollectionLoadContext = {}): Promise<void> {
     this.sanitizeSources();
 
     const supportedSources = this.data.items.filter(source => {
@@ -343,9 +345,17 @@ export class SourcesNode extends Node<ISchema, {}> {
       this.sourcesService.missingInputs = sourcesNotCreated.map(
         source => this.sourcesService.sourceDisplayData[source.type]?.name,
       );
+
+      if (context.loadSession?.strictCoordinateMigration) {
+        throw new SceneCollectionMigrationError(
+          `Could not create sources required for coordinate migration: ${sourcesNotCreatedNames.join(
+            ', ',
+          )}`,
+        );
+      }
     }
 
-    sources.forEach(async source => {
+    sources.forEach(source => {
       const sourceInfo = sourceData[source.name];
 
       this.sourcesService.addSource(source, sourceInfo.name, {
@@ -383,15 +393,18 @@ export class SourcesNode extends Node<ISchema, {}> {
           console.error('Attempting to load hotkey for not created source:', sourceInfo.id);
         }
 
-        promises.push(sourceInfo.hotkeys.load({ sourceId: sourceInfo.id }));
+        promises.push(
+          sourceInfo.hotkeys.load({
+            sourceId: sourceInfo.id,
+            loadSession: context.loadSession,
+          }),
+        );
       }
 
       this.sourceFiltersService.loadFilterData(sourceInfo.id, sourceInfo.filters.items);
     });
 
-    return new Promise(resolve => {
-      Promise.all(promises).then(() => resolve());
-    });
+    return Promise.all(promises).then(() => undefined);
   }
 
   migrate(version: number) {

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -221,7 +221,7 @@ export class SourcesNode extends Node<ISchema, ISceneCollectionLoadContext> {
     return removed;
   }
 
-  load(context: ISceneCollectionLoadContext = {}): Promise<void> {
+  async load(context: ISceneCollectionLoadContext = {}): Promise<void> {
     this.sanitizeSources();
 
     const supportedSources = this.data.items.filter(source => {
@@ -404,7 +404,7 @@ export class SourcesNode extends Node<ISchema, ISceneCollectionLoadContext> {
       this.sourceFiltersService.loadFilterData(sourceInfo.id, sourceInfo.filters.items);
     });
 
-    return Promise.all(promises).then(() => undefined);
+    await Promise.all(promises);
   }
 
   migrate(version: number) {

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -54,6 +54,7 @@ import {
   SceneCollectionMigrationError,
   SceneCollectionOperationalError,
 } from './errors';
+import { ENotificationType, NotificationsService } from 'services/notifications';
 
 const uuid = window['require']('uuid/v4');
 
@@ -92,6 +93,9 @@ interface ILoadedCollectionData {
 
 const DEFAULT_COLLECTION_NAME = 'Scenes';
 
+const COORDINATE_MIGRATION_BLOCKED_NOTIFICATION_CODE =
+  'SCENE_COLLECTION_COORDINATE_MIGRATION_BLOCKED';
+
 /**
  * V2 of the scene collections service:
  * - Completely asynchronous
@@ -118,6 +122,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   @Inject() private widgetsService: WidgetsService;
   @Inject() private virtualWebcamService: VirtualWebcamService;
   @Inject() private fileManagerService: FileManagerService;
+  @Inject() private notificationsService: NotificationsService;
 
   collectionAdded = new Subject<ISceneCollectionsManifestEntry>();
   collectionRemoved = new Subject<ISceneCollectionsManifestEntry>();
@@ -132,6 +137,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   private collectionLoaded = false;
   private coordinateMigrationBlockedCollectionId: string | null = null;
+  private coordinateMigrationBlockedNotificationId: number | null = null;
 
   /**
    * Whether the error dialogue is currently open.
@@ -321,6 +327,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       this.setupEmptyCollection();
     }
 
+    this.setCoordinateMigrationBlockedCollection(null);
     this.collectionLoaded = true;
     await this.save();
     this.collectionSwitched.next(collection);
@@ -518,6 +525,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
 
     this.collectionSwitched.next(collection);
 
+    this.setCoordinateMigrationBlockedCollection(null);
     this.collectionLoaded = true;
     await this.save();
   }
@@ -659,6 +667,9 @@ export class SceneCollectionsService extends Service implements ISceneCollection
         await this.handleCollectionLoadError();
         this.setupEmptyCollection();
       }
+      if (this.activeCollection?.id === id) {
+        this.setCoordinateMigrationBlockedCollection(null);
+      }
       this.collectionLoaded = true;
       return;
     }
@@ -714,7 +725,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
         if (migrationFallbackData) {
           await this.deloadPartialApplicationState();
           await this.loadDataIntoApplicationState(migrationFallbackData, false);
-          this.coordinateMigrationBlockedCollectionId = id;
+          this.setCoordinateMigrationBlockedCollection(id);
           this.collectionLoaded = true;
           console.error(
             'Coordinate migration was not persisted because the collection did not load completely.',
@@ -738,14 +749,14 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       console.error('Scene collection was loaded but there were no scenes.');
       this.setupEmptyCollection();
       this.collectionLoaded = true;
-      if (loadedResult.coordinateMigrationRequired) {
-        this.coordinateMigrationBlockedCollectionId = id;
-      }
+      this.setCoordinateMigrationBlockedCollection(
+        loadedResult.coordinateMigrationRequired ? id : null,
+      );
       return;
     }
 
     this.stateService.writeDataToCollectionFile(id, loadedData, true);
-    this.coordinateMigrationBlockedCollectionId = null;
+    this.setCoordinateMigrationBlockedCollection(null);
     this.collectionLoaded = true;
 
     if (loadedResult.coordinateMigrationRequired) {
@@ -825,6 +836,33 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     );
   }
 
+  private setCoordinateMigrationBlockedCollection(id: string | null) {
+    this.coordinateMigrationBlockedCollectionId = id;
+
+    if (id) {
+      if (this.coordinateMigrationBlockedNotificationId != null) return;
+
+      const notification = this.notificationsService.push({
+        code: COORDINATE_MIGRATION_BLOCKED_NOTIFICATION_CODE,
+        type: ENotificationType.WARNING,
+        lifeTime: -1,
+        playSound: false,
+        message: $t(
+          'This scene collection could not be upgraded. To prevent data loss, changes to it will not be saved until it can be loaded completely.',
+        ),
+      });
+      this.coordinateMigrationBlockedNotificationId = notification.id;
+      return;
+    }
+
+    if (this.coordinateMigrationBlockedNotificationId != null) {
+      // Marking the warning as read removes the persistent toast while retaining
+      // notification history. A later blocked migration can create a fresh warning.
+      this.notificationsService.markAsRead(this.coordinateMigrationBlockedNotificationId);
+      this.coordinateMigrationBlockedNotificationId = null;
+    }
+  }
+
   private async restorePreviousCollection(
     previousCollectionId: string | undefined,
     previousCollectionData: string | undefined,
@@ -837,9 +875,9 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       await this.deloadPartialApplicationState();
       await this.setActiveCollection(previousCollectionId);
       await this.loadDataIntoApplicationState(previousCollectionData, false);
-      this.coordinateMigrationBlockedCollectionId = migrationWasBlocked
-        ? previousCollectionId
-        : null;
+      this.setCoordinateMigrationBlockedCollection(
+        migrationWasBlocked ? previousCollectionId : null,
+      );
       this.collectionLoaded = true;
     } catch (rollbackError: unknown) {
       throw new SceneCollectionOperationalError(

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -43,8 +43,17 @@ import * as remote from '@electron/remote';
 import { GuestCamNode } from './nodes/guest-cam';
 import { DualOutputService } from 'services/dual-output';
 import { NodeMapNode } from './nodes/node-map';
-import { VideoSettingsService } from 'services/settings-v2';
+import { IBaseResolutions, VideoSettingsService } from 'services/settings-v2';
 import { WidgetsService, WidgetType } from 'services/widgets';
+import { VirtualWebcamService } from 'services/virtual-webcam';
+import { FileManagerService } from 'services/file-manager';
+import { videoOutputCoordinator } from 'services/video-output-coordinator';
+import {
+  isSceneCollectionMigrationError,
+  isSceneCollectionOperationalError,
+  SceneCollectionMigrationError,
+  SceneCollectionOperationalError,
+} from './errors';
 
 const uuid = window['require']('uuid/v4');
 
@@ -68,6 +77,17 @@ interface ISceneCollectionInternalCreateOptions extends ISceneCollectionCreateOp
   setupFunction?: () => boolean | Promise<boolean>;
 
   auto?: boolean;
+}
+
+interface ICollectionFilePreflight {
+  primaryData?: string;
+  primaryError?: unknown;
+  backupData?: string;
+  backupError?: unknown;
+}
+
+interface ILoadedCollectionData {
+  coordinateMigrationRequired: boolean;
 }
 
 const DEFAULT_COLLECTION_NAME = 'Scenes';
@@ -96,6 +116,8 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   @Inject() videoSettingsService: VideoSettingsService;
   @Inject() private defaultHardwareService: DefaultHardwareService;
   @Inject() private widgetsService: WidgetsService;
+  @Inject() private virtualWebcamService: VirtualWebcamService;
+  @Inject() private fileManagerService: FileManagerService;
 
   collectionAdded = new Subject<ISceneCollectionsManifestEntry>();
   collectionRemoved = new Subject<ISceneCollectionsManifestEntry>();
@@ -109,6 +131,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * Is used to decide whether we should save.
    */
   private collectionLoaded = false;
+  private coordinateMigrationBlockedCollectionId: string | null = null;
 
   /**
    * Whether the error dialogue is currently open.
@@ -179,6 +202,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   async persistForShutdown() {
     await this.disableAutoSave();
+    await this.videoSettingsService.flushPendingCanvasSettings();
     await this.save();
     this.stateService.flushManifestFile();
   }
@@ -198,6 +222,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   async save(): Promise<void> {
     if (!this.collectionLoaded) return;
     if (!this.activeCollection) return;
+    if (this.coordinateMigrationBlockedCollectionId === this.activeCollection.id) return;
     await this.saveCurrentApplicationStateAs(this.activeCollection.id);
     this.stateService.SET_MODIFIED(this.activeCollection.id, new Date().toISOString());
   }
@@ -213,14 +238,54 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    */
   @RunInLoadingMode()
   async load(id: string, shouldAttemptRecovery = true): Promise<void> {
-    await this.deloadCurrentApplicationState();
+    await this.videoSettingsService.flushPendingCanvasSettings();
+    const releaseVideoReset = videoOutputCoordinator.reserveVideoReset();
+
+    try {
+      await this.loadWithVideoResetReservation(id, shouldAttemptRecovery);
+    } finally {
+      releaseVideoReset();
+    }
+  }
+
+  private async loadWithVideoResetReservation(
+    id: string,
+    shouldAttemptRecovery: boolean,
+  ): Promise<void> {
+    const previousCollectionId = this.activeCollection?.id;
+    const previousMigrationBlocked =
+      this.coordinateMigrationBlockedCollectionId === previousCollectionId;
+    let previousCollectionData: string | undefined;
+
+    await this.disableAutoSave();
+    await this.save();
+    if (previousCollectionId && this.collectionLoaded) {
+      previousCollectionData = this.stateService.readCollectionFile(previousCollectionId);
+    }
+
+    const preflight = this.hasActiveVideoOutput()
+      ? await this.preflightCollectionFiles(id)
+      : undefined;
+
+    await this.deloadCurrentApplicationState({ save: false });
+
     try {
       await this.setActiveCollection(id);
 
-      await this.readCollectionDataAndLoadIntoApplicationState(id);
+      await this.readCollectionDataAndLoadIntoApplicationState(id, preflight);
       this.collectionSwitched.next(this.getCollection(id)!);
     } catch (e: unknown) {
       console.error('Error loading collection!', e);
+
+      if (isSceneCollectionOperationalError(e)) {
+        await this.restorePreviousCollection(
+          previousCollectionId,
+          previousCollectionData,
+          previousMigrationBlocked,
+          e,
+        );
+        throw e;
+      }
 
       if (shouldAttemptRecovery) {
         await this.attemptRecovery(id);
@@ -571,72 +636,18 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * from disk into the current application state.
    * @param id The id of the collection to load
    */
-  private async readCollectionDataAndLoadIntoApplicationState(id: string): Promise<void> {
-    const exists = await this.stateService.collectionFileExists(id);
+  private async readCollectionDataAndLoadIntoApplicationState(
+    id: string,
+    preflight?: ICollectionFilePreflight,
+  ): Promise<void> {
+    const exists = preflight
+      ? preflight.primaryData != null ||
+        preflight.primaryError != null ||
+        preflight.backupData != null ||
+        preflight.backupError != null
+      : await this.stateService.collectionFileExists(id);
 
-    if (exists) {
-      let data: string;
-
-      try {
-        data = this.stateService.readCollectionFile(id);
-        if (!data) throw new Error('Got blank data from collection file');
-        await this.loadDataIntoApplicationState(data);
-      } catch (e: unknown) {
-        console.error(
-          'Error while loading collection, restoring backup:',
-          e instanceof Error ? e.message : e,
-        );
-
-        try {
-          /*
-           *  Attempt to deload application state because we invoke `loadDataIntoApplicationState` a second time below,
-           *  which can cause partial state from the call above to still
-           *  be present and result in duplicate items (for instance, scenes)
-           *  and methods being invoked (like `updateRegisteredHotkeys`) as
-           *  part of the loading process.
-           */
-          this.deloadPartialApplicationState();
-
-          // Check for a backup and load it
-          const backupExists = await this.stateService.collectionFileExists(id, true);
-          // Rethrow the original error if no backup exists
-          if (!backupExists) throw e;
-
-          data = this.stateService.readCollectionFile(id, true);
-          if (!data) throw new Error('Got blank data from backup collection file');
-          await this.loadDataIntoApplicationState(data);
-        } catch (backupError: unknown) {
-          console.error(
-            'Error while loading backup collection:',
-            backupError instanceof Error ? backupError.message : backupError,
-          );
-
-          // If there is an error loading the backup, create an empty scene collection
-          // otherwise the app will fail to load
-          await this.handleCollectionLoadError();
-          await this.create({ auto: true });
-          return; // Prevent further execution by returning early
-        }
-      }
-
-      // create an empty scene collection if failed to load both the collection and the backup
-      if (!data) {
-        await this.create({ auto: true });
-        return;
-      }
-
-      // the app cannot load without a default scene
-      if (this.scenesService.views.scenes.length === 0) {
-        console.error('Scene collection was loaded but there were no scenes.');
-        this.setupEmptyCollection();
-        this.collectionLoaded = true;
-        return; // Return early to prevent writing a backup for an empty scene collection
-      }
-
-      // Everything was successful, write a backup
-      this.stateService.writeDataToCollectionFile(id, data, true);
-      this.collectionLoaded = true;
-    } else {
+    if (!exists) {
       try {
         await this.attemptRecovery(id);
       } catch (recoveryError: unknown) {
@@ -649,6 +660,194 @@ export class SceneCollectionsService extends Service implements ISceneCollection
         this.setupEmptyCollection();
       }
       this.collectionLoaded = true;
+      return;
+    }
+
+    let loadedData: string | undefined;
+    let loadedResult: ILoadedCollectionData | undefined;
+    let migrationFallbackData: string | undefined;
+    let primaryError: unknown = preflight?.primaryError;
+
+    try {
+      if (preflight?.primaryError) throw preflight.primaryError;
+      if (preflight && preflight.primaryData == null) {
+        throw new Error('No primary collection file was available after preflight');
+      }
+      loadedData = preflight?.primaryData ?? this.stateService.readCollectionFile(id);
+      if (!loadedData) throw new Error('Got blank data from collection file');
+      loadedResult = await this.loadCollectionCandidate(id, loadedData);
+    } catch (error: unknown) {
+      if (isSceneCollectionOperationalError(error)) throw error;
+      primaryError = error;
+      if (isSceneCollectionMigrationError(error) && loadedData) {
+        migrationFallbackData = loadedData;
+      }
+      console.error(
+        'Error while loading collection, restoring backup:',
+        error instanceof Error ? error.message : error,
+      );
+    }
+
+    if (!loadedResult) {
+      await this.deloadPartialApplicationState();
+
+      try {
+        const backupExists = preflight
+          ? preflight.backupData != null || preflight.backupError != null
+          : await this.stateService.collectionFileExists(id, true);
+        if (!backupExists) throw primaryError;
+        if (preflight?.backupError) throw preflight.backupError;
+
+        loadedData = preflight?.backupData ?? this.stateService.readCollectionFile(id, true);
+        if (!loadedData) throw new Error('Got blank data from backup collection file');
+        loadedResult = await this.loadCollectionCandidate(id, loadedData);
+      } catch (backupError: unknown) {
+        if (isSceneCollectionOperationalError(backupError)) throw backupError;
+        if (isSceneCollectionMigrationError(backupError) && loadedData) {
+          migrationFallbackData = migrationFallbackData ?? loadedData;
+        }
+        console.error(
+          'Error while loading backup collection:',
+          backupError instanceof Error ? backupError.message : backupError,
+        );
+
+        if (migrationFallbackData) {
+          await this.deloadPartialApplicationState();
+          await this.loadDataIntoApplicationState(migrationFallbackData, false);
+          this.coordinateMigrationBlockedCollectionId = id;
+          this.collectionLoaded = true;
+          console.error(
+            'Coordinate migration was not persisted because the collection did not load completely.',
+          );
+          return;
+        }
+
+        await this.handleCollectionLoadError();
+        await this.create({ auto: true });
+        return;
+      }
+    }
+
+    if (!loadedData || !loadedResult) {
+      await this.create({ auto: true });
+      return;
+    }
+
+    // The app cannot load without a default scene.
+    if (this.scenesService.views.scenes.length === 0) {
+      console.error('Scene collection was loaded but there were no scenes.');
+      this.setupEmptyCollection();
+      this.collectionLoaded = true;
+      if (loadedResult.coordinateMigrationRequired) {
+        this.coordinateMigrationBlockedCollectionId = id;
+      }
+      return;
+    }
+
+    this.stateService.writeDataToCollectionFile(id, loadedData, true);
+    this.coordinateMigrationBlockedCollectionId = null;
+    this.collectionLoaded = true;
+
+    if (loadedResult.coordinateMigrationRequired) {
+      await this.save();
+      await this.fileManagerService.flushAll();
+    }
+  }
+
+  private async loadCollectionCandidate(id: string, data: string): Promise<ILoadedCollectionData> {
+    const root = this.parseCollectionData(data);
+    if (
+      root.requiresCoordinateMigration &&
+      !(await this.stateService.absoluteCollectionBackupExists(id))
+    ) {
+      this.stateService.writeAbsoluteCollectionBackup(id, data);
+      await this.fileManagerService.flushAll();
+    }
+
+    return this.loadDataIntoApplicationState(data, undefined, root);
+  }
+
+  private async preflightCollectionFiles(id: string): Promise<ICollectionFilePreflight> {
+    const result: ICollectionFilePreflight = {};
+    let videoResetError: SceneCollectionOperationalError | undefined;
+
+    const inspect = async (backup: boolean) => {
+      if (!(await this.stateService.collectionFileExists(id, backup))) return;
+
+      try {
+        const data = this.stateService.readCollectionFile(id, backup);
+        if (!data) throw new Error('Got blank data from scene collection preflight');
+        const root = this.parseCollectionData(data);
+        if (this.baseResolutionsDiffer(root.data.baseResolutions)) {
+          videoResetError = new SceneCollectionOperationalError(
+            'Cannot switch scene collections while a video output is active because the collection uses a different base canvas resolution.',
+          );
+        }
+
+        if (backup) result.backupData = data;
+        else result.primaryData = data;
+      } catch (error: unknown) {
+        if (backup) result.backupError = error;
+        else result.primaryError = error;
+      }
+    };
+
+    // Inspect both candidates before the live graph is removed. The backup is
+    // a normal recovery input and therefore belongs to the same preflight.
+    await inspect(false);
+    await inspect(true);
+
+    if (videoResetError) throw videoResetError;
+    if (result.primaryData == null && result.backupData == null) {
+      throw (
+        result.primaryError ?? result.backupError ?? new Error('No local collection file exists')
+      );
+    }
+    return result;
+  }
+
+  private baseResolutionsDiffer(resolutions: IBaseResolutions): boolean {
+    const current = this.videoSettingsService.baseResolutions;
+    return (['horizontal', 'vertical'] as const).some(display => {
+      return (
+        resolutions[display].baseWidth !== current[display].baseWidth ||
+        resolutions[display].baseHeight !== current[display].baseHeight
+      );
+    });
+  }
+
+  private hasActiveVideoOutput(): boolean {
+    return (
+      this.streamingService.isStreaming ||
+      this.streamingService.isRecording ||
+      this.streamingService.isReplayBufferActive ||
+      this.virtualWebcamService.views.running
+    );
+  }
+
+  private async restorePreviousCollection(
+    previousCollectionId: string | undefined,
+    previousCollectionData: string | undefined,
+    migrationWasBlocked: boolean,
+    originalError: SceneCollectionOperationalError,
+  ) {
+    if (!previousCollectionId || !previousCollectionData) return;
+
+    try {
+      await this.deloadPartialApplicationState();
+      await this.setActiveCollection(previousCollectionId);
+      await this.loadDataIntoApplicationState(previousCollectionData, false);
+      this.coordinateMigrationBlockedCollectionId = migrationWasBlocked
+        ? previousCollectionId
+        : null;
+      this.collectionLoaded = true;
+    } catch (rollbackError: unknown) {
+      throw new SceneCollectionOperationalError(
+        `Failed to restore the previous scene collection after an operational load failure: ${
+          rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+        }`,
+        { originalError, rollbackError },
+      );
     }
   }
 
@@ -669,8 +868,22 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * Parses and loads the given JSON string into application state
    * @param data Scene collection JSON data
    */
-  private async loadDataIntoApplicationState(data: string) {
-    const root: RootNode = parse(data, NODE_TYPES);
+  private parseCollectionData(data: string): RootNode {
+    const root = parse(data, NODE_TYPES);
+    if (!(root instanceof RootNode)) {
+      throw new Error('Scene collection does not contain a valid root node');
+    }
+    return root;
+  }
+
+  private async loadDataIntoApplicationState(
+    data: string,
+    strictCoordinateMigration?: boolean,
+    parsedRoot?: RootNode,
+  ): Promise<ILoadedCollectionData> {
+    const root = parsedRoot ?? this.parseCollectionData(data);
+    const strict = strictCoordinateMigration ?? root.requiresCoordinateMigration;
+    this.sourcesService.missingInputs = [];
 
     // Since scene collections are already segmented by OS,
     // the source code below which restored collections was
@@ -680,9 +893,28 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       // The underlying function already wrote all details to the log.
       // Users will see a very basic information.
       this.showUnsupportedSourcesDialog();
+      if (strict) {
+        throw new SceneCollectionMigrationError(
+          'Unsupported sources prevent a complete coordinate migration.',
+        );
+      }
     }
 
-    await root.load();
+    try {
+      await root.load({
+        loadSession: { strictCoordinateMigration: strict },
+      });
+    } catch (error: unknown) {
+      if (isSceneCollectionOperationalError(error)) throw error;
+      if (isSceneCollectionMigrationError(error)) throw error;
+      if (strict) {
+        throw new SceneCollectionMigrationError(
+          'A scene collection node failed during coordinate migration.',
+          error,
+        );
+      }
+      throw error;
+    }
     this.hotkeysService.bindHotkeys();
 
     if (this.sourcesService.missingInputs.length > 0) {
@@ -705,6 +937,8 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     if (this.newUserFirstLogin) {
       this.newUserFirstLogin = false;
     }
+
+    return { coordinateMigrationRequired: root.requiresCoordinateMigration };
   }
 
   async showUnsupportedSourcesDialog(e?: Error | unknown) {
@@ -756,7 +990,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
         const newCollection = this.collections.find(coll => coll.serverId === collection.serverId);
 
         if (newCollection) {
-          await this.load(newCollection.id, false);
+          await this.loadWithVideoResetReservation(newCollection.id, false);
           return;
         }
       }
@@ -769,6 +1003,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
    * performed while the application is already in a "LOADING" state.
    */
   private async deloadCurrentApplicationState({ save = true }: { save?: boolean } = {}) {
+    await this.videoSettingsService.flushPendingCanvasSettings();
     this.tcpServerService.stopRequestsHandling();
 
     this.collectionWillSwitch.next();
@@ -953,8 +1188,13 @@ export class SceneCollectionsService extends Service implements ISceneCollection
 
   private autoSaveInterval: number | null;
   private autoSavePromise: Promise<void>;
+  // Prevent a scoped pause from re-enabling autosave after another operation
+  // (for example shutdown) has changed its state.
+  private autoSaveRevision = 0;
 
-  enableAutoSave() {
+  enableAutoSave(expectedRevision?: number) {
+    if (expectedRevision != null && expectedRevision !== this.autoSaveRevision) return;
+    this.autoSaveRevision++;
     if (this.autoSaveInterval) return;
     this.autoSaveInterval = window.setInterval(async () => {
       if (this.streamingService.views.streamingStatus === EStreamingState.Live) return;
@@ -965,12 +1205,16 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     }, 60 * 1000);
   }
 
-  async disableAutoSave() {
+  async disableAutoSave(): Promise<{ wasEnabled: boolean; revision: number }> {
+    const wasEnabled = this.autoSaveInterval != null;
+    const revision = ++this.autoSaveRevision;
     if (this.autoSaveInterval) clearInterval(this.autoSaveInterval);
     this.autoSaveInterval = null;
 
     // Wait for the current saving process to finish
     if (this.autoSavePromise) await this.autoSavePromise;
+
+    return { wasEnabled, revision };
   }
 
   private async setActiveCollection(id: string) {

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -111,6 +111,10 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
     return this.fileManagerService.exists(filePath);
   }
 
+  async absoluteCollectionBackupExists(id: string) {
+    return this.fileManagerService.exists(this.getAbsoluteCollectionBackupPath(id));
+  }
+
   /**
    * Reads the contents of the file into a string
    * @param id The id of the collection
@@ -135,6 +139,10 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
     let collectionPath = this.getCollectionFilePath(id);
     if (backup) collectionPath = `${collectionPath}.bak`;
     this.fileManagerService.write(collectionPath, data);
+  }
+
+  writeAbsoluteCollectionBackup(id: string, data: string) {
+    this.fileManagerService.write(this.getAbsoluteCollectionBackupPath(id), data);
   }
 
   /**
@@ -177,6 +185,10 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
 
   getCollectionFilePath(id: string) {
     return path.join(this.collectionsDirectory, `${id}.json`);
+  }
+
+  getAbsoluteCollectionBackupPath(id: string) {
+    return `${this.getCollectionFilePath(id)}.absolute.bak`;
   }
 
   /**

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -292,9 +292,6 @@ export class SceneItem extends SceneItemNode {
   }
 
   loadItemAttributes(customSceneItem: ISceneItemInfo) {
-    const visible = customSceneItem.visible;
-    const position = { x: customSceneItem.x, y: customSceneItem.y };
-    const crop = customSceneItem.crop;
     const display = customSceneItem?.display ?? this?.display ?? 'horizontal';
 
     // guarantee vertical context exists to prevent null errors
@@ -304,27 +301,58 @@ export class SceneItem extends SceneItemNode {
     const context = this.videoSettingsService.contexts[display];
 
     const obsSceneItem = this.getObsSceneItem();
-    obsSceneItem.video = context as obs.IVideo;
 
     this.UPDATE({
-      visible,
+      visible: obsSceneItem.visible,
       sceneItemId: this.sceneItemId,
-      transform: {
-        position,
-        crop,
-        scale: { x: customSceneItem.scaleX, y: customSceneItem.scaleY },
-        rotation: customSceneItem.rotation,
-      },
       locked: !!customSceneItem.locked,
-      streamVisible: !!customSceneItem.streamVisible,
-      recordingVisible: !!customSceneItem.recordingVisible,
-      scaleFilter: customSceneItem.scaleFilter,
-      blendingMode: customSceneItem.blendingMode,
-      blendingMethod: customSceneItem.blendingMethod,
+      streamVisible: obsSceneItem.streamVisible,
+      recordingVisible: obsSceneItem.recordingVisible,
+      scaleFilter: obsSceneItem.scaleFilter,
+      blendingMode: obsSceneItem.blendingMode,
+      blendingMethod: obsSceneItem.blendingMethod,
       display,
       output: context,
-      position: obsSceneItem.position,
     });
+    this.refreshTransformFromObs(false);
+  }
+
+  /**
+   * Refreshes Desktop's public absolute-pixel model after OSN has invalidated
+   * its transform cache for a canvas resize. Crop reference dimensions are an
+   * internal persistence detail and intentionally stay out of this model.
+   */
+  refreshTransformFromObs(notify = true) {
+    const obsSceneItem = this.getObsSceneItem();
+    const position = obsSceneItem.position;
+    const scale = obsSceneItem.scale;
+    const crop = obsSceneItem.crop;
+
+    this.UPDATE({
+      sceneItemId: this.sceneItemId,
+      transform: {
+        position: { x: position.x, y: position.y },
+        scale: { x: scale.x, y: scale.y },
+        crop: {
+          top: crop.top,
+          right: crop.right,
+          bottom: crop.bottom,
+          left: crop.left,
+        },
+        rotation: obsSceneItem.rotation,
+      },
+      position: { x: position.x, y: position.y },
+    });
+
+    if (this.type === 'scene') {
+      const baseResolution = this.videoSettingsService.baseResolutions[
+        this.display ?? 'horizontal'
+      ];
+      this.baseWidth = baseResolution.baseWidth;
+      this.baseHeight = baseResolution.baseHeight;
+    }
+
+    if (notify) this.scenesService.itemUpdated.next(this.getModel());
   }
 
   setTransform(transform: IPartialTransform) {

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -190,8 +190,24 @@ export class SceneItem extends SceneItemNode {
           bottom: Math.round(crop.bottom),
           left: Math.round(crop.left),
         };
+        let obsCrop: obs.ICropInfo = cropModel;
+
+        // A nested scene reports the ambient canvas size to OBS on the worker
+        // thread, which may differ from the canvas where this crop was authored.
+        // Keep the reference internal so the public transform remains four-field.
+        if (this.type === 'scene') {
+          const reference = this.videoSettingsService.baseResolutions[
+            newSettings.display ?? 'horizontal'
+          ];
+          obsCrop = {
+            ...cropModel,
+            referenceWidth: reference.baseWidth,
+            referenceHeight: reference.baseHeight,
+          };
+        }
+
         changed.transform.crop = cropModel;
-        obsSceneItem.crop = cropModel;
+        obsSceneItem.crop = obsCrop;
       }
 
       if (changedTransform.rotation !== void 0) {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -464,7 +464,7 @@ export class Scene {
   }
 
   addSources(nodes: TSceneNodeInfo[]) {
-    const arrayItems: (ISceneItemInfo & obs.ISceneItemInfo)[] = [];
+    const obsSceneItems: Dictionary<obs.ISceneItem> = {};
 
     // tslint:disable-next-line:no-parameter-reassignment TODO
     nodes = nodes.filter(sceneNode => {
@@ -472,38 +472,39 @@ export class Scene {
       const source = this.sourcesService.views.getSource(sceneNode.sourceId);
       if (!source) return false;
 
-      arrayItems.push({
+      const display = sceneNode.display ?? 'horizontal';
+      const video =
+        this.videoSettingsService.contexts[display] ??
+        this.videoSettingsService.contexts.horizontal;
+      if (!video) throw new Error(`Video context ${display} is not available`);
+
+      const transform: obs.ISceneItemInfo = {
         name: source.sourceId,
-        id: sceneNode.id,
-        sourceId: source.sourceId,
-        crop: sceneNode.crop,
+        crop: sceneNode.crop ?? { top: 0, right: 0, bottom: 0, left: 0 },
         scaleX: sceneNode.scaleX == null ? 1 : sceneNode.scaleX,
         scaleY: sceneNode.scaleY == null ? 1 : sceneNode.scaleY,
-        visible: sceneNode.visible,
+        visible: sceneNode.visible !== false,
         x: sceneNode.x == null ? 0 : sceneNode.x,
         y: sceneNode.y == null ? 0 : sceneNode.y,
-        locked: sceneNode.locked,
         rotation: sceneNode.rotation || 0,
         streamVisible: sceneNode.streamVisible!,
         recordingVisible: sceneNode.recordingVisible!,
         scaleFilter: sceneNode.scaleFilter!,
         blendingMode: sceneNode.blendingMode!,
-        blendingMethod: sceneNode.blendingMethod,
-        display: sceneNode.display,
-      });
+        blendingMethod: sceneNode.blendingMethod!,
+      };
+
+      obsSceneItems[sceneNode.id] = this.getObsScene().add(source.getObsInput(), transform, video);
       return true;
     });
 
-    const obsSceneItems = obs.addItems(this.getObsScene(), arrayItems);
-
     // create folder and items
-    let itemIndex = 0;
     nodes.forEach(nodeModel => {
       const display = nodeModel?.display ?? 'horizontal';
-      const obsSceneItem = obsSceneItems[itemIndex];
       if (nodeModel.sceneNodeType === 'folder') {
         this.createFolder(nodeModel.name, { id: nodeModel.id, display });
       } else {
+        const obsSceneItem = obsSceneItems[nodeModel.id];
         this.ADD_SOURCE_TO_SCENE(
           nodeModel.id,
           nodeModel.sourceId,
@@ -513,7 +514,6 @@ export class Scene {
         );
         const item = this.getItem(nodeModel.id)!;
         item.loadItemAttributes(nodeModel);
-        itemIndex++;
       }
     });
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -465,6 +465,7 @@ export class Scene {
 
   addSources(nodes: TSceneNodeInfo[]) {
     const obsSceneItems: Dictionary<obs.ISceneItem> = {};
+    const obsScene = this.getObsScene();
 
     // tslint:disable-next-line:no-parameter-reassignment TODO
     nodes = nodes.filter(sceneNode => {
@@ -494,7 +495,7 @@ export class Scene {
         blendingMethod: sceneNode.blendingMethod!,
       };
 
-      obsSceneItems[sceneNode.id] = this.getObsScene().add(source.getObsInput(), transform, video);
+      obsSceneItems[sceneNode.id] = obsScene.add(source.getObsInput(), transform, video);
       return true;
     });
 

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -11,12 +11,21 @@ import {
   EVideoFormat,
   EColorSpace,
   ERangeType,
+  SceneFactory,
 } from '../../../obs-api';
 import { DualOutputService } from 'services/dual-output';
 import { SettingsService } from 'services/settings';
 import { OutputSettingsService } from 'services/settings/output';
 import { Subject } from 'rxjs';
 import { horizontalDisplayData } from './default-settings-data';
+import isEqual from 'lodash/isEqual';
+import { Mutex } from 'util/mutex';
+import { videoOutputCoordinator } from 'services/video-output-coordinator';
+import type { SceneCollectionsService } from 'services/scene-collections';
+import type { ScenesService } from 'services/scenes';
+import type { StreamingService } from 'services/streaming';
+import type { VirtualWebcamService } from 'services/virtual-webcam';
+import type { FileManagerService } from 'services/file-manager';
 
 /**
  * Display Types
@@ -30,6 +39,20 @@ export type TDisplayType = typeof displays[number];
 export interface IVideoSetting {
   horizontal: IVideoInfo;
   vertical: IVideoInfo;
+}
+
+export interface IBaseResolution {
+  baseWidth: number;
+  baseHeight: number;
+}
+
+export type IBaseResolutions = Record<TDisplayType, IBaseResolution>;
+
+type TVideoSettingsPatches = Partial<Record<TDisplayType, Partial<IVideoInfo>>>;
+
+interface IAppliedVideoSettings {
+  baseResolutionChanged: boolean;
+  previous: Partial<Record<TDisplayType, IVideoInfo>>;
 }
 
 export type IVideoInfoValue =
@@ -89,6 +112,11 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
   @Inject() dualOutputService: DualOutputService;
   @Inject() settingsService: SettingsService;
   @Inject() outputSettingsService: OutputSettingsService;
+  @Inject() private sceneCollectionsService: SceneCollectionsService;
+  @Inject() private scenesService: ScenesService;
+  @Inject() private streamingService: StreamingService;
+  @Inject() private virtualWebcamService: VirtualWebcamService;
+  @Inject() private fileManagerService: FileManagerService;
 
   initialState = {
     horizontal: null as IVideoInfo,
@@ -113,6 +141,15 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     horizontal: null as IVideo,
     vertical: null as IVideo,
   };
+
+  private readonly videoSettingsMutex = new Mutex();
+  private pendingCanvasSettings: TVideoSettingsPatches = {};
+  private pendingCanvasSettingsTimer: number | null = null;
+  private canvasSettingsFlushPromise: Promise<void> | null = null;
+  private pendingCanvasSettingsWaiters: Array<{
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  }> = [];
 
   get values() {
     return {
@@ -459,18 +496,284 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     }
   }
 
-  @debounce(200)
-  updateObsSettings(display: TDisplayType = 'horizontal', shouldSyncFPS: Boolean = false) {
-    // confirm all vertical fps settings are synced to the horizontal fps settings
-    // update contexts to values on state
-    this.contexts[display].video = this.state[display];
-    this.contexts[display].legacySettings = this.state[display];
-    if (shouldSyncFPS) {
-      this.syncFPSSettings();
+  /**
+   * Applies collection-authored base resolutions before any scene graph is
+   * recreated. SceneCollectionsService owns the surrounding loading mode and
+   * output-start reservation.
+   */
+  async applyCollectionBaseResolutions(resolutions: IBaseResolutions): Promise<boolean> {
+    return this.videoSettingsMutex.do(() => {
+      const result = this.applyVideoSettingsPatches({
+        horizontal: resolutions.horizontal,
+        vertical: resolutions.vertical,
+      });
+      return result.baseResolutionChanged;
+    });
+  }
+
+  private changesBaseResolution(patch: Partial<IVideoInfo>, display: TDisplayType): boolean {
+    const pending = this.pendingCanvasSettings[display];
+    return (['baseWidth', 'baseHeight'] as const).some(key => {
+      if (!Object.prototype.hasOwnProperty.call(patch, key)) return false;
+      return (
+        Object.prototype.hasOwnProperty.call(pending ?? {}, key) ||
+        patch[key] !== this.state[display]?.[key]
+      );
+    });
+  }
+
+  private queueCanvasSettings(
+    patch: Partial<IVideoInfo>,
+    display: TDisplayType,
+    shouldSyncFPS = false,
+  ): Promise<void> {
+    this.pendingCanvasSettings[display] = {
+      ...this.pendingCanvasSettings[display],
+      ...patch,
+    };
+    if (shouldSyncFPS && display === 'horizontal') this.queueSynchronizedFpsSettings();
+
+    if (this.pendingCanvasSettingsTimer != null) {
+      window.clearTimeout(this.pendingCanvasSettingsTimer);
+    }
+
+    const result = new Promise<void>((resolve, reject) => {
+      this.pendingCanvasSettingsWaiters.push({ resolve, reject });
+    });
+
+    this.pendingCanvasSettingsTimer = window.setTimeout(() => {
+      void this.flushPendingCanvasSettings().catch(() => undefined);
+    }, 200);
+
+    // Some legacy callers intentionally ignore the return value. Keep their
+    // behavior while still allowing callers that await the operation to react.
+    result.catch(error => console.error('Failed to update the base canvas resolution', error));
+    return result;
+  }
+
+  private queueSynchronizedFpsSettings() {
+    const horizontal = {
+      ...this.state.horizontal,
+      ...this.pendingCanvasSettings.horizontal,
+    };
+    const fpsSettings: Array<keyof IVideoInfo> = ['scaleType', 'fpsType', 'fpsNum', 'fpsDen'];
+    const verticalPatch = fpsSettings.reduce((patch, key) => {
+      patch[key] = horizontal[key] as never;
+      return patch;
+    }, {} as Partial<IVideoInfo>);
+    this.pendingCanvasSettings.vertical = {
+      ...this.pendingCanvasSettings.vertical,
+      ...verticalPatch,
+    };
+  }
+
+  async flushPendingCanvasSettings(): Promise<void> {
+    if (this.canvasSettingsFlushPromise) {
+      await this.canvasSettingsFlushPromise;
+      if (this.pendingCanvasSettingsWaiters.length) await this.flushPendingCanvasSettings();
+      return;
+    }
+    if (!this.pendingCanvasSettingsWaiters.length) return;
+
+    if (this.pendingCanvasSettingsTimer != null) {
+      window.clearTimeout(this.pendingCanvasSettingsTimer);
+    }
+    const patches = this.pendingCanvasSettings;
+    const waiters = this.pendingCanvasSettingsWaiters;
+    this.pendingCanvasSettings = {};
+    this.pendingCanvasSettingsWaiters = [];
+    this.pendingCanvasSettingsTimer = null;
+
+    const flushPromise = this.runCanvasSettingsTransaction(patches);
+    this.canvasSettingsFlushPromise = flushPromise;
+    try {
+      await flushPromise;
+      waiters.forEach(waiter => waiter.resolve());
+    } catch (error: unknown) {
+      waiters.forEach(waiter => waiter.reject(error));
+      throw error;
+    } finally {
+      if (this.canvasSettingsFlushPromise === flushPromise) {
+        this.canvasSettingsFlushPromise = null;
+      }
+    }
+
+    if (this.pendingCanvasSettingsWaiters.length) await this.flushPendingCanvasSettings();
+  }
+
+  private async runCanvasSettingsTransaction(patches: TVideoSettingsPatches): Promise<void> {
+    await this.videoSettingsMutex.do(async () => {
+      const releaseVideoReset = videoOutputCoordinator.reserveVideoReset();
+      let autoSaveState: Awaited<
+        ReturnType<SceneCollectionsService['disableAutoSave']>
+      > | null = null;
+      let appliedSettings: IAppliedVideoSettings | null = null;
+
+      try {
+        this.assertVideoOutputsInactive();
+        autoSaveState = await this.sceneCollectionsService.disableAutoSave();
+        appliedSettings = this.applyVideoSettingsPatches(patches);
+        if (!appliedSettings.baseResolutionChanged) return;
+
+        this.refreshSceneItemTransforms();
+        await this.sceneCollectionsService.save();
+        await this.fileManagerService.flushAll();
+      } catch (error: unknown) {
+        if (appliedSettings) {
+          try {
+            this.applyVideoSettingsPatches(appliedSettings.previous);
+            this.refreshSceneItemTransforms();
+            await this.sceneCollectionsService.save();
+            await this.fileManagerService.flushAll();
+          } catch (rollbackError: unknown) {
+            const message =
+              rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+            throw new Error(`Failed to roll back the canvas resolution change: ${message}`);
+          }
+        }
+        throw error;
+      } finally {
+        if (autoSaveState?.wasEnabled) {
+          this.sceneCollectionsService.enableAutoSave(autoSaveState.revision);
+        }
+        releaseVideoReset();
+      }
+    });
+  }
+
+  private assertVideoOutputsInactive() {
+    if (
+      this.streamingService.isStreaming ||
+      this.streamingService.isRecording ||
+      this.streamingService.isReplayBufferActive ||
+      this.virtualWebcamService.views.running
+    ) {
+      throw new Error('The base canvas resolution cannot change while a video output is active.');
     }
   }
 
-  updateVideoSettings(patch: Partial<IVideoInfo>, display: TDisplayType = 'horizontal') {
+  private applyVideoSettingsPatches(patches: TVideoSettingsPatches): IAppliedVideoSettings {
+    const updates: Array<{
+      display: TDisplayType;
+      previous: IVideoInfo;
+      next: IVideoInfo;
+    }> = [];
+    let baseResolutionChanged = false;
+
+    displays.forEach(display => {
+      const patch = patches[display];
+      if (!patch) return;
+      this.ensureVideoContext(display);
+
+      const previous = { ...(this.state[display] ?? this.contexts[display].video) };
+      const next = { ...previous, ...patch };
+      this.validateVideoDimensions(next);
+      if (isEqual(previous, next)) return;
+
+      if (previous.baseWidth !== next.baseWidth || previous.baseHeight !== next.baseHeight) {
+        baseResolutionChanged = true;
+      }
+      updates.push({ display, previous, next });
+    });
+
+    const applied: typeof updates = [];
+    try {
+      updates.forEach(update => {
+        this.contexts[update.display].video = update.next;
+        applied.push(update);
+      });
+
+      updates.forEach(update => {
+        this.SET_VIDEO_CONTEXT(update.display, { ...update.next });
+        this.contexts[update.display].legacySettings = update.next;
+        this.dualOutputService.updateVideoSettings(update.next, update.display);
+      });
+      if (updates.length) this.settingsService.refreshVideoSettings();
+    } catch (error: unknown) {
+      let rollbackError: unknown;
+      [...applied].reverse().forEach(update => {
+        try {
+          this.contexts[update.display].video = update.previous;
+        } catch (error: unknown) {
+          rollbackError = rollbackError ?? error;
+        }
+      });
+
+      updates.forEach(update => {
+        this.SET_VIDEO_CONTEXT(update.display, { ...update.previous });
+        this.contexts[update.display].legacySettings = update.previous;
+        this.dualOutputService.updateVideoSettings(update.previous, update.display);
+      });
+      if (updates.length) this.settingsService.refreshVideoSettings();
+
+      if (rollbackError) {
+        const message =
+          rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+        throw new Error(`Video reset failed and its rollback also failed: ${message}`);
+      }
+      throw error;
+    }
+
+    return {
+      baseResolutionChanged,
+      previous: updates.reduce((result, update) => {
+        result[update.display] = update.previous;
+        return result;
+      }, {} as Partial<Record<TDisplayType, IVideoInfo>>),
+    };
+  }
+
+  private ensureVideoContext(display: TDisplayType) {
+    if (this.contexts[display]) return;
+    if (!this.establishVideoContext(display) || !this.contexts[display]) {
+      throw new Error(`The ${display} video context could not be established.`);
+    }
+  }
+
+  private validateVideoDimensions(settings: IVideoInfo) {
+    const dimensions = [
+      settings.baseWidth,
+      settings.baseHeight,
+      settings.outputWidth,
+      settings.outputHeight,
+    ];
+    if (
+      dimensions.some(
+        dimension => !Number.isInteger(dimension) || dimension < 2 || dimension > 32 * 1024,
+      )
+    ) {
+      throw new Error('Video dimensions must be whole numbers between 2 and 32768.');
+    }
+  }
+
+  private refreshSceneItemTransforms() {
+    SceneFactory.invalidateItemTransformCache();
+    this.scenesService.views
+      .getSceneItems()
+      .forEach(sceneItem => sceneItem.refreshTransformFromObs());
+  }
+
+  @debounce(200)
+  async updateObsSettings(display: TDisplayType = 'horizontal', shouldSyncFPS: Boolean = false) {
+    await this.videoSettingsMutex.do(() => {
+      // confirm all vertical fps settings are synced to the horizontal fps settings
+      // update contexts to values on state
+      this.contexts[display].video = this.state[display];
+      this.contexts[display].legacySettings = this.state[display];
+      if (shouldSyncFPS) {
+        this.syncFPSSettings();
+      }
+    });
+  }
+
+  updateVideoSettings(
+    patch: Partial<IVideoInfo>,
+    display: TDisplayType = 'horizontal',
+  ): Promise<void> | void {
+    if (this.changesBaseResolution(patch, display)) {
+      return this.queueCanvasSettings(patch, display);
+    }
+
     const newVideoSettings = { ...this.state[display], ...patch };
 
     this.SET_VIDEO_CONTEXT(display, newVideoSettings);
@@ -492,7 +795,18 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     value: IVideoInfoValue,
     display: TDisplayType = 'horizontal',
     shouldSyncFPS: Boolean = false,
-  ) {
+  ): Promise<void> | void {
+    if (
+      (key === 'baseWidth' || key === 'baseHeight') &&
+      this.changesBaseResolution({ [key]: value } as Partial<IVideoInfo>, display)
+    ) {
+      return this.queueCanvasSettings(
+        { [key]: value } as Partial<IVideoInfo>,
+        display,
+        !!shouldSyncFPS,
+      );
+    }
+
     this.SET_VIDEO_SETTING(key, value, display);
     this.updateObsSettings(display, shouldSyncFPS);
 
@@ -509,7 +823,18 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
    * @param display - name of context (aka display) to apply setting to. Default is horizontal.
    * @param settings - collection of key/value pairs. Each pair is a video setting and its' value.
    */
-  setVideoSettings(display: TDisplayType = 'horizontal', settings: ObsSetting[]) {
+  setVideoSettings(
+    display: TDisplayType = 'horizontal',
+    settings: ObsSetting[],
+  ): Promise<void> | void {
+    const patch = settings.reduce((result, setting) => {
+      result[setting.key] = setting.value as never;
+      return result;
+    }, {} as Partial<IVideoInfo>);
+    if (this.changesBaseResolution(patch, display)) {
+      return this.queueCanvasSettings(patch, display, true);
+    }
+
     for (let i = 0; i < settings.length; i++) {
       const setting: ObsSetting = settings[i];
       this.SET_VIDEO_SETTING(setting.key, setting.value, display);
@@ -525,7 +850,14 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     }
   }
 
-  setSettings(settings: Partial<IVideoInfo>, display: TDisplayType = 'horizontal') {
+  setSettings(
+    settings: Partial<IVideoInfo>,
+    display: TDisplayType = 'horizontal',
+  ): Promise<void> | void {
+    if (this.changesBaseResolution(settings, display)) {
+      return this.queueCanvasSettings(settings, display);
+    }
+
     this.SET_SETTINGS(settings, display);
 
     this.updateObsSettings(display);

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -991,10 +991,13 @@ export class OutputSettingsService extends Service {
     }
     const currentSettings = this.getSettings();
 
+    let videoSettingsUpdate: Promise<void> | void;
     if (settingsPatch.inputResolution) {
       const [width, height] = settingsPatch.inputResolution.split('x');
-      this.videoSettingsService.setVideoSetting('baseWidth', Number(width));
-      this.videoSettingsService.setVideoSetting('baseHeight', Number(height));
+      videoSettingsUpdate = this.videoSettingsService.setSettings({
+        baseWidth: Number(width),
+        baseHeight: Number(height),
+      });
     }
 
     if (settingsPatch.streaming) {
@@ -1006,6 +1009,8 @@ export class OutputSettingsService extends Service {
     }
 
     if (settingsPatch.replayBuffer) this.setReplayBufferSettings(settingsPatch.replayBuffer);
+
+    return videoSettingsUpdate;
   }
 
   private setReplayBufferSettings(replayBufferSettings: Partial<IReplayBufferSettings>) {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -102,6 +102,7 @@ import {
   shouldStopStreamingContext as shouldStopStreamingOutputContext,
   TStreamingDisplay,
 } from './output-context';
+import { videoOutputCoordinator } from 'services/video-output-coordinator';
 
 type TOBSOutputType = 'streaming' | 'recording' | 'replayBuffer';
 type TOutputContext = TDisplayType | 'enhancedBroadcasting' | 'stream' | 'streamSecond';
@@ -446,7 +447,7 @@ export class StreamingService
       (!this.streamSettingsService.state.protectedModeEnabled &&
         this.userService.state.auth?.primaryPlatform !== 'twitch') // twitch is a special case
     ) {
-      this.finishStartStreaming();
+      await this.finishStartStreaming();
       return;
     }
 
@@ -1556,6 +1557,15 @@ export class StreamingService
   }
 
   async finishStartStreaming(): Promise<unknown> {
+    const releaseOutputStart = videoOutputCoordinator.beginOutputStart();
+    try {
+      return await this.finishStartStreamingWithReservation();
+    } finally {
+      releaseOutputStart();
+    }
+  }
+
+  private async finishStartStreamingWithReservation(): Promise<unknown> {
     // register a promise that we should reject or resolve in the `handleStreamingSignal`
     const startStreamingPromise = new Promise((resolve, reject) => {
       this.resolveStartStreaming = resolve;
@@ -2599,6 +2609,15 @@ export class StreamingService
   }
 
   private async handleStartRecording() {
+    const releaseOutputStart = videoOutputCoordinator.beginOutputStart();
+    try {
+      await this.handleStartRecordingWithReservation();
+    } finally {
+      releaseOutputStart();
+    }
+  }
+
+  private async handleStartRecordingWithReservation() {
     // Only attempt to create recording instances if the recording status is offline
     // This prevents errors when trying to create a recording instance when one already exists
     if (this.isRecording) {
@@ -3306,7 +3325,13 @@ export class StreamingService
    */
 
   startReplayBuffer(): void {
+    void this.startReplayBufferWithReservation();
+  }
+
+  private async startReplayBufferWithReservation(): Promise<void> {
+    let releaseOutputStart = () => {};
     try {
+      releaseOutputStart = videoOutputCoordinator.beginOutputStart();
       // Only attempt to create or start the replay buffer instance if the replay buffer is offline
       if (this.views.isReplayBufferActive) {
         console.warn('Replay buffer is already active');
@@ -3322,12 +3347,12 @@ export class StreamingService
       // recording instance first in the app's current session. A band-aid solution is to always create the
       // horizontal recording instance and then destroy it since we won't be using it.
       if (display === 'vertical' && this.contexts.horizontal.recording === null) {
-        this.createTemporaryHorizontalRecording();
+        await this.createTemporaryHorizontalRecording();
       }
 
       this.SET_REPLAY_BUFFER_STATUS(EReplayBufferState.Running, display);
       const audioTrack = display === 'horizontal' ? 1 : 2;
-      this.createReplayBuffer({ display, audioTrack });
+      await this.createReplayBuffer({ display, audioTrack });
     } catch (e: unknown) {
       console.error('Error toggling replay buffer:', e);
 
@@ -3349,6 +3374,8 @@ export class StreamingService
         EOutputCode.Error,
         message,
       );
+    } finally {
+      releaseOutputStart();
     }
   }
 

--- a/app/services/ts-importer.ts
+++ b/app/services/ts-importer.ts
@@ -211,17 +211,19 @@ export class TwitchStudioImporterService extends StatefulService<{
     await this.sceneCollectionsService.create({
       name: 'Twitch Studio Imported',
       setupFunction: async () => {
-        this.setupVideo(config);
-        this.importScenes(config);
+        await this.setupVideo(config);
+        await this.importScenes(config);
 
         return this.scenesService.views.scenes.length !== 0;
       },
     });
   }
 
-  setupVideo(config: ITSConfig) {
-    this.videoSettingsService.setVideoSetting('baseWidth', config.graphics.canvasWidth);
-    this.videoSettingsService.setVideoSetting('baseHeight', config.graphics.canvasHeight);
+  async setupVideo(config: ITSConfig) {
+    await this.videoSettingsService.setSettings({
+      baseWidth: config.graphics.canvasWidth,
+      baseHeight: config.graphics.canvasHeight,
+    });
   }
 
   async importScenes(config: ITSConfig) {

--- a/app/services/video-output-coordinator.ts
+++ b/app/services/video-output-coordinator.ts
@@ -1,0 +1,41 @@
+/**
+ * Coordinates video-context resets with output startup. Active outputs are
+ * checked by the caller; this closes the smaller race where an output begins
+ * while a reset transaction is being prepared (or vice versa).
+ */
+class VideoOutputCoordinator {
+  private outputStartsInProgress = 0;
+  private videoResetReservations = 0;
+
+  beginOutputStart(): () => void {
+    if (this.videoResetReservations > 0) {
+      throw new Error('A video canvas change is currently in progress.');
+    }
+
+    this.outputStartsInProgress++;
+    return this.createRelease(() => this.outputStartsInProgress--);
+  }
+
+  reserveVideoReset(): () => void {
+    if (this.outputStartsInProgress > 0) {
+      throw new Error('A video output is currently starting.');
+    }
+    if (this.videoResetReservations > 0) {
+      throw new Error('Another video canvas operation is already in progress.');
+    }
+
+    this.videoResetReservations++;
+    return this.createRelease(() => this.videoResetReservations--);
+  }
+
+  private createRelease(release: () => void): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      release();
+    };
+  }
+}
+
+export const videoOutputCoordinator = new VideoOutputCoordinator();

--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -13,6 +13,7 @@ import { EOBSOutputType, EOBSOutputSignal, IOBSOutputSignalInfo } from './core/s
 import os from 'os';
 import { SignalsService } from './signals-manager';
 import { $t } from 'services/i18n';
+import { videoOutputCoordinator } from 'services/video-output-coordinator';
 
 const PLUGIN_PLIST_PATH =
   '/Library/CoreMediaIO/Plug-Ins/DAL/vcam-plugin.plugin/Contents/Info.plist';
@@ -260,14 +261,18 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
   start() {
     if (this.state.running) return;
 
+    let releaseOutputStart = () => {};
     try {
+      releaseOutputStart = videoOutputCoordinator.beginOutputStart();
       obs.NodeObs.OBS_service_startVirtualCam();
+      this.SET_RUNNING(true);
+      this.runningChanged.next(true);
     } catch (error: unknown) {
       this.handleUnknownVirtualCamError(error);
       return;
+    } finally {
+      releaseOutputStart();
     }
-    this.SET_RUNNING(true);
-    this.runningChanged.next(true);
 
     this.usageStatisticsService.recordFeatureUsage('VirtualWebcam');
   }

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "relative-coordinates2",
+      "version": "0.27.6",
       "win64": true,
       "osx": true
     },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.27.4",
+      "version": "relative-coordinates2",
       "win64": true,
       "osx": true
     },

--- a/test/regular/relative-coordinates.ts
+++ b/test/regular/relative-coordinates.ts
@@ -7,6 +7,32 @@ import { VideoSettingsService } from '../../app/services/settings-v2/video';
 import { StreamingService } from '../../app/services/streaming';
 import { sleep } from '../helpers/sleep';
 import { startRecording, stopRecording } from '../helpers/modules/streaming';
+import { focusMain, focusWindow } from '../helpers/modules/core';
+
+const fs = require('fs');
+const path = require('path');
+
+interface IPersistedSceneCollection {
+  relativeCoordinates: boolean;
+  baseResolutions: {
+    horizontal: { baseWidth: number; baseHeight: number };
+  };
+  scenes: {
+    items: Array<{
+      id: string;
+      sceneItems: {
+        items: Array<{
+          id: string;
+          x: number;
+          y: number;
+          scaleX: number;
+          scaleY: number;
+          display?: string;
+        }>;
+      };
+    }>;
+  };
+}
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -279,4 +305,116 @@ test('Rapid canvas width and height updates are applied as one coherent resize',
   t.true(approximatelyEqual(resizedTransform.scale.x, resizeFactor));
   t.true(approximatelyEqual(resizedTransform.scale.y, resizeFactor));
   t.is(loadingWatcher.receivedEvents.length, 0, 'debounced resizing remains seamless');
+});
+
+test('A persistence failure rolls back the canvas resolution and scene transforms', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const scene = scenesService.createScene('Relative Coordinates Rollback Scene');
+  const item = scene.createAndAddSource('Rollback Source', 'color_source');
+  const originalVideo = { ...videoSettingsService.state.horizontal };
+  const targetVideo = {
+    baseWidth: Math.max(2, Math.floor(originalVideo.baseWidth * 0.75)),
+    baseHeight: Math.max(2, Math.floor(originalVideo.baseHeight * 0.75)),
+  };
+
+  item.setTransform({
+    position: { x: originalVideo.baseWidth * 0.4, y: originalVideo.baseHeight * 0.3 },
+    scale: { x: 0.8, y: 1.1 },
+  });
+  const originalTransform = item.getModel().transform;
+
+  t.true(await focusWindow('worker'), 'worker window is available');
+  await t.context.app.client.execute(`
+    (() => {
+      const fileManager = window.servicesManager.getResource('FileManagerService');
+      const originalFlushAll = fileManager.flushAll;
+      let shouldFail = true;
+
+      window.__restoreRelativeCoordinatesFlushAll = () => {
+        fileManager.flushAll = originalFlushAll;
+        delete window.__restoreRelativeCoordinatesFlushAll;
+      };
+      fileManager.flushAll = function(...args) {
+        if (shouldFail) {
+          shouldFail = false;
+          return Promise.reject(new Error('Injected canvas persistence failure'));
+        }
+        return originalFlushAll.apply(this, args);
+      };
+    })();
+    0;
+  `);
+  await focusMain();
+
+  skipCheckingErrorsInLog();
+  let rejection: { error?: string } | undefined;
+  try {
+    await Promise.resolve(videoSettingsService.setSettings(targetVideo, 'horizontal'));
+  } catch (error: unknown) {
+    rejection = error as { error?: string };
+  } finally {
+    await focusWindow('worker');
+    await t.context.app.client.execute(`
+      if (window.__restoreRelativeCoordinatesFlushAll) {
+        window.__restoreRelativeCoordinatesFlushAll();
+      }
+      0;
+    `);
+    await focusMain();
+  }
+
+  t.regex(rejection?.error ?? '', /Injected canvas persistence failure/);
+  t.deepEqual(videoSettingsService.state.horizontal, originalVideo);
+  const rolledBackTransform = item.getModel().transform;
+  t.true(approximatelyEqual(rolledBackTransform.position.x, originalTransform.position.x));
+  t.true(approximatelyEqual(rolledBackTransform.position.y, originalTransform.position.y));
+  t.true(approximatelyEqual(rolledBackTransform.scale.x, originalTransform.scale.x));
+  t.true(approximatelyEqual(rolledBackTransform.scale.y, originalTransform.scale.y));
+  t.deepEqual(rolledBackTransform.crop, originalTransform.crop);
+  t.is(rolledBackTransform.rotation, originalTransform.rotation);
+
+  const collectionPath = path.join(
+    t.context.cacheDir,
+    'slobs-client',
+    'SceneCollections',
+    `${sceneCollectionsService.activeCollection.id}.json`,
+  );
+  const persisted = JSON.parse(
+    fs.readFileSync(collectionPath).toString(),
+  ) as IPersistedSceneCollection;
+  const persistedScene = persisted.scenes.items.find(candidate => candidate.id === scene.id);
+  const persistedItem = persistedScene?.sceneItems.items.find(
+    candidate => candidate.id === item.id,
+  );
+
+  t.true(persisted.relativeCoordinates);
+  t.deepEqual(persisted.baseResolutions.horizontal, {
+    baseWidth: originalVideo.baseWidth,
+    baseHeight: originalVideo.baseHeight,
+  });
+  t.truthy(persistedScene);
+  t.truthy(persistedItem);
+  t.true(approximatelyEqual(persistedItem!.x, originalTransform.position.x));
+  t.true(approximatelyEqual(persistedItem!.y, originalTransform.position.y));
+  t.true(approximatelyEqual(persistedItem!.scaleX, originalTransform.scale.x));
+  t.true(approximatelyEqual(persistedItem!.scaleY, originalTransform.scale.y));
+  t.is(persistedItem!.display, 'horizontal');
+
+  await videoSettingsService.setSettings(targetVideo, 'horizontal');
+
+  const resizedTransform = item.getModel().transform;
+  const resizeFactor = targetVideo.baseHeight / originalVideo.baseHeight;
+  t.is(videoSettingsService.state.horizontal.baseWidth, targetVideo.baseWidth);
+  t.is(videoSettingsService.state.horizontal.baseHeight, targetVideo.baseHeight);
+  t.true(
+    approximatelyEqual(resizedTransform.position.x, originalTransform.position.x * resizeFactor),
+  );
+  t.true(
+    approximatelyEqual(resizedTransform.position.y, originalTransform.position.y * resizeFactor),
+  );
 });

--- a/test/regular/relative-coordinates.ts
+++ b/test/regular/relative-coordinates.ts
@@ -1,0 +1,76 @@
+import { test, useWebdriver } from '../helpers/webdriver';
+import { getApiClient } from '../helpers/api-client';
+import { ScenesService } from '../../app/services/scenes';
+import { VideoSettingsService } from '../../app/services/settings-v2/video';
+import { sleep } from '../helpers/sleep';
+
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
+useWebdriver();
+
+function approximatelyEqual(actual: number, expected: number) {
+  return Math.abs(actual - expected) < 0.01;
+}
+
+test('Base canvas changes scale only items assigned to that canvas', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const scene = scenesService.createScene('Relative Coordinates Scene');
+  const sourceItem = scene.createAndAddSource('Relative Coordinates', 'color_source');
+  const verticalItem = scene.addSource(sourceItem.sourceId, {
+    display: 'vertical',
+    select: false,
+  });
+  const horizontalItem = sourceItem;
+  const originalHorizontal = { ...videoSettingsService.state.horizontal };
+
+  horizontalItem.setTransform({
+    position: {
+      x: originalHorizontal.baseWidth / 2,
+      y: originalHorizontal.baseHeight / 2,
+    },
+    scale: { x: 1, y: 1 },
+  });
+  verticalItem.setTransform({
+    position: { x: 120, y: 240 },
+    scale: { x: 0.75, y: 0.75 },
+  });
+
+  const originalVerticalTransform = verticalItem.getModel().transform;
+  const targetBaseWidth = Math.max(2, Math.floor(originalHorizontal.baseWidth / 2));
+  const targetBaseHeight = Math.max(2, Math.floor(originalHorizontal.baseHeight / 2));
+  const loadingWatcher = client.watchForEvents(['AppService.loadingChanged']);
+  await sleep(100);
+
+  try {
+    await videoSettingsService.setSettings({
+      baseWidth: targetBaseWidth,
+      baseHeight: targetBaseHeight,
+    });
+    await sleep(100);
+
+    const resizedHorizontal = horizontalItem.getModel().transform;
+    const resizedVertical = verticalItem.getModel().transform;
+    t.is(loadingWatcher.receivedEvents.length, 0, 'canvas resizing remains seamless');
+    t.true(approximatelyEqual(resizedHorizontal.position.x, targetBaseWidth / 2));
+    t.true(approximatelyEqual(resizedHorizontal.position.y, targetBaseHeight / 2));
+    t.true(
+      approximatelyEqual(
+        resizedHorizontal.scale.x,
+        targetBaseHeight / originalHorizontal.baseHeight,
+      ),
+    );
+    t.deepEqual(resizedVertical, originalVerticalTransform);
+
+    const transformBeforeOutputChange = horizontalItem.getModel().transform;
+    videoSettingsService.setSettings({
+      outputWidth: originalHorizontal.outputWidth === 640 ? 644 : 640,
+      outputHeight: originalHorizontal.outputHeight === 360 ? 362 : 360,
+    });
+    await sleep(500);
+    t.deepEqual(horizontalItem.getModel().transform, transformBeforeOutputChange);
+  } finally {
+    await videoSettingsService.setSettings(originalHorizontal);
+  }
+});

--- a/test/regular/relative-coordinates.ts
+++ b/test/regular/relative-coordinates.ts
@@ -279,6 +279,114 @@ test('Canvas resizing is rejected while recording and succeeds after recording s
   );
 });
 
+test('Collection switching with different base resolutions is rejected while recording', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ExternalScenesService>('ScenesService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const streamingService = client.getResource<StreamingService>('StreamingService');
+  const currentCollectionId = sceneCollectionsService.activeCollection.id;
+  const originalVideo = { ...videoSettingsService.state.horizontal };
+  const currentScene = scenesService.createScene('Recording Collection Preflight Scene');
+  const currentItem = currentScene.createAndAddSource(
+    'Recording Collection Preflight Source',
+    'color_source',
+  );
+  const targetVideo = {
+    baseWidth: Math.max(2, Math.floor(originalVideo.baseWidth * 0.75)),
+    baseHeight: Math.max(2, Math.floor(originalVideo.baseHeight * 0.75)),
+  };
+
+  currentItem.setTransform({
+    position: { x: originalVideo.baseWidth * 0.35, y: originalVideo.baseHeight * 0.45 },
+    scale: { x: 0.8, y: 1.1 },
+  });
+  const currentSceneId = currentScene.id;
+  const currentItemId = currentItem.sceneItemId;
+
+  const targetCollection = await sceneCollectionsService.create({
+    name: 'Different Resolution Recording Target',
+  });
+  await sceneCollectionsService.load(currentCollectionId);
+
+  // Build the target fixture through Desktop's managed file cache so setup
+  // does not need an otherwise unrelated live canvas reset and switch back.
+  const targetCollectionPath = path.join(
+    t.context.cacheDir,
+    'slobs-client',
+    'SceneCollections',
+    `${targetCollection.id}.json`,
+  );
+  t.true(await focusWindow('worker'), 'worker window is available');
+  await t.context.app.client.execute(`
+    (() => {
+      const fileManager = window.servicesManager.getResource('FileManagerService');
+      const collectionPath = ${JSON.stringify(targetCollectionPath)};
+      const targetVideo = ${JSON.stringify(targetVideo)};
+      const collection = JSON.parse(fileManager.read(collectionPath, { validateJSON: true }));
+
+      collection.baseResolution = { ...collection.baseResolution, ...targetVideo };
+      collection.baseResolutions.horizontal = {
+        ...collection.baseResolutions.horizontal,
+        ...targetVideo,
+      };
+      fileManager.write(collectionPath, JSON.stringify(collection, null, 2));
+    })();
+    0;
+  `);
+  await focusMain();
+
+  const reloadedScene = scenesService.getScene(currentSceneId);
+  const reloadedItem = reloadedScene.getItem(currentItemId);
+  const expectedSceneNames = scenesService.getSceneNames();
+  const expectedActiveSceneId = scenesService.activeSceneId;
+  const expectedTransform = reloadedItem.getModel().transform;
+  const expectedSourceId = reloadedItem.sourceId;
+
+  t.deepEqual(videoSettingsService.state.horizontal, originalVideo);
+
+  await startRecording();
+  try {
+    // This rejection is expected and may be logged by the RPC promise handler.
+    skipCheckingErrorsInLog();
+    const switchWatcher = client.watchForEvents([
+      'SceneCollectionsService.collectionWillSwitch',
+      'SceneCollectionsService.collectionSwitched',
+    ]);
+    await sleep(100);
+
+    let rejection: { error?: string } | undefined;
+    try {
+      await sceneCollectionsService.load(targetCollection.id);
+    } catch (error: unknown) {
+      rejection = error as { error?: string };
+    }
+    await sleep(100);
+
+    t.regex(rejection?.error ?? '', /different base canvas resolution/i);
+    t.true(streamingService.isRecording);
+    t.is(sceneCollectionsService.activeCollection.id, currentCollectionId);
+    t.is(scenesService.activeSceneId, expectedActiveSceneId);
+    t.deepEqual(scenesService.getSceneNames(), expectedSceneNames);
+    t.is(switchWatcher.receivedEvents.length, 0, 'scene graph teardown never begins');
+
+    const preservedScene = scenesService.getScene(currentSceneId);
+    const preservedItem = preservedScene.getItem(currentItemId);
+    t.is(preservedItem.sourceId, expectedSourceId);
+    t.deepEqual(preservedItem.getModel().transform, expectedTransform);
+    t.deepEqual(videoSettingsService.state.horizontal, originalVideo);
+  } finally {
+    await stopRecording();
+  }
+
+  for (let attempt = 0; attempt < 100 && streamingService.isRecording; attempt++) {
+    await sleep(50);
+  }
+  t.false(streamingService.isRecording, 'recording reaches the offline state');
+});
+
 test('Rapid canvas width and height updates are applied as one coherent resize', async t => {
   const client = await getApiClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');

--- a/test/regular/relative-coordinates.ts
+++ b/test/regular/relative-coordinates.ts
@@ -1,8 +1,12 @@
-import { test, useWebdriver } from '../helpers/webdriver';
+import { skipCheckingErrorsInLog, test, useWebdriver } from '../helpers/webdriver';
 import { getApiClient } from '../helpers/api-client';
 import { ScenesService } from '../../app/services/scenes';
+import { ScenesService as ExternalScenesService } from '../../app/services/api/external-api/scenes';
+import { SceneCollectionsService } from '../../app/services/api/external-api/scene-collections';
 import { VideoSettingsService } from '../../app/services/settings-v2/video';
+import { StreamingService } from '../../app/services/streaming';
 import { sleep } from '../helpers/sleep';
+import { startRecording, stopRecording } from '../helpers/modules/streaming';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -73,4 +77,206 @@ test('Base canvas changes scale only items assigned to that canvas', async t => 
   } finally {
     await videoSettingsService.setSettings(originalHorizontal);
   }
+});
+
+test('Canvas resolutions and transforms survive a scene collection reload', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ExternalScenesService>('ScenesService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const scene = scenesService.createScene('Relative Coordinates Reload Scene');
+  const horizontalItem = scene.createAndAddSource('Reload Source', 'color_source');
+  const verticalItem = scene.addSource(horizontalItem.sourceId, { display: 'vertical' });
+  const originalHorizontal = { ...videoSettingsService.state.horizontal };
+  const originalVertical = { ...videoSettingsService.state.vertical };
+  const targetHorizontal = {
+    baseWidth: Math.max(2, Math.floor(originalHorizontal.baseWidth * 0.75)),
+    baseHeight: Math.max(2, Math.floor(originalHorizontal.baseHeight * 0.75)),
+  };
+  const targetVertical = {
+    baseWidth: Math.max(2, Math.floor(originalVertical.baseWidth * 0.8)),
+    baseHeight: Math.max(2, Math.floor(originalVertical.baseHeight * 0.8)),
+  };
+
+  horizontalItem.setTransform({
+    position: { x: originalHorizontal.baseWidth * 0.25, y: originalHorizontal.baseHeight * 0.4 },
+    scale: { x: 0.8, y: 1.2 },
+  });
+  verticalItem.setTransform({
+    position: { x: originalVertical.baseWidth * 0.6, y: originalVertical.baseHeight * 0.3 },
+    scale: { x: 1.1, y: 0.7 },
+  });
+
+  await videoSettingsService.setSettings(targetHorizontal, 'horizontal');
+  await videoSettingsService.setSettings(targetVertical, 'vertical');
+
+  const expectedHorizontalTransform = horizontalItem.getModel().transform;
+  const expectedVerticalTransform = verticalItem.getModel().transform;
+  const collectionId = sceneCollectionsService.activeCollection.id;
+  const sceneId = scene.id;
+  const horizontalItemId = horizontalItem.sceneItemId;
+  const verticalItemId = verticalItem.sceneItemId;
+
+  await sceneCollectionsService.create({ name: 'Relative Coordinates Other Collection' });
+  await videoSettingsService.setSettings(
+    {
+      baseWidth: originalHorizontal.baseWidth,
+      baseHeight: originalHorizontal.baseHeight,
+    },
+    'horizontal',
+  );
+  await videoSettingsService.setSettings(
+    {
+      baseWidth: originalVertical.baseWidth,
+      baseHeight: originalVertical.baseHeight,
+    },
+    'vertical',
+  );
+  t.is(videoSettingsService.state.horizontal.baseWidth, originalHorizontal.baseWidth);
+  t.is(videoSettingsService.state.horizontal.baseHeight, originalHorizontal.baseHeight);
+  t.is(videoSettingsService.state.vertical.baseWidth, originalVertical.baseWidth);
+  t.is(videoSettingsService.state.vertical.baseHeight, originalVertical.baseHeight);
+
+  await sceneCollectionsService.load(collectionId);
+
+  const reloadedScene = scenesService.getScene(sceneId);
+  const reloadedHorizontalItem = reloadedScene.getItem(horizontalItemId);
+  const reloadedVerticalItem = reloadedScene.getItem(verticalItemId);
+  const actualHorizontalTransform = reloadedHorizontalItem.getModel().transform;
+  const actualVerticalTransform = reloadedVerticalItem.getModel().transform;
+
+  t.is(videoSettingsService.state.horizontal.baseWidth, targetHorizontal.baseWidth);
+  t.is(videoSettingsService.state.horizontal.baseHeight, targetHorizontal.baseHeight);
+  t.is(videoSettingsService.state.vertical.baseWidth, targetVertical.baseWidth);
+  t.is(videoSettingsService.state.vertical.baseHeight, targetVertical.baseHeight);
+  t.is(reloadedHorizontalItem.display, 'horizontal');
+  t.is(reloadedVerticalItem.display, 'vertical');
+  t.true(
+    approximatelyEqual(
+      actualHorizontalTransform.position.x,
+      expectedHorizontalTransform.position.x,
+    ),
+  );
+  t.true(
+    approximatelyEqual(
+      actualHorizontalTransform.position.y,
+      expectedHorizontalTransform.position.y,
+    ),
+  );
+  t.true(
+    approximatelyEqual(actualHorizontalTransform.scale.x, expectedHorizontalTransform.scale.x),
+  );
+  t.true(
+    approximatelyEqual(actualHorizontalTransform.scale.y, expectedHorizontalTransform.scale.y),
+  );
+  t.true(
+    approximatelyEqual(actualVerticalTransform.position.x, expectedVerticalTransform.position.x),
+  );
+  t.true(
+    approximatelyEqual(actualVerticalTransform.position.y, expectedVerticalTransform.position.y),
+  );
+  t.true(approximatelyEqual(actualVerticalTransform.scale.x, expectedVerticalTransform.scale.x));
+  t.true(approximatelyEqual(actualVerticalTransform.scale.y, expectedVerticalTransform.scale.y));
+});
+
+test('Canvas resizing is rejected while recording and succeeds after recording stops', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const streamingService = client.getResource<StreamingService>('StreamingService');
+  const scene = scenesService.createScene('Relative Coordinates Recording Scene');
+  const item = scene.createAndAddSource('Recording Source', 'color_source');
+  const originalVideo = { ...videoSettingsService.state.horizontal };
+  const targetVideo = {
+    baseWidth: Math.max(2, Math.floor(originalVideo.baseWidth * 0.75)),
+    baseHeight: Math.max(2, Math.floor(originalVideo.baseHeight * 0.75)),
+  };
+
+  item.setTransform({
+    position: { x: originalVideo.baseWidth / 3, y: originalVideo.baseHeight / 3 },
+    scale: { x: 1, y: 1 },
+  });
+  const originalTransform = item.getModel().transform;
+
+  await startRecording();
+  try {
+    // The service logs rejected legacy fire-and-forget updates in addition to
+    // rejecting the returned promise, so this expected error is handled here.
+    skipCheckingErrorsInLog();
+    const loadingWatcher = client.watchForEvents(['AppService.loadingChanged']);
+    await sleep(100);
+
+    let rejection: { error?: string } | undefined;
+    try {
+      await Promise.resolve(videoSettingsService.setSettings(targetVideo, 'horizontal'));
+    } catch (error: unknown) {
+      rejection = error as { error?: string };
+    }
+    await sleep(100);
+
+    t.regex(rejection?.error ?? '', /cannot change while a video output is active/i);
+    t.is(videoSettingsService.state.horizontal.baseWidth, originalVideo.baseWidth);
+    t.is(videoSettingsService.state.horizontal.baseHeight, originalVideo.baseHeight);
+    t.deepEqual(item.getModel().transform, originalTransform);
+    t.is(loadingWatcher.receivedEvents.length, 0, 'rejected resizing remains seamless');
+  } finally {
+    await stopRecording();
+  }
+
+  for (let attempt = 0; attempt < 100 && streamingService.isRecording; attempt++) {
+    await sleep(50);
+  }
+  t.false(streamingService.isRecording, 'recording reaches the offline state');
+
+  await videoSettingsService.setSettings(targetVideo, 'horizontal');
+
+  const resizedTransform = item.getModel().transform;
+  const resizeFactor = targetVideo.baseHeight / originalVideo.baseHeight;
+  t.is(videoSettingsService.state.horizontal.baseWidth, targetVideo.baseWidth);
+  t.is(videoSettingsService.state.horizontal.baseHeight, targetVideo.baseHeight);
+  t.true(
+    approximatelyEqual(resizedTransform.position.x, originalTransform.position.x * resizeFactor),
+  );
+  t.true(
+    approximatelyEqual(resizedTransform.position.y, originalTransform.position.y * resizeFactor),
+  );
+});
+
+test('Rapid canvas width and height updates are applied as one coherent resize', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const scene = scenesService.createScene('Relative Coordinates Debounce Scene');
+  const item = scene.createAndAddSource('Debounce Source', 'color_source');
+  const originalVideo = { ...videoSettingsService.state.horizontal };
+  const targetBaseWidth = Math.max(2, Math.floor(originalVideo.baseWidth * 0.75));
+  const targetBaseHeight = Math.max(2, Math.floor(originalVideo.baseHeight * 0.75));
+  const loadingWatcher = client.watchForEvents(['AppService.loadingChanged']);
+
+  item.setTransform({
+    position: { x: originalVideo.baseWidth / 2, y: originalVideo.baseHeight / 2 },
+    scale: { x: 1, y: 1 },
+  });
+  await sleep(100);
+
+  const widthUpdate = Promise.resolve(
+    videoSettingsService.setVideoSetting('baseWidth', targetBaseWidth, 'horizontal'),
+  );
+  const heightUpdate = Promise.resolve(
+    videoSettingsService.setVideoSetting('baseHeight', targetBaseHeight, 'horizontal'),
+  );
+  await Promise.all([widthUpdate, heightUpdate]);
+  await sleep(100);
+
+  const resizedTransform = item.getModel().transform;
+  const resizeFactor = targetBaseHeight / originalVideo.baseHeight;
+  t.is(videoSettingsService.state.horizontal.baseWidth, targetBaseWidth);
+  t.is(videoSettingsService.state.horizontal.baseHeight, targetBaseHeight);
+  t.true(approximatelyEqual(resizedTransform.position.x, targetBaseWidth / 2));
+  t.true(approximatelyEqual(resizedTransform.position.y, targetBaseHeight / 2));
+  t.true(approximatelyEqual(resizedTransform.scale.x, resizeFactor));
+  t.true(approximatelyEqual(resizedTransform.scale.y, resizeFactor));
+  t.is(loadingWatcher.receivedEvents.length, 0, 'debounced resizing remains seamless');
 });

--- a/test/regular/relative-coordinates.ts
+++ b/test/regular/relative-coordinates.ts
@@ -16,6 +16,7 @@ interface IPersistedSceneCollection {
   relativeCoordinates: boolean;
   baseResolutions: {
     horizontal: { baseWidth: number; baseHeight: number };
+    vertical: { baseWidth: number; baseHeight: number };
   };
   scenes: {
     items: Array<{
@@ -28,6 +29,14 @@ interface IPersistedSceneCollection {
           scaleX: number;
           scaleY: number;
           display?: string;
+          crop: {
+            top: number;
+            right: number;
+            bottom: number;
+            left: number;
+            referenceWidth?: number;
+            referenceHeight?: number;
+          };
         }>;
       };
     }>;
@@ -417,4 +426,82 @@ test('A persistence failure rolls back the canvas resolution and scene transform
   t.true(
     approximatelyEqual(resizedTransform.position.y, originalTransform.position.y * resizeFactor),
   );
+});
+
+test('Nested-scene crop references survive Desktop save, reload, and canvas resize', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ExternalScenesService>('ScenesService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const videoSettingsService = client.getResource<VideoSettingsService>('VideoSettingsService');
+  const outerScene = scenesService.createScene('Relative Coordinates Crop Outer Scene');
+  const nestedScene = scenesService.createScene('Relative Coordinates Crop Nested Scene');
+  nestedScene.createAndAddSource('Nested Content', 'color_source');
+  const nestedItem = outerScene.addSource(nestedScene.id, { display: 'vertical' });
+  const originalVertical = { ...videoSettingsService.state.vertical };
+  const firstResize = {
+    baseWidth: Math.max(2, Math.floor(originalVertical.baseWidth * 1.25)),
+    baseHeight: Math.max(2, Math.floor(originalVertical.baseHeight * 1.25)),
+  };
+  const secondResize = {
+    baseWidth: Math.max(2, Math.floor(originalVertical.baseWidth * 1.5)),
+    baseHeight: Math.max(2, Math.floor(originalVertical.baseHeight * 1.5)),
+  };
+  const authoredCrop = { top: 24, right: 36, bottom: 48, left: 12 };
+
+  nestedItem.setTransform({
+    position: { x: originalVertical.baseWidth * 0.2, y: originalVertical.baseHeight * 0.3 },
+    scale: { x: 1, y: 1 },
+    crop: authoredCrop,
+  });
+  t.deepEqual(nestedItem.getModel().transform.crop, authoredCrop);
+
+  const collectionPath = path.join(
+    t.context.cacheDir,
+    'slobs-client',
+    'SceneCollections',
+    `${sceneCollectionsService.activeCollection.id}.json`,
+  );
+  const readPersistedItem = () => {
+    const persisted = JSON.parse(
+      fs.readFileSync(collectionPath).toString(),
+    ) as IPersistedSceneCollection;
+    const persistedScene = persisted.scenes.items.find(candidate => candidate.id === outerScene.id);
+    const persistedItem = persistedScene?.sceneItems.items.find(
+      candidate => candidate.id === nestedItem.id,
+    );
+    return { persisted, persistedItem };
+  };
+
+  await videoSettingsService.setSettings(firstResize, 'vertical');
+
+  const firstSave = readPersistedItem();
+  t.truthy(firstSave.persistedItem);
+  t.deepEqual(firstSave.persistedItem!.crop, {
+    ...authoredCrop,
+    referenceWidth: originalVertical.baseWidth,
+    referenceHeight: originalVertical.baseHeight,
+  });
+
+  const outerSceneId = outerScene.id;
+  const nestedItemId = nestedItem.id;
+  await sceneCollectionsService.load(sceneCollectionsService.activeCollection.id);
+
+  const reloadedOuterScene = scenesService.getScene(outerSceneId);
+  const reloadedNestedItem = reloadedOuterScene.getItem(nestedItemId);
+  t.is(reloadedNestedItem.display, 'vertical');
+  t.deepEqual(reloadedNestedItem.getModel().transform.crop, authoredCrop);
+
+  await videoSettingsService.setSettings(secondResize, 'vertical');
+
+  const secondSave = readPersistedItem();
+  t.deepEqual(secondSave.persisted.baseResolutions.vertical, secondResize);
+  t.truthy(secondSave.persistedItem);
+  t.deepEqual(secondSave.persistedItem!.crop, {
+    ...authoredCrop,
+    referenceWidth: originalVertical.baseWidth,
+    referenceHeight: originalVertical.baseHeight,
+  });
+  t.deepEqual(reloadedNestedItem.getModel().transform.crop, authoredCrop);
 });

--- a/test/regular/services/scene-collections/migrations.ts
+++ b/test/regular/services/scene-collections/migrations.ts
@@ -2,6 +2,7 @@ import { skipCheckingErrorsInLog, test, useWebdriver } from '../../../helpers/we
 import { sceneExisting } from '../../../helpers/modules/scenes';
 import { getApiClient } from '../../../helpers/api-client';
 import { SceneCollectionsService } from '../../../../app/services/api/external-api/scene-collections';
+import { NotificationsService } from '../../../../app/services/api/external-api/notifications/notifications';
 
 const fs = require('fs');
 const path = require('path');
@@ -9,6 +10,8 @@ const path = require('path');
 const LEGACY_COLLECTION_ID = '4e467470-923c-43a3-90d2-2be39c8c34ee';
 const FAIL_CLOSED_COLLECTION_ID = '0beea742-fcb8-4cf0-9c54-a22f01247437';
 const UNSUPPORTED_SOURCE_TYPE = 'unsupported_relative_coordinates_test_source';
+const COORDINATE_MIGRATION_BLOCKED_NOTIFICATION_CODE =
+  'SCENE_COLLECTION_COORDINATE_MIGRATION_BLOCKED';
 
 function copyFile(src: string, dest: string) {
   return new Promise<void>((resolve, reject) => {
@@ -97,6 +100,7 @@ test('A legacy collection with an unsupported source fails coordinate migration 
   const sceneCollectionsService = client.getResource<SceneCollectionsService>(
     'SceneCollectionsService',
   );
+  const notificationsService = client.getResource<NotificationsService>('NotificationsService');
 
   // The rejected strict migration intentionally logs its reason before Desktop
   // reloads the original data in compatibility mode.
@@ -122,4 +126,16 @@ test('A legacy collection with an unsupported source fails coordinate migration 
   t.deepEqual(persisted, absoluteBackup);
   t.is(persisted.schemaVersion, 1);
   t.false(persisted.relativeCoordinates === true);
+
+  const migrationWarning = notificationsService
+    .getAll()
+    .find(notification => notification.code === COORDINATE_MIGRATION_BLOCKED_NOTIFICATION_CODE);
+  t.truthy(migrationWarning);
+  t.is(migrationWarning!.type, 'WARNING');
+  t.true(migrationWarning!.unread);
+  t.is(migrationWarning!.lifeTime, -1);
+  t.true(migrationWarning!.message.includes('changes to it will not be saved'));
+
+  await sceneCollectionsService.load(LEGACY_COLLECTION_ID);
+  t.false(notificationsService.getNotification(migrationWarning!.id).unread);
 });

--- a/test/regular/services/scene-collections/migrations.ts
+++ b/test/regular/services/scene-collections/migrations.ts
@@ -17,7 +17,10 @@ function copyFile(src: string, dest: string) {
   });
 }
 
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver({
+  noSync: true,
   beforeAppStartCb: async t => {
     const dataDir = path.resolve(__dirname, '..', '..', '..', '..', '..', 'test', 'data');
 
@@ -49,4 +52,20 @@ test('Loading an old scene collection', async t => {
   t.true(await sceneExisting('Intermission'));
   t.true(await sceneExisting('Be Right Back'));
   t.true(await sceneExisting('Stream Ending Soon'));
+
+  const collectionPath = path.join(
+    t.context.cacheDir,
+    'slobs-client',
+    'SceneCollections',
+    '4e467470-923c-43a3-90d2-2be39c8c34ee.json',
+  );
+  const absoluteBackupPath = `${collectionPath}.absolute.bak`;
+  const migrated = JSON.parse(fs.readFileSync(collectionPath).toString());
+  const absoluteBackup = JSON.parse(fs.readFileSync(absoluteBackupPath).toString());
+
+  t.is(migrated.schemaVersion, 5);
+  t.true(migrated.relativeCoordinates);
+  t.truthy(migrated.baseResolutions.horizontal);
+  t.truthy(migrated.baseResolutions.vertical);
+  t.is(absoluteBackup.schemaVersion, 1);
 });

--- a/test/regular/services/scene-collections/migrations.ts
+++ b/test/regular/services/scene-collections/migrations.ts
@@ -1,8 +1,14 @@
-import { test, useWebdriver } from '../../../helpers/webdriver';
+import { skipCheckingErrorsInLog, test, useWebdriver } from '../../../helpers/webdriver';
 import { sceneExisting } from '../../../helpers/modules/scenes';
+import { getApiClient } from '../../../helpers/api-client';
+import { SceneCollectionsService } from '../../../../app/services/api/external-api/scene-collections';
 
 const fs = require('fs');
 const path = require('path');
+
+const LEGACY_COLLECTION_ID = '4e467470-923c-43a3-90d2-2be39c8c34ee';
+const FAIL_CLOSED_COLLECTION_ID = '0beea742-fcb8-4cf0-9c54-a22f01247437';
+const UNSUPPORTED_SOURCE_TYPE = 'unsupported_relative_coordinates_test_source';
 
 function copyFile(src: string, dest: string) {
   return new Promise<void>((resolve, reject) => {
@@ -23,19 +29,35 @@ useWebdriver({
   noSync: true,
   beforeAppStartCb: async t => {
     const dataDir = path.resolve(__dirname, '..', '..', '..', '..', '..', 'test', 'data');
+    const legacyFixturePath = path.join(dataDir, 'scene-collection.json');
 
     fs.mkdirSync(path.join(t.context.cacheDir, 'slobs-client'));
     const sceneCollectionsPath = path.join(t.context.cacheDir, 'slobs-client', 'SceneCollections');
     fs.mkdirSync(sceneCollectionsPath);
 
     await copyFile(
-      path.join(dataDir, 'scene-collection.json'),
-      path.join(sceneCollectionsPath, '4e467470-923c-43a3-90d2-2be39c8c34ee.json'),
+      legacyFixturePath,
+      path.join(sceneCollectionsPath, `${LEGACY_COLLECTION_ID}.json`),
     );
 
-    await copyFile(
-      path.join(dataDir, 'scene-collection-manifest.json'),
+    const failClosedFixture = JSON.parse(fs.readFileSync(legacyFixturePath).toString());
+    failClosedFixture.sources.items[0].type = UNSUPPORTED_SOURCE_TYPE;
+    fs.writeFileSync(
+      path.join(sceneCollectionsPath, `${FAIL_CLOSED_COLLECTION_ID}.json`),
+      JSON.stringify(failClosedFixture, null, 2),
+    );
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'scene-collection-manifest.json')).toString(),
+    );
+    manifest.collections.push({
+      ...manifest.collections[0],
+      id: FAIL_CLOSED_COLLECTION_ID,
+      name: 'Legacy Unsupported Source',
+    });
+    fs.writeFileSync(
       path.join(sceneCollectionsPath, 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
     );
   },
 });
@@ -57,7 +79,7 @@ test('Loading an old scene collection', async t => {
     t.context.cacheDir,
     'slobs-client',
     'SceneCollections',
-    '4e467470-923c-43a3-90d2-2be39c8c34ee.json',
+    `${LEGACY_COLLECTION_ID}.json`,
   );
   const absoluteBackupPath = `${collectionPath}.absolute.bak`;
   const migrated = JSON.parse(fs.readFileSync(collectionPath).toString());
@@ -68,4 +90,36 @@ test('Loading an old scene collection', async t => {
   t.truthy(migrated.baseResolutions.horizontal);
   t.truthy(migrated.baseResolutions.vertical);
   t.is(absoluteBackup.schemaVersion, 1);
+});
+
+test('A legacy collection with an unsupported source fails coordinate migration closed', async t => {
+  const client = await getApiClient();
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+
+  // The rejected strict migration intentionally logs its reason before Desktop
+  // reloads the original data in compatibility mode.
+  skipCheckingErrorsInLog();
+  await sceneCollectionsService.load(FAIL_CLOSED_COLLECTION_ID);
+
+  const collectionPath = path.join(
+    t.context.cacheDir,
+    'slobs-client',
+    'SceneCollections',
+    `${FAIL_CLOSED_COLLECTION_ID}.json`,
+  );
+  const absoluteBackupPath = `${collectionPath}.absolute.bak`;
+
+  t.is(sceneCollectionsService.activeCollection.id, FAIL_CLOSED_COLLECTION_ID);
+  t.true(fs.existsSync(absoluteBackupPath));
+
+  const persisted = JSON.parse(fs.readFileSync(collectionPath).toString());
+  const absoluteBackup = JSON.parse(fs.readFileSync(absoluteBackupPath).toString());
+
+  t.is(absoluteBackup.schemaVersion, 1);
+  t.is(absoluteBackup.sources.items[0].type, UNSUPPORTED_SOURCE_TYPE);
+  t.deepEqual(persisted, absoluteBackup);
+  t.is(persisted.schemaVersion, 1);
+  t.false(persisted.relativeCoordinates === true);
 });


### PR DESCRIPTION
The ultimate goal of the task is:

> Enable safe base canvas resolution changes in settings by introducing relative scene coordinates across `obs-studio`, `obs-studio-node`, and `desktop`, preserving the visual layout of shared horizontal/vertical scene graph.



https://github.com/user-attachments/assets/a544dc8c-0529-45eb-825a-d5c90d67166e


### Description
This is the Desktop part of a three-repository change:

1. `obs-studio` implements canvas-aware relative transforms and crop references.
https://github.com/streamlabs/obs-studio/pull/764
2. `obs-studio-node` exposes the native lifecycle and metadata.
https://github.com/streamlabs/obs-studio-node/pull/1764
3. `desktop` migrates collections and applies Base Resolution changes transactionally.


Previously, scene-item transforms were tied to absolute canvas pixels. Changing the Base (Canvas) Resolution could therefore produce incorrect positioning, scaling, and crop behavior, especially across horizontal and vertical canvases or after saving and reloading a collection.

OBS now stores normalized transforms internally while preserving the existing absolute-pixel API. Desktop must coordinate collection persistence, legacy migration, canvas resizing, output lifecycle, and transform-cache refreshes around that new contract.

### What changed

- Introduced scene collection schema v5, recording:
  - Relative-coordinate mode.
  - Independent horizontal and vertical authored base resolutions.
- Added fail-closed migration for legacy absolute-coordinate collections:
  - Restores the saved base resolution before rebuilding the scene graph.
  - Creates a one-time `.absolute.bak` backup.
  - Awaits nested scene and source loading.
  - Refuses to persist a partial v5 collection when a source is missing or unsupported.
- Made Base (Canvas) Resolution changes transactional:
  - Serializes and coalesces width/height updates.
  - Prevents output startup during the transaction.
  - Invalidates native transform caches and refreshes Desktop’s absolute-pixel models.
  - Persists and flushes the result atomically.
  - Restores resolution, transforms, and persisted data if any step fails.
- Kept canvas resolution changes seamless; no intermediate loading screen is shown.
- Kept Output (Scaled) Resolution independent from scene-item migration.
- Preserved independent horizontal and vertical canvas routing across save/reload.
- Persisted nested-scene crop reference dimensions internally without changing the public scene-transform API.
- Added collection-switch preflight while video output is active:
  - Primary and backup collection files are checked before removing the current scene graph.
  - A collection requiring a different base resolution is rejected while recording or another video output is active.
- Updated output-start coordination for streaming, recording, replay buffer, and virtual camera.
- Updated Desktop to use the coordinated OSN initialization and scene-item APIs.

### User-facing behavior

- Base canvas resizing remains seamless.
- Items scale only with the canvas to which they are assigned.
- Horizontal and vertical canvases retain independent resolutions and transforms.
- Output resolution changes do not move or resize scene items.
- Unsafe canvas changes and collection switches are rejected while video output is active, without disturbing the current scene graph or output.
- Legacy collections are either migrated completely or left unmodified with an absolute backup.

### OSN initialization

Desktop now uses the object-based OSN initializer:

```ts
OBS_API_initAPI({
  language,
  appDataPath,
  version,
  crashServerUrl,
});