### PR TITLE
Update node-libuiohook to version 1.1.19

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -12,7 +12,7 @@
       "name": "node-libuiohook",
       "url": "https://slobs-node-libuiohook.s3-us-west-2.amazonaws.com/",
       "archive": "node-libuiohook-[VERSION]-[OS][ARCH].tar.gz",
-      "version": "1.1.17",
+      "version": "1.1.19",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
This fixed hotkeys crash in Electron 43.

Steps to reproduce:
```text
1) Open Streamlabs Desktop Settings > Game Overlay and enable it
2) Go to Hotkeys and set a hotkey to enable the game overlay (I tested with F2, and H)
3) Close settings
4) Press your hotkey, and Streamlabs Desktop will crash.
```

See details here:
https://github.com/streamlabs/node-libuiohook/pull/54