### PR TITLE
Update the theme mapping

### DIFF
--- a/app/services/platform-apps/api/modules/theme.ts
+++ b/app/services/platform-apps/api/modules/theme.ts
@@ -11,6 +11,12 @@ enum ETheme {
 const themeTable = {
   'day-theme': ETheme.Day,
   'night-theme': ETheme.Night,
+  'prime-light': ETheme.Day,
+  'prime-dark': ETheme.Night,
+  'golive-day-theme': ETheme.Day,
+  'golive-night-theme': ETheme.Night,
+  'golive-prime-light': ETheme.Day,
+  'golive-prime-dark': ETheme.Night,
 };
 
 export class ThemeModule extends Module {


### PR DESCRIPTION
This prevents `getTheme()` and `themeChanged` from returning `undefined` for valid themes, including Obsidian Ultra
- Add Platform Apps Theme API support for Ultra and Go Live themes.
- Map light variants to `day` and dark variants to `night`.