### PR TITLE
Stop crash handler process before test extraction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           path: ${{ runner.temp }}/frontend-test-artifact
       - name: 'Prepare Test Runner'
         run: |
-          'obs64','crash-handler','chromedriver','electron' | ForEach-Object {
+          'obs64','crash-handler','crash-handler-process','chromedriver','electron' | ForEach-Object {
             Get-Process -Name $_ -ErrorAction Ignore | Stop-Process -Force -ErrorAction Ignore
           }
           Remove-Item -Recurse -Force "$env:TEMP\slobs-test*" -ErrorAction Ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: 'Frontend Tests'
 
 on:
   push:
-    branches: [staging, master, fix-crash-handler-process-cleanup]
+    branches: [staging, master]
   pull_request:
     branches: [staging, master]
     types: [synchronize, opened, reopened]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: 'Frontend Tests'
 
 on:
   push:
-    branches: [staging, master]
+    branches: [staging, master, fix-crash-handler-process-cleanup]
   pull_request:
     branches: [staging, master]
     types: [synchronize, opened, reopened]


### PR DESCRIPTION
## Summary
- stop `crash-handler-process` during self-hosted runner cleanup
- retain the existing `crash-handler` cleanup entry

This addresses the locked `crash-handler-process.exe` and `zlib.dll` files that caused artifact extraction to fail in run 33013367744, attempt 1.

## Validation
- `actionlint` with the repository's custom runner label allowed
- `yarn prettier --check .github/workflows/tests.yml`
- `git diff --check`