### PR TITLE
Add RxJS unsubscribe code review instructions

### DIFF
--- a/.github/instructions/rxjs-unsubscribe.instructions.md
+++ b/.github/instructions/rxjs-unsubscribe.instructions.md
@@ -1,0 +1,17 @@
+applyTo: "app/components/**,app/components-react/**"
+
+# Tracking RxJS subscriptions
+
+When code reviewing a PR, check that any RxJS subscriptions created in components are tied to the component lifecycle and will be unsubscribed or otherwise cleaned up.
+
+Flag subscriptions that can outlive the component, are created without teardown, or are not bound through an established cleanup pattern.
+
+## `useSubscription` guidance
+
+When reviewing a PR, judge whether `useSubscription` is the better fit than a manual effect-based subscription, and explain why in your review if it is not.
+
+Using `useSubscription` is acceptable when the observable and callback are stable for the lifetime of the component and the intended behavior is subscribe-on-mount and unsubscribe-on-unmount.
+
+Flag uses of `useSubscription` when the observable, callback, or subscription behavior is expected to change with props/state over time, because those cases should use an effect with correct dependencies (or equivalent stream lifecycle handling) so the subscription can be re-bound correctly.
+
+`useSubscription` should only replace the subscription part of an effect. If the effect also performs other mount-time setup or needs extra teardown, keep a manual `useEffect` and use the hook only for the listener.

--- a/.github/instructions/translations.instructions.md
+++ b/.github/instructions/translations.instructions.md
@@ -37,7 +37,7 @@ If no such key/value pair has been removed in the PR, it should be flagged as a 
 
 When code reviewing a PR, check for any files added to the `app/i18n/en-US/**` directory, these are new translation files.
 Each new file added there must be added as a `require` in the `fallbackDictionary` of `app/i18n/fallback.ts`.
-Flag any new translation files not included in the `fallbackDirectory` as needing to be included there.
+Flag any new translation files not included in the `fallbackDictionary` as needing to be included there.
 
 # Special Considerations
 


### PR DESCRIPTION
# Add RxJS unsubscribe code review instructions

## Issues

Copilot code review has no guidance on RxJS subscription lifecycles in components, so subscriptions that outlive their component or misuse `useSubscription` go unflagged. The translations instructions also referenced a non-existent `fallbackDirectory`.

## Fixes

- Adds `.github/instructions/rxjs-unsubscribe.instructions.md`, scoped to `app/components/**` and `app/components-react/**`. It tells reviewers to flag subscriptions created without teardown, and describes when `useSubscription` is the right fit (stable observable/callback, subscribe-on-mount/unsubscribe-on-unmount) versus when an effect with correct dependencies is needed so the subscription can be re-bound.
- Fixes `fallbackDirectory` → `fallbackDictionary` in the translations instructions.

**File(s) changed:** `.github/instructions/rxjs-unsubscribe.instructions.md`, `.github/instructions/translations.instructions.md`

## Performance Implications

None. Documentation only — no runtime code changes.