### PR TITLE
Fix stream shift.

### DIFF
--- a/app/components-react/root/StartStreamingButton.tsx
+++ b/app/components-react/root/StartStreamingButton.tsx
@@ -164,8 +164,8 @@ function StartStreamingButton(p: { disabled?: boolean }) {
   // and also to cancel the action on unmount to prevent memory leaks and state updates on unmounted components
   const toggleStreaming = useDebounce(500, handleToggleStreaming);
 
-  // Checking for a stream shift status can take up to four seconds
-  const checkIsLive = useDebounce(4000, RestreamService.actions.checkIsLive);
+  // Debounce checking for the live status of the stream and enable canceling on unmount
+  const checkIsLive = useDebounce(0, RestreamService.actions.checkIsLive);
 
   const getIsRedButton = useMemo(() => {
     return streamingStatus !== EStreamingState.Offline && streamShiftStatus !== 'pending';

--- a/app/components-react/root/StartStreamingButton.tsx
+++ b/app/components-react/root/StartStreamingButton.tsx
@@ -3,15 +3,13 @@ import cx from 'classnames';
 import { EStreamingState } from 'services/streaming';
 import { EGlobalSyncStatus } from 'services/media-backup';
 import { $t } from 'services/i18n';
-import { useVuex } from '../hooks';
+import { useDebounce, useVuex } from '../hooks';
 import { Services } from '../service-provider';
 import * as remote from '@electron/remote';
 import { TStreamShiftStatus } from 'services/restream';
 import { promptAction } from 'components-react/modals';
 import { TSocketEvent } from 'services/websocket';
 import { useRealmObject } from 'components-react/hooks/realm';
-import debounce from 'lodash/debounce';
-import Utils from 'services/utils';
 
 function StartStreamingButton(p: { disabled?: boolean }) {
   const {
@@ -22,7 +20,6 @@ function StartStreamingButton(p: { disabled?: boolean }) {
     MediaBackupService,
     SourcesService,
     RestreamService,
-    UsageStatisticsService,
   } = Services;
 
   const {
@@ -30,7 +27,6 @@ function StartStreamingButton(p: { disabled?: boolean }) {
     delayEnabled,
     delaySeconds,
     streamShiftStatus,
-    streamShiftForceGoLive,
     isDualOutputMode,
     isLoggedIn,
     isPrime,
@@ -42,7 +38,6 @@ function StartStreamingButton(p: { disabled?: boolean }) {
       delayEnabled: StreamingService.views.delayEnabled,
       delaySeconds: StreamingService.views.delaySeconds,
       streamShiftStatus: RestreamService.state.streamShiftStatus,
-      streamShiftForceGoLive: RestreamService.state.streamShiftForceGoLive,
       isDualOutputMode: StreamingService.views.isDualOutputMode,
       isLoggedIn: UserService.isLoggedIn,
       isPrime: UserService.state.isPrime,
@@ -79,86 +74,33 @@ function StartStreamingButton(p: { disabled?: boolean }) {
   useEffect(() => {
     // Check for stream shift status on mount. This will happen on app launch because the main window is always active
     if (isPrime && streamingStatus === EStreamingState.Offline) {
-      fetchStreamShiftStatus().catch((e: unknown) => {
-        console.error('Error fetching stream shift status:', e);
-      });
+      checkIsLive();
     }
 
-    const streamShiftEvent = StreamingService.streamShiftEvent.subscribe((event: TSocketEvent) => {
-      if (streamShiftForceGoLive) return;
-      if (event.type !== 'streamSwitchRequest' && event.type !== 'switchActionComplete') {
-        return;
-      }
-
-      const { streamShiftStreamId } = RestreamService.state;
-      console.debug('Event ID: ' + event.data.identifier, '\n Stream ID: ' + streamShiftStreamId);
-      const isIncomingStream: boolean =
-        (streamShiftStreamId && event.data.identifier === streamShiftStreamId) || false;
-
-      if (event.type === 'streamSwitchRequest') {
-        if (isIncomingStream) {
-          // Don't record the request from this device because the other device will record it
-          RestreamService.actions.confirmStreamShift('approved');
-        } else {
-          recordStreamShiftAnalytics('request', event.data.identifier);
-        }
-      }
-
-      if (event.type === 'switchActionComplete') {
-        // End the stream on this device if switching the stream to another device
-        // Only record analytics if the stream was switched from this device to a different one
-        if (!isIncomingStream) {
-          Services.RestreamService.actions.endStreamShiftStream(event.data.identifier);
-
-          recordStreamShiftAnalytics('complete', event.data.identifier);
-        }
-
+    const streamShiftEvent = StreamingService.streamShiftEvent.subscribe(
+      async (event: TSocketEvent) => {
         // Notify the user
-        const message = formatStreamShiftMessage(isIncomingStream, event.data.identifier);
+        const message = await RestreamService.actions.return.handleStreamShiftEvent(event);
 
-        promptAction({
-          title: $t('Stream successfully switched'),
-          message,
-          btnText: $t('Close'),
-          btnType: 'default',
-          cancelBtnPosition: 'none',
-        });
-      }
-    });
+        // An empty message means the handler declined to notify (e.g. a forced go live),
+        // so don't show an alert with an empty body
+        if (event.type === 'switchActionComplete' && message) {
+          promptAction({
+            title: $t('Stream successfully switched'),
+            message,
+            btnText: $t('Close'),
+            btnType: 'default',
+            cancelBtnPosition: 'none',
+          });
+        }
+      },
+    );
 
     return () => {
       toggleStreaming.cancel();
+      checkIsLive.cancel();
       streamShiftEvent.unsubscribe();
     };
-  }, []);
-
-  const recordStreamShiftAnalytics = useCallback((action: 'request' | 'complete', id: string) => {
-    // Prevent recording analytics event in test mode
-    if (Utils.isTestMode()) return;
-
-    // Note: because the event's stream id is from the device that requested the switch,
-    // it is not possible to know what type of device the stream will be switching from.
-    // We can only identify the type of device the stream is switching to.
-    const remoteDeviceType = /[A-Z]/.test(id) ? 'mobile' : 'desktop';
-    const switchType = `desktop-${remoteDeviceType}`;
-
-    UsageStatisticsService.recordAnalyticsEvent('StreamShift', {
-      stream: switchType,
-      action,
-    });
-  }, []);
-
-  const formatStreamShiftMessage = useCallback((isFromOtherDevice: boolean, id: string) => {
-    if (isFromOtherDevice) {
-      return $t(
-        'Your stream has been switched to Streamlabs Desktop from another device. Enjoy your stream!',
-      );
-    }
-
-    const remoteDeviceType = /[A-Z]/.test(id) ? 'mobile' : 'desktop';
-    return remoteDeviceType === 'mobile'
-      ? $t('Your stream has been successfully switched to Streamlabs Mobile. Enjoy your stream!')
-      : $t('Your stream has been successfully switched to Streamlabs Desktop. Enjoy your stream!');
   }, []);
 
   const handleToggleStreaming = useCallback(async () => {
@@ -220,9 +162,10 @@ function StartStreamingButton(p: { disabled?: boolean }) {
 
   // Wrap the toggleStreaming function in a debounce to prevent multiple rapid clicks
   // and also to cancel the action on unmount to prevent memory leaks and state updates on unmounted components
-  const toggleStreaming = useMemo(() => debounce(handleToggleStreaming, 500), [
-    handleToggleStreaming,
-  ]);
+  const toggleStreaming = useDebounce(500, handleToggleStreaming);
+
+  // Checking for a stream shift status can take up to four seconds
+  const checkIsLive = useDebounce(4000, RestreamService.actions.checkIsLive);
 
   const getIsRedButton = useMemo(() => {
     return streamingStatus !== EStreamingState.Offline && streamShiftStatus !== 'pending';
@@ -236,17 +179,6 @@ function StartStreamingButton(p: { disabled?: boolean }) {
     );
   }, [p.disabled, streamingStatus, delaySecondsRemaining]);
 
-  const fetchStreamShiftStatus = useCallback(async () => {
-    try {
-      const isLive = await RestreamService.actions.return.checkIsLive();
-      return isLive;
-    } catch (e: unknown) {
-      console.log('Error checking stream shift status', e);
-      setIsLoading(false);
-      return false;
-    }
-  }, []);
-
   const shouldShowGoLiveWindow = useCallback(() => {
     if (!UserService.isLoggedIn) return false;
     const primaryPlatform = UserService.state.auth?.primaryPlatform;
@@ -254,13 +186,17 @@ function StartStreamingButton(p: { disabled?: boolean }) {
 
     if (!primaryPlatform) return false;
 
+    if (streamShiftStatus === 'pending') {
+      return true;
+    }
+
     if (StreamingService.views.isDualOutputMode) {
       return true;
     }
 
     if (
       !!UserService.state.auth?.platforms &&
-      StreamingService.views.isMultiplatformMode &&
+      isMultiplatformMode &&
       Object.keys(UserService.state.auth?.platforms).length > 1
     ) {
       return true;
@@ -269,14 +205,14 @@ function StartStreamingButton(p: { disabled?: boolean }) {
     if (primaryPlatform === 'twitch') {
       // For Twitch, we can show the Go Live window even with protected mode off
       // This is mainly for legacy reasons.
-      return StreamingService.views.isMultiplatformMode || updateStreamInfoOnLive;
+      return isMultiplatformMode || updateStreamInfoOnLive;
     } else {
       return (
         StreamSettingsService.state.protectedModeEnabled &&
         StreamSettingsService.isSafeToModifyStreamKey()
       );
     }
-  }, [primaryPlatform, isMultiplatformMode, updateStreamInfoOnLive]);
+  }, [primaryPlatform, isMultiplatformMode, updateStreamInfoOnLive, streamShiftStatus]);
 
   return (
     <button

--- a/app/components-react/root/StartStreamingButton.tsx
+++ b/app/components-react/root/StartStreamingButton.tsx
@@ -10,6 +10,7 @@ import { TStreamShiftStatus } from 'services/restream';
 import { promptAction } from 'components-react/modals';
 import { TSocketEvent } from 'services/websocket';
 import { useRealmObject } from 'components-react/hooks/realm';
+import debounce from 'lodash/debounce';
 
 function StartStreamingButton(p: { disabled?: boolean }) {
   const {
@@ -162,7 +163,10 @@ function StartStreamingButton(p: { disabled?: boolean }) {
 
   // Wrap the toggleStreaming function in a debounce to prevent multiple rapid clicks
   // and also to cancel the action on unmount to prevent memory leaks and state updates on unmounted components
-  const toggleStreaming = useDebounce(500, handleToggleStreaming);
+  // Don't use the useDebounce hook here to maintain stateful callbacks
+  const toggleStreaming = useMemo(() => debounce(handleToggleStreaming, 500), [
+    handleToggleStreaming,
+  ]);
 
   // Debounce checking for the live status of the stream and enable canceling on unmount
   const checkIsLive = useDebounce(0, RestreamService.actions.checkIsLive);

--- a/app/components-react/shared/DisplaySelector.tsx
+++ b/app/components-react/shared/DisplaySelector.tsx
@@ -28,6 +28,7 @@ export default function DisplaySelector(p: IDisplaySelectorProps) {
   } = useGoLiveSettings().extend(module => ({
     get canDualStream() {
       if (!p.platform) return false;
+      if (module.isLiveOutputEditingEnabled) return false;
       return module.getCanDualStream(p.platform);
     },
     get display(): TDisplayOutput {

--- a/app/components-react/windows/go-live/GoLive.m.less
+++ b/app/components-react/windows/go-live/GoLive.m.less
@@ -52,6 +52,17 @@
 .destination-mode {
   padding-right: 25px !important;
   padding-left: 25px !important;
+
+  // Without a left column this padding is the only gutter, so the children's own right margins
+  // sit on top of it and inset the right edge further than the left. Those margins exist to
+  // separate the two columns, which is not this layout.
+  > *:not(:first-child) {
+    margin-right: 0;
+  }
+
+  .right-column-scroll {
+    margin-right: 0 !important;
+  }
 }
 
 .update-mode {

--- a/app/components-react/windows/go-live/GoLiveWindow.tsx
+++ b/app/components-react/windows/go-live/GoLiveWindow.tsx
@@ -66,9 +66,7 @@ function ModalFooter() {
     isPrime,
     isStreamShiftMode,
     hasIncompatibleCodec,
-    streamShiftStatus,
     codec,
-    checkIsLive,
     forceStreamShiftGoLive,
     goLiveWithDefaultCodec,
     showSettings,
@@ -93,10 +91,6 @@ function ModalFooter() {
 
     get streamShiftStatus() {
       return module.streamShiftStatus;
-    },
-
-    async checkIsLive() {
-      return this.restreamService.actions.return.checkIsLive();
     },
 
     async forceStreamShiftGoLive() {
@@ -146,14 +140,6 @@ function ModalFooter() {
   const [isCoolingDown, setIsCoolingDown] = useState(false);
   const isStreamShiftPromptShown = useRef(false);
 
-  // Check stream shift status on mount for Prime users
-  useEffect(() => {
-    if (!isPrime) return;
-    checkIsLive().catch((e: unknown) => {
-      console.error('Error checking stream shift status on mount:', e);
-    });
-  }, []);
-
   const promptUseDefaultCodec = useCallback(async () => {
     // If the user is not live but has an incompatible codec, prompt to change codec
     let message = $t(
@@ -193,15 +179,6 @@ function ModalFooter() {
     });
   }, [isStreamShiftMode, isDualOutputMode, codec, goLiveWithDefaultCodec, showSettings]);
 
-  const startStreamShift = useCallback(() => {
-    if (isDualOutputMode) {
-      Services.DualOutputService.actions.toggleDisplay(false, 'vertical');
-    }
-
-    setStreamShift(true);
-    goLive();
-  }, [isDualOutputMode, goLive, setStreamShift]);
-
   const promptStreamShift = useCallback(async () => {
     isStreamShiftPromptShown.current = true;
     await promptAction({
@@ -215,7 +192,8 @@ function ModalFooter() {
         if (hasIncompatibleCodec) {
           promptUseDefaultCodec();
         } else {
-          startStreamShift();
+          setStreamShift(true);
+          goLive();
           close();
         }
       },
@@ -236,8 +214,9 @@ function ModalFooter() {
       maskClosable: false,
     });
   }, [
+    isStreamShiftPromptShown,
     hasIncompatibleCodec,
-    startStreamShift,
+    setStreamShift,
     close,
     forceStreamShiftGoLive,
     promptUseDefaultCodec,
@@ -246,10 +225,20 @@ function ModalFooter() {
 
   // When the streaming service detects an active stream on another device, show the prompt
   useEffect(() => {
-    if (streamShiftStatus !== 'pending') return;
-    if (isStreamShiftPromptShown.current) return;
-    promptStreamShift();
-  }, [streamShiftStatus, promptStreamShift]);
+    // Prompt the user to switch to Streamlabs Desktop if a stream is detected on another device
+    // Note: Intentionally left out of the dependency array to avoid multiple prompts on window load
+    if (Services.RestreamService.views.streamShiftStatus === 'pending') {
+      promptStreamShift();
+    }
+
+    const isLive = Services.RestreamService.isLive.subscribe(isLive => {
+      if (isLive && !isStreamShiftPromptShown.current) {
+        promptStreamShift();
+      }
+    });
+
+    return () => isLive.unsubscribe();
+  }, []);
 
   useEffect(() => {
     if (!isCoolingDown) return;

--- a/app/components-react/windows/go-live/GoLiveWindow.tsx
+++ b/app/components-react/windows/go-live/GoLiveWindow.tsx
@@ -226,7 +226,7 @@ function ModalFooter() {
   // When the streaming service detects an active stream on another device, show the prompt
   useEffect(() => {
     // Prompt the user to switch to Streamlabs Desktop if a stream is detected on another device
-    // Note: Intentionally left out of the dependency array to avoid multiple prompts on window load
+
     if (Services.RestreamService.views.streamShiftStatus === 'pending') {
       promptStreamShift();
     }
@@ -238,6 +238,8 @@ function ModalFooter() {
     });
 
     return () => isLive.unsubscribe();
+    // Note : `promptStreamShift` is intentionally left out of the dependency array to avoid multiple prompts on window load
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/app/components-react/windows/go-live/GoLiveWindow.tsx
+++ b/app/components-react/windows/go-live/GoLiveWindow.tsx
@@ -224,9 +224,9 @@ function ModalFooter() {
   ]);
 
   // When the streaming service detects an active stream on another device, show the prompt
+  // Note : `promptStreamShift` is intentionally left out of the dependency array to avoid multiple prompts on window load
   useEffect(() => {
     // Prompt the user to switch to Streamlabs Desktop if a stream is detected on another device
-
     if (Services.RestreamService.views.streamShiftStatus === 'pending') {
       promptStreamShift();
     }
@@ -238,7 +238,6 @@ function ModalFooter() {
     });
 
     return () => isLive.unsubscribe();
-    // Note : `promptStreamShift` is intentionally left out of the dependency array to avoid multiple prompts on window load
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -315,8 +315,17 @@ export class GoLiveSettingsModule {
       );
     }
 
-    // determine if TikTok apply notification should be shown
+    // Determine if TikTok apply notification should be shown
     Services.TikTokService.actions.handleApplyPrompt();
+
+    // Determine if Stream Shift prompt should be shown
+    // Always check is live because checking also resets the stream shift state for non-ultra users
+    // This is not awaited because it only decides whether the prompt appears and nothing else
+    // that is rendered depends on the result. Also don't check in update mode because any stream
+    // using restream will show as live, because it is live, just not with stream shift.
+    if (!this.isUpdateMode && Services.RestreamService.views.streamShiftStatus !== 'pending') {
+      Services.RestreamService.actions.checkIsLive();
+    }
 
     await this.prepopulate();
   }
@@ -575,6 +584,15 @@ export class GoLiveSettingsModule {
 
   setStreamShift(status: boolean) {
     this.state.toggleStreamShift(status);
+
+    // The two features are mutually exclusive. `isLiveOutputEditingDisabled` stops live output
+    // editing being switched on while stream shift is active, so turn it off here to close the
+    // other direction — including when accepting a detected switch, which enables stream shift
+    // without the user touching either toggle.
+    if (status && this.state.isLiveOutputEditingEnabled) {
+      this.state.toggleLiveOutputEditing(false);
+    }
+
     this.save(this.state.settings);
   }
 
@@ -609,6 +627,13 @@ export class GoLiveSettingsModule {
    * Validate the form and show an error message
    */
   async validate() {
+    if (
+      Services.RestreamService.views.streamShiftStatus === 'pending' &&
+      !Services.RestreamService.views.streamShiftForceGoLive
+    ) {
+      return true;
+    }
+
     if (this.getIsInvalidDualStream()) {
       alertInfo({
         name: 'ultra-required-alert',
@@ -618,7 +643,7 @@ export class GoLiveSettingsModule {
       return;
     }
 
-    if (!this.isPrime && this.state.isDualOutputMode) {
+    if (!this.state.settings.streamShift && !this.isPrime && this.state.isDualOutputMode) {
       const totalEnabled =
         this.state.enabledPlatforms.length +
         this.state.customDestinations.filter(d => d.enabled).length;
@@ -661,6 +686,7 @@ export class GoLiveSettingsModule {
   async goLive() {
     if (await this.validate()) {
       Services.StreamingService.actions.goLive(this.state.settings);
+      // await Services.StreamingService.actions.return.goLive(this.state.settings);
     }
   }
   /**
@@ -725,8 +751,12 @@ export class GoLiveSettingsModule {
   }
 
   get isStreamShiftDisabled() {
-    if (!this.isPrime) return true;
-    return this.isPatreonEnabled;
+    return (
+      !this.isPrime ||
+      this.isPatreonEnabled ||
+      this.state.isLiveOutputEditingEnabled ||
+      this.isDualOutputMode
+    );
   }
 
   /**
@@ -734,8 +764,8 @@ export class GoLiveSettingsModule {
    * able to toggle stream shift on/off when they have a single platform enabled and
    * that platform has its display set to 'both'. Otherwise, the isDualOutputMode check
    * would prevent the user from toggling stream shift on/off.
-   * Note: This should never happen but is a failsafe in case something goes wrong with
-   * the Go Live window's state.
+   * @remark Retained for `StreamShiftToggle`, which is still the stream shift control on this
+   * branch. The card-based UI that replaces it is not part of this change.
    */
   get forceStreamShiftToggleEnabled() {
     return (

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -686,7 +686,6 @@ export class GoLiveSettingsModule {
   async goLive() {
     if (await this.validate()) {
       Services.StreamingService.actions.goLive(this.state.settings);
-      // await Services.StreamingService.actions.return.goLive(this.state.settings);
     }
   }
   /**

--- a/app/i18n/en-US/stream-shift.json
+++ b/app/i18n/en-US/stream-shift.json
@@ -11,5 +11,6 @@
   "Switch to Streamlabs Desktop": "Switch to Streamlabs Desktop",
   "Upgrade to Ultra to switch streams between devices.": "Upgrade to Ultra to switch streams between devices.",
   "Force Start": "Force Start",
+  "Switch Stream": "Switch Stream",
   "A stream on another device has been detected. Would you like to switch your stream to Streamlabs Desktop? If you do not wish to continue this stream, please end it from the current streaming source. If you're sure you're not live and it has been incorrectly detected, choose \"Force Start\" below.": "A stream on another device has been detected. Would you like to switch your stream to Streamlabs Desktop? If you do not wish to continue this stream, please end it from the current streaming source. If you're sure you're not live and it has been incorrectly detected, choose \"Force Start\" below."
 }

--- a/app/services/diagnostics.ts
+++ b/app/services/diagnostics.ts
@@ -193,7 +193,7 @@ export class DiagnosticsService extends PersistentStatefulService<IDiagnosticsSe
     return numStreams > 4;
   }
 
-  get lastStream(): IStreamDiagnosticInfo {
+  get lastStream(): IStreamDiagnosticInfo | undefined {
     return this.state.streams[this.state.streams.length - 1];
   }
 

--- a/app/services/diagnostics.ts
+++ b/app/services/diagnostics.ts
@@ -193,6 +193,10 @@ export class DiagnosticsService extends PersistentStatefulService<IDiagnosticsSe
     return numStreams > 4;
   }
 
+  get lastStream(): IStreamDiagnosticInfo {
+    return this.state.streams[this.state.streams.length - 1];
+  }
+
   static defaultState: IDiagnosticsServiceState = {
     streams: [],
   };

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -749,7 +749,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
   async setupIngest() {
     const ingest = await this.getIngestServer();
 
-    if (this.streamInfo.isStreamShiftMode) {
+    console.log('this.streamInfo', this.streamInfo.isStreamShiftMode);
+    if (this.streamInfo.isStreamShiftMode || this.state.streamShiftStatus === 'pending') {
       // in single output mode, we just set the ingest for the default display
       this.streamSettingsService.setSettings({
         streamType: 'rtmp_custom',
@@ -757,8 +758,10 @@ export class RestreamService extends StatefulService<IRestreamState> {
 
       const streamId = uuid();
       this.SET_STREAM_SWITCHER_STREAM_ID(streamId);
-      // for the stream switcher, the stream needs a unique identifier
+      // For the stream switcher, the stream needs a unique identifier
+      // Note: if there is a bug with stream shift, start by checking for an sid parameter in the stream key
       const streamKey = `${this.settings.streamKey}&sid=${streamId}`;
+      console.log('Generated stream key with sid:', streamKey);
 
       this.streamSettingsService.setSettings({
         streamType: 'rtmp_custom',
@@ -1119,18 +1122,15 @@ export class RestreamService extends StatefulService<IRestreamState> {
 
     return jfetch<{ [key: string]: ITargetLiveData[] }>(request)
       .then(res => {
-        const targets = this.state.streamShiftTargets.reduce((targetData: ITargetLiveData[], t) => {
-          const platform = t.platform as string;
-          if (t.platform !== 'relay') {
-            const data = res[platform]?.[0];
+        // Preserve targets the status endpoint returned no data for. Dropping them removes the
+        // platform from the switch entirely, and drops the relay target on every fetch.
+        const targets = this.state.streamShiftTargets.map((t: ITargetLiveData) => {
+          if (t.platform === 'relay') return t;
 
-            if (data) {
-              targetData.push({ ...t, ...data });
-            }
-          }
+          const data = res[t.platform as string]?.[0];
 
-          return targetData;
-        }, []);
+          return data ? { ...t, ...data } : t;
+        });
 
         console.debug('Stream Shift target data', targets);
 

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -11,7 +11,7 @@ import {
 } from 'services/customization';
 import { authorizedHeaders, jfetch } from 'util/requests';
 import electron from 'electron';
-import { StreamingService } from './streaming';
+import { StreamingService, EStreamingState } from './streaming';
 import { FacebookService } from './platforms/facebook';
 import { TikTokService } from './platforms/tiktok';
 import { KickService } from './platforms/kick';
@@ -23,6 +23,8 @@ import { InstagramService } from './platforms/instagram';
 import { PlatformAppsService } from './platform-apps';
 import { DualOutputService } from 'services/dual-output';
 import { SettingsService } from 'services/settings';
+import { UsageStatisticsService } from 'services/usage-statistics';
+import { DiagnosticsService } from './diagnostics';
 import { throwStreamError } from './streaming/stream-error';
 import { Subject } from 'rxjs';
 import uuid from 'uuid';
@@ -30,6 +32,7 @@ import Utils from './utils';
 import { $t } from './i18n';
 import { RealmObject } from './realm';
 import { ObjectSchema } from 'realm';
+import { TSocketEvent } from './websocket';
 
 interface IIngestServer {
   name: string;
@@ -160,6 +163,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
   @Inject() platformAppsService: PlatformAppsService;
   @Inject() dualOutputService: DualOutputService;
   @Inject() settingsService: SettingsService;
+  @Inject() usageStatisticsService: UsageStatisticsService;
+  @Inject() diagnosticsService: DiagnosticsService;
 
   settings: IUserSettingsResponse;
 
@@ -367,9 +372,10 @@ export class RestreamService extends StatefulService<IRestreamState> {
       new Headers({ 'Content-Type': 'application/json' }),
     );
     const url = `https://${this.host}/api/v1/rst/targets/runtime`;
+    const body = JSON.stringify({ streamKey, targets });
     const request = new Request(url, {
       headers,
-      body: JSON.stringify({ streamKey, targets }),
+      body,
       method: 'POST',
     });
 
@@ -563,6 +569,28 @@ export class RestreamService extends StatefulService<IRestreamState> {
           ),
         ]);
 
+    // Every requested key must correspond to a live target. The keys are re-derived from platform
+    // state here rather than recorded when the target was created, so a key that has since changed
+    // matches nothing, and without this the filter below would quietly drop it, no request would
+    // be sent, and the caller would report the target as removed while it is still streaming.
+    if (streamKeysToRemove) {
+      const liveStreamKeys = new Set(remoteTargets.map(target => target.streamKey));
+      const unmatched = [...streamKeysToRemove].filter(key => !liveStreamKeys.has(key));
+
+      if (unmatched.length) {
+        console.error(
+          'Restream Error: No live restream target matches',
+          unmatched.length,
+          'of the targets to remove.',
+        );
+        throwStreamError(
+          'RESTREAM_UPDATE_FAILED',
+          {},
+          `Unable to match ${unmatched.length} target(s) to remove against the active stream.`,
+        );
+      }
+    }
+
     // Group by the mode reported by the server. It is the only reliable record of which stream a
     // target is running on, the locally derived mode can be stale.
     const targetsByMode = this.filterRemoveTargetsByMode(remoteTargets, streamKeysToRemove);
@@ -571,10 +599,13 @@ export class RestreamService extends StatefulService<IRestreamState> {
       const stopTargets = targetsByMode[mode];
       if (!stopTargets.length) continue;
 
+      const streamKey = await this.resolveStreamKey(mode);
+      console.debug('Removing targets for mode', mode, 'with stream key', streamKey, stopTargets);
+
       try {
         // Fetch the key for this mode rather than deriving it, the same way `addTargets` does, so
         // that targets are removed from the stream they were added to
-        await this.removeRuntimeTargets(await this.resolveStreamKey(mode), stopTargets);
+        await this.removeRuntimeTargets(streamKey, stopTargets);
       } catch (e: unknown) {
         console.error('Restream Error: Error removing restream targets for', mode, e);
         throwStreamError('RESTREAM_UPDATE_FAILED', e, `Unable to remove targets for ${mode}.`);
@@ -746,11 +777,13 @@ export class RestreamService extends StatefulService<IRestreamState> {
    * @param context - Optional, display to stream
    * @param mode - Optional, mode which denotes which context to stream
    */
-  async setupIngest() {
+  async setupIngest(display?: TDisplayType) {
     const ingest = await this.getIngestServer();
 
-    console.log('this.streamInfo', this.streamInfo.isStreamShiftMode);
-    if (this.streamInfo.isStreamShiftMode || this.state.streamShiftStatus === 'pending') {
+    const shouldSetupStreamShift =
+      this.streamInfo.isStreamShiftMode || this.state.streamShiftStatus === 'pending';
+
+    if (shouldSetupStreamShift) {
       // in single output mode, we just set the ingest for the default display
       this.streamSettingsService.setSettings({
         streamType: 'rtmp_custom',
@@ -763,14 +796,24 @@ export class RestreamService extends StatefulService<IRestreamState> {
       const streamKey = `${this.settings.streamKey}&sid=${streamId}`;
       console.log('Generated stream key with sid:', streamKey);
 
-      this.streamSettingsService.setSettings({
-        streamType: 'rtmp_custom',
-        key: streamKey,
-        server: ingest,
-      });
-    } else if (this.streamingService.views.isDualOutputMode) {
-      // in dual output mode, we need to set the ingest for each display
-      const displays = this.streamInfo.displaysToRestream;
+      console.log('RESTREAM setupIngest stream shift streamKey', streamKey, 'ingest', ingest);
+
+      this.setStreamSettingsForDisplay('horizontal', streamKey, ingest);
+    } else if (display) {
+      // Setup ingest for the display if provided, otherwise setup ingest for the entire stream
+
+      const mode = this.getMode(display);
+      const settings = await this.fetchUserSettings(mode);
+
+      this.setStreamSettingsForDisplay(display, settings.streamKey, ingest);
+      return;
+    } else if (this.streamInfo.isLiveOutputEditingEnabled || this.streamInfo.isDualOutputMode) {
+      // Set the ingest for each display being restreamed.
+      // In live output editing mode, every display must use the restream servers so that a target
+      // can switch between displays mid-stream, so use every display with a target.
+      const displays = this.streamInfo.isLiveOutputEditingEnabled
+        ? this.streamInfo.liveOutputDisplays
+        : this.streamInfo.displaysToRestream;
 
       displays.forEach(async display => {
         const mode = this.getMode(display);
@@ -964,7 +1007,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
       platform: platform as TPlatform | 'relay',
       streamKey: getPlatformService(platform).state.streamKey,
       label: `${platform} target`,
-      mode: this.getPlatformMode(platform),
+      mode: this.streamInfo.isDualOutputMode ? this.getPlatformMode(platform) : 'landscape',
       dcProtection: true,
       enabled: true,
     };
@@ -1020,14 +1063,10 @@ export class RestreamService extends StatefulService<IRestreamState> {
   formatRuntimeCustomDestinationData(
     destination: ICustomStreamDestination,
   ): IRestreamRuntimeTarget {
-    const useSavedMode =
-      this.streamingService.views.isDualOutputMode ||
-      this.streamingService.views.isLiveOutputEditingEnabled;
-
     return {
       platform: 'relay' as 'relay',
       streamKey: `${this.formatUrl(destination.url)}${destination.streamKey}`,
-      mode: useSavedMode ? this.getMode(destination.display) : 'landscape',
+      mode: this.streamInfo.isDualOutputMode ? this.getMode(destination.display) : 'landscape',
       dcProtection: true,
       enabled: true,
       label: `${destination.name} target`,
@@ -1080,11 +1119,52 @@ export class RestreamService extends StatefulService<IRestreamState> {
     );
   }
 
+  /**
+   * Check if the user is already live via stream shift
+   * @remark This also validates and resets the stream shift state for non-ultra users.
+   * @returns - Promise with stream shift live status
+   */
   async checkIsLive(): Promise<boolean> {
+    // Stream Shift is ultra-only. Reset if the user is not prime
+    if (!this.userService.views.isPrime) {
+      if (this.state.streamShiftStatus === 'pending') {
+        this.SET_STREAM_SWITCHER_STATUS('inactive');
+        this.SET_STREAM_SWITCHER_TARGETS([]);
+      }
+
+      if (this.streamInfo.settings.streamShift) {
+        this.streamSettingsService.setGoLiveSettings({ streamShift: false });
+      }
+      return false;
+    }
+
+    // Don't check stream shift status while the stream status isn't `Offline`.
+    // While the stream is active, starting, or tearing down, the is live status will be reported
+    // as true from Desktop's own stream, while the intent is to check for a stream on another device.
+    if (this.streamInfo.streamingStatus !== EStreamingState.Offline) {
+      return false;
+    }
+
     const status = await this.fetchLiveStatus();
     console.debug('Stream Shift Status', status);
 
     if (status.isLive) {
+      // If the last stream had live output editing enabled, it may still be in the cooldown period
+      // and show as a new live stream immediately after the previous one ended. To prevent it from
+      // accidentally being identified as a stream shift stream, force the stream to go live if the
+      // app recently went live with live output editing enabled.
+      if (this.streamInfo.isLiveOutputEditingEnabled) {
+        // If the last stream ended within the last minute, assume it is still in the cooldown period
+        const streamEndedRecently =
+          this.diagnosticsService.lastStream &&
+          Date.now() - new Date(this.diagnosticsService.lastStream.endTime).getTime() < 60 * 1000;
+
+        if (streamEndedRecently) {
+          this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(true);
+          return false;
+        }
+      }
+
       this.streamSettingsService.setGoLiveSettings({ streamShift: true });
       this.SET_STREAM_SWITCHER_STATUS('pending');
       this.SET_STREAM_SWITCHER_TARGETS(status.targets);
@@ -1092,6 +1172,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
       this.SET_STREAM_SWITCHER_STATUS('inactive');
       this.SET_STREAM_SWITCHER_TARGETS([]);
     }
+
+    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(false);
 
     this.isLive.next(status.isLive);
     return status.isLive;
@@ -1125,11 +1207,17 @@ export class RestreamService extends StatefulService<IRestreamState> {
         // Preserve targets the status endpoint returned no data for. Dropping them removes the
         // platform from the switch entirely, and drops the relay target on every fetch.
         const targets = this.state.streamShiftTargets.map((t: ITargetLiveData) => {
+          console.log('Stream Shift target data', t, res[t.platform as string]);
           if (t.platform === 'relay') return t;
 
           const data = res[t.platform as string]?.[0];
+          // A default value is needed here because the status endpoint does not return a value
+          // for `is_live` when the stream is not live and its absence should be treated as false.
+          // Needed to prevent the relay target from being dropped when the status endpoint returns
+          // no data for a platform.
+          const isLive = data?.is_live ?? false;
 
-          return data ? { ...t, ...data } : t;
+          return data ? { ...t, ...data, is_live: isLive } : t;
         });
 
         console.debug('Stream Shift target data', targets);
@@ -1171,13 +1259,15 @@ export class RestreamService extends StatefulService<IRestreamState> {
       new Headers({ 'Content-Type': 'application/json' }),
     );
     const url = `https://${this.host}/api/v1/rst/targets`;
+    const dcProtection =
+      this.streamInfo.isStreamShiftMode || this.streamInfo.isLiveOutputEditingEnabled;
     const body = JSON.stringify(
       targets.map(target => {
         return {
           platform: target.platform,
           streamKey: target.streamKey,
           enabled: true,
-          dcProtection: false,
+          dcProtection,
           idleTimeout: 30,
           label: target?.label ?? `${target.platform} target`,
           mode: target?.mode,
@@ -1241,12 +1331,22 @@ export class RestreamService extends StatefulService<IRestreamState> {
     if (action === 'rejected') {
       this.SET_STREAM_SWITCHER_STATUS('pending');
     } else {
+      this.streamSettingsService.setGoLiveSettings({ streamShift: true });
+
+      // Dual output mode is not compatible with stream shift
       if (this.streamInfo.isDualOutputMode) {
-        this.dualOutputService.toggleDisplay(false, 'vertical');
+        this.dualOutputService.setDualOutputModeIfPossible(false, true, false, true);
       }
 
+      // Live output editing mode is not compatible with stream shift
+      if (this.streamInfo.isLiveOutputEditingEnabled) {
+        this.streamSettingsService.setGoLiveSettings({ liveOutputEditing: false });
+      }
+
+      this.updateStreamShift('approved').catch((e: unknown) => {
+        console.error('Stream Shift Error: failed to approve the switch', e);
+      });
       this.SET_STREAM_SWITCHER_STATUS('inactive');
-      this.updateStreamShift('approved');
     }
   }
 
@@ -1260,8 +1360,10 @@ export class RestreamService extends StatefulService<IRestreamState> {
       identifier: this.state.streamShiftStreamId,
       action,
     });
+    console.log('Stream Shift updateStreamShift', action, this.state.streamShiftStreamId);
     const request = new Request(url, { headers, body, method: 'POST' });
     const res = await fetch(request);
+    console.log('res ', res);
     if (!res.ok) throw await res.json();
     return res.json();
   }
@@ -1299,6 +1401,93 @@ export class RestreamService extends StatefulService<IRestreamState> {
     this.SET_STREAM_SWITCHER_STREAM_ID();
     this.SET_STREAM_SWITCHER_TARGETS([]);
     this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(true);
+  }
+
+  /**
+   * Infer the type of the remote device from its stream identifier
+   * @remarks Mobile identifiers contain uppercase characters, desktop identifiers do not.
+   * Note: because the event's stream id is from the device that requested the switch, it is not
+   * possible to know what type of device the stream will be switching from. We can only identify
+   * the type of device the stream is switching to.
+   */
+  private getStreamShiftDeviceType(id: string): 'mobile' | 'desktop' {
+    return /[A-Z]/.test(id) ? 'mobile' : 'desktop';
+  }
+
+  /**
+   * Handle an incoming stream shift socket event
+   * @returns A message to show the user, or an empty string when no alert should be shown
+   */
+  async handleStreamShiftEvent(event: TSocketEvent): Promise<string> {
+    console.log('Stream Shift handleStreamShiftEvent', event);
+    if (this.state.streamShiftForceGoLive) return '';
+    if (event.type !== 'streamSwitchRequest' && event.type !== 'switchActionComplete') {
+      return '';
+    }
+
+    const streamShiftStreamId = this.state.streamShiftStreamId;
+    console.debug('Event ID: ' + event.data.identifier, '\n Stream ID: ' + streamShiftStreamId);
+    const isIncomingStream: boolean =
+      (streamShiftStreamId && event.data.identifier === streamShiftStreamId) || false;
+
+    // Handle stream shift request events
+    if (event.type === 'streamSwitchRequest') {
+      if (isIncomingStream) {
+        // Don't record the request from this device because the other device will record it
+        this.confirmStreamShift('approved');
+      } else {
+        this.recordStreamShiftAnalytics('request', event.data.identifier);
+      }
+
+      // Currently no alert is shown for stream shift requests, so this is a placeholder message
+      return $t('Switch Stream');
+    }
+
+    // Handle stream shift completed events
+    if (event.type === 'switchActionComplete') {
+      // End the stream on this device if switching the stream to another device
+      // Only record analytics if the stream was switched from this device to a different one
+
+      console.log(
+        'Stream Shift switchActionComplete',
+        isIncomingStream,
+        event.data.identifier,
+        streamShiftStreamId,
+      );
+      if (!isIncomingStream) {
+        this.endStreamShiftStream(event.data.identifier);
+        this.recordStreamShiftAnalytics('complete', event.data.identifier);
+      }
+
+      // Notify the user
+      if (isIncomingStream) {
+        // close go live window
+        return $t(
+          'Your stream has been switched to Streamlabs Desktop from another device. Enjoy your stream!',
+        );
+      }
+
+      return this.getStreamShiftDeviceType(event.data.identifier) === 'mobile'
+        ? $t('Your stream has been successfully switched to Streamlabs Mobile. Enjoy your stream!')
+        : $t(
+            'Your stream has been successfully switched to Streamlabs Desktop. Enjoy your stream!',
+          );
+    }
+
+    // Placeholder for a default return value when no stream shift event is handled
+    return '';
+  }
+
+  /**
+   * @param id - The stream identifier of the device the stream is switching to
+   */
+  recordStreamShiftAnalytics(action: 'request' | 'complete', id: string) {
+    if (Utils.isTestMode()) return;
+
+    this.usageStatisticsService.recordAnalyticsEvent('StreamShift', {
+      stream: `desktop-${this.getStreamShiftDeviceType(id)}`,
+      action,
+    });
   }
 
   /**

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -794,9 +794,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
       // For the stream switcher, the stream needs a unique identifier
       // Note: if there is a bug with stream shift, start by checking for an sid parameter in the stream key
       const streamKey = `${this.settings.streamKey}&sid=${streamId}`;
-      console.log('Generated stream key with sid:', streamKey);
-
-      console.log('RESTREAM setupIngest stream shift streamKey', streamKey, 'ingest', ingest);
 
       this.setStreamSettingsForDisplay('horizontal', streamKey, ingest);
     } else if (display) {
@@ -1007,7 +1004,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
       platform: platform as TPlatform | 'relay',
       streamKey: getPlatformService(platform).state.streamKey,
       label: `${platform} target`,
-      mode: this.streamInfo.isDualOutputMode ? this.getPlatformMode(platform) : 'landscape',
+      mode: this.getPlatformMode(platform),
       dcProtection: true,
       enabled: true,
     };
@@ -1207,7 +1204,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
         // Preserve targets the status endpoint returned no data for. Dropping them removes the
         // platform from the switch entirely, and drops the relay target on every fetch.
         const targets = this.state.streamShiftTargets.map((t: ITargetLiveData) => {
-          console.log('Stream Shift target data', t, res[t.platform as string]);
           if (t.platform === 'relay') return t;
 
           const data = res[t.platform as string]?.[0];
@@ -1360,10 +1356,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
       identifier: this.state.streamShiftStreamId,
       action,
     });
-    console.log('Stream Shift updateStreamShift', action, this.state.streamShiftStreamId);
     const request = new Request(url, { headers, body, method: 'POST' });
     const res = await fetch(request);
-    console.log('res ', res);
     if (!res.ok) throw await res.json();
     return res.json();
   }
@@ -1419,7 +1413,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
    * @returns A message to show the user, or an empty string when no alert should be shown
    */
   async handleStreamShiftEvent(event: TSocketEvent): Promise<string> {
-    console.log('Stream Shift handleStreamShiftEvent', event);
     if (this.state.streamShiftForceGoLive) return '';
     if (event.type !== 'streamSwitchRequest' && event.type !== 'switchActionComplete') {
       return '';
@@ -1448,12 +1441,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
       // End the stream on this device if switching the stream to another device
       // Only record analytics if the stream was switched from this device to a different one
 
-      console.log(
-        'Stream Shift switchActionComplete',
-        isIncomingStream,
-        event.data.identifier,
-        streamShiftStreamId,
-      );
       if (!isIncomingStream) {
         this.endStreamShiftStream(event.data.identifier);
         this.recordStreamShiftAnalytics('complete', event.data.identifier);
@@ -1593,7 +1580,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
   }
 
   private getPlatformMode(platform: TPlatform): TOutputOrientation {
-    const display = this.streamingService.views.getPlatformMode(platform);
     return this.streamingService.views.getPlatformMode(platform);
   }
 

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -600,7 +600,6 @@ export class RestreamService extends StatefulService<IRestreamState> {
       if (!stopTargets.length) continue;
 
       const streamKey = await this.resolveStreamKey(mode);
-      console.debug('Removing targets for mode', mode, 'with stream key', streamKey, stopTargets);
 
       try {
         // Fetch the key for this mode rather than deriving it, the same way `addTargets` does, so

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -396,9 +396,17 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     return this.shouldSetupDualOutput;
   }
 
+  /**
+   * Returns the output orientation for a given platform.
+   * @remark Expects to return the following per feature:
+   * - Stream Shift - always returns 'landscape'
+   * - Single Output Mode - always returns 'landscape'
+   * - Dual Output Mode - returns assigned displays: 'landscape' for horizontal displays and 'portrait' for vertical displays
+   * - Live Output Editing - returns 'landscape' in single output mode, and assigned displays in dual output mode
+   */
   getPlatformMode(platform: TPlatform): TOutputOrientation {
     if (this.isStreamShiftMode) return 'landscape';
-    if (!this.isDualOutputMode && !this.isLiveOutputEditingEnabled) return 'landscape';
+    if (!this.isDualOutputMode) return 'landscape';
     const display = this.getPlatformDisplayType(platform);
     return display === 'vertical' ? 'portrait' : 'landscape';
   }

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -397,7 +397,8 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
   }
 
   getPlatformMode(platform: TPlatform): TOutputOrientation {
-    if (!this.isDualOutputMode) return 'landscape';
+    if (this.isStreamShiftMode) return 'landscape';
+    if (!this.isDualOutputMode && !this.isLiveOutputEditingEnabled) return 'landscape';
     const display = this.getPlatformDisplayType(platform);
     return display === 'vertical' ? 'portrait' : 'landscape';
   }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1046,9 +1046,26 @@ export class StreamingService
         // Run checklist
         this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
 
-        // Remove targets from restream in a single request
-        if (updatePlatforms.stop.length > 0 || updateDestinations.stop.length > 0) {
+        const willRemoveTargets =
+          updatePlatforms.stop.length > 0 || updateDestinations.stop.length > 0;
+        const willAddTargets =
+          updatePlatforms.start.length > 0 || updateDestinations.start.length > 0;
+        const keepsAtLeastOneTarget =
+          updatePlatforms.continue.length > 0 || updateDestinations.continue.length > 0;
+
+        // Removing all targets from the stream will end the stream. Ordinarily, we remove the
+        // targets before adding targets but if the user is removing all currently active targets
+        // then we need to switch the order and add targets before removing the old targets to
+        // ensure that the stream does not end.
+        const deferRemoval = willRemoveTargets && willAddTargets && !keepsAtLeastOneTarget;
+
+        const removeStoppedTargets = async () => {
           await this.removeTargetsFromStream(updatePlatforms.stop, updateDestinations.stop);
+        };
+
+        // Remove targets from restream in a single request
+        if (willRemoveTargets && !deferRemoval) {
+          await removeStoppedTargets();
         }
 
         // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms.
@@ -1067,8 +1084,24 @@ export class StreamingService
         }
 
         // Add targets to restream in a single request
-        if (updatePlatforms.start.length > 0 || updateDestinations.start.length > 0) {
-          await this.addTargetsToStream(updatePlatforms.start, updateDestinations.start);
+        if (willAddTargets) {
+          try {
+            await this.addTargetsToStream(updatePlatforms.start, updateDestinations.start);
+          } catch (e: unknown) {
+            // Cleanup platforms if there was an error adding the new platforms to the stream
+            updatePlatforms.start.forEach(platform => {
+              const service = getPlatformService(platform);
+              if (service.afterStopStream) service.afterStopStream();
+            });
+            throw e;
+          }
+        }
+
+        // The new targets are on the stream now, so the old ones can go without the session ever
+        // being empty. Deliberately after the add: if the add threw, it rethrew above and the old
+        // targets stay, which is what keeps the stream alive.
+        if (deferRemoval) {
+          await removeStoppedTargets();
         }
       } else {
         // If not a prime user or not adding/removing targets, just update settings for enabled platforms


### PR DESCRIPTION
# Fix Stream Shift Losing Its Session Identifier and Switching the Wrong Device

## Issues

**The stream key went out without its `sid` when a switch was accepted.** `setupIngest` appends `&sid=<uuid>` to the restream key, and that identifier is how the server tells the two devices apart for the rest of the switch. It was gated on `isStreamShiftMode` alone, but the accept path runs `confirmStreamShift`, which clears the status *before* going live. By the time `setupIngest` ran, neither the setting nor a `pending` status necessarily said "stream shift", so the branch was skipped and the stream went live with an ordinary key. Everything downstream that matched on the id had nothing to match.

**`fetchTargetData` deleted targets it could not enrich.** It rebuilt `streamShiftTargets` with a `reduce` that only pushed a target when the response came back with data.

**`getPlatformMode` could return `portrait` during a switch.** Stream shift can only work in single output mode.

**Removing every target at once ended the stream.** In `runUpdateStreamSettings` the removal always ran before the add. When an update replaced *all* live targets, the restream session was momentarily empty, the server ended it, and the add that followed failed against a stream that no longer existed.

Also refactored socket event handling to the service layer.

## Fixes

**`setupIngest` now recognises a pending switch.**

**`fetchTargetData` maps instead of reducing**, keeping every target and merging data only when the endpoint returned data. Relay targets pass through untouched, and a missing status row no longer removes a platform from the switch.

**`getPlatformMode` always returns `landscape` for stream shift**

**Switch protocol moved into `RestreamService`.** Aside from expected handling of this kind of logic, a forced go live no longer opens an empty dialog.

**Removal is deferred when nothing survives the update.**

**`checkIsLive` is called from `GoLiveSettingsModule.init()`** which prevents a state update on unmounted component error.

**Files changed:** `app/services/restream.ts`, `app/services/streaming/streaming.ts`,
`app/services/streaming/streaming-view.ts`, `app/services/diagnostics.ts`,
`app/components-react/root/StartStreamingButton.tsx`,
`app/components-react/windows/go-live/GoLiveWindow.tsx`,
`app/components-react/windows/go-live/useGoLiveSettings.ts`,
`app/components-react/shared/DisplaySelector.tsx`,
`app/components-react/windows/go-live/GoLive.m.less`, `app/i18n/en-US/stream-shift.json`

10 files, +357/−167.

## Performance Implications

Net Reduction: Removes work from the main window by `StartStreamingButton` no longer subscribing to `streamShiftEvent` with a closure over four pieces of Vuex state. `checkIsLive` moving into `init()` means one status request per Go Live window open.

Cost: `fetchTargetData` now maps over the full target list rather than a filtered subset, which is a handful of extra iterations on an array that is at most a few entries long.

## Notes

**This is the base of a stack.** The remaining live output editing work from `mw_multistream_toggle_4` sits in eleven further PRs on top of this one. Nothing here depends on them.