### PR TITLE
Fix frontend test artifact extraction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: 'Frontend Tests'
 
 on:
   push:
-    branches: [staging, master]
+    branches: [staging, master, fix-frontend-test-artifact-layout]
   pull_request:
     branches: [staging, master]
     types: [synchronize, opened, reopened]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,14 +68,15 @@ jobs:
         run: node node_modules/electron/install.js
       - name: 'Compile Assets'
         run: yarn ci:compile
+      - name: 'Package Test Build'
+        run: 7z a -t7z -mx=1 -bb0 "$env:RUNNER_TEMP\frontend-test-build.7z" . '-xr!.git'
+        shell: powershell
       - name: 'Upload Test Build'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-test-build
-          path: |
-            .
-            !.git/**
-          include-hidden-files: true
+          path: ${{ runner.temp }}/frontend-test-build.7z
+          compression-level: 0
           retention-days: 1
 
   test:
@@ -94,16 +95,24 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: frontend-test-build
-          path: ${{ runner.temp }}/frontend-test-build
+          path: ${{ runner.temp }}/frontend-test-artifact
       - name: 'Run Tests'
         run: |
           'obs64','crash-handler','chromedriver','electron' | ForEach-Object {
             Get-Process -Name $_ -ErrorAction Ignore | Stop-Process -Force -ErrorAction Ignore
           }
           Remove-Item -Recurse -Force "$env:TEMP\slobs-test*" -ErrorAction Ignore
+
+          $projectDirectory = Join-Path $env:RUNNER_TEMP 'frontend-test-project'
+          New-Item -ItemType Directory -Force -Path $projectDirectory | Out-Null
+          7z x "$env:RUNNER_TEMP\frontend-test-artifact\frontend-test-build.7z" "-o$projectDirectory" -y -bb0
+          Set-Location $projectDirectory
+
+          if (-not (Test-Path package.json)) {
+            throw "Test build does not contain package.json at $projectDirectory"
+          }
           yarn ci:tests
         shell: powershell
-        working-directory: ${{ runner.temp }}/frontend-test-build
         env:
           SLOBS_TEST_USER_POOL_TOKEN: ${{ secrets.SLOBS_TEST_USER_POOL_TOKEN }}
           BROWSER_SOURCE_HARDWARE_ACCELERATION: 'OFF'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           name: frontend-test-build
           path: ${{ runner.temp }}/frontend-test-artifact
-      - name: 'Run Tests'
+      - name: 'Prepare Test Runner'
         run: |
           'obs64','crash-handler','chromedriver','electron' | ForEach-Object {
             Get-Process -Name $_ -ErrorAction Ignore | Stop-Process -Force -ErrorAction Ignore
@@ -111,8 +111,10 @@ jobs:
           if (-not (Test-Path package.json)) {
             throw "Test build does not contain package.json at $projectDirectory"
           }
-          yarn ci:tests
         shell: powershell
+      - name: 'Run Tests'
+        run: yarn ci:tests
+        working-directory: ${{ runner.temp }}/frontend-test-project
         env:
           SLOBS_TEST_USER_POOL_TOKEN: ${{ secrets.SLOBS_TEST_USER_POOL_TOKEN }}
           BROWSER_SOURCE_HARDWARE_ACCELERATION: 'OFF'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: 'Frontend Tests'
 
 on:
   push:
-    branches: [staging, master, fix-frontend-test-artifact-layout]
+    branches: [staging, master]
   pull_request:
     branches: [staging, master]
     types: [synchronize, opened, reopened]


### PR DESCRIPTION
## Summary
- package the prepared test workspace into a single `.7z` before artifact upload
- disable redundant artifact compression
- extract into an explicit project directory on each test runner
- verify `package.json` exists before invoking Yarn

This fixes the `No project found in /C:/actions-runner/_work/_temp/frontend-test-build` failure from run 33006382789. The original artifact contained 85,622 separate files; using one archive makes the transferred layout deterministic and preserves it across the hosted/self-hosted boundary.

## Validation
- exercised the 7-Zip create/list command locally
- `actionlint` with the repository's custom runner label allowed
- `yarn prettier --check .github/workflows/tests.yml`
- `git diff --check`