### PR TITLE
Add dismissable to AI Highlighter toggle in Edit Stream window.

### DIFF
--- a/app/components-react/windows/go-live/AiHighlighterToggle.m.less
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.m.less
@@ -223,4 +223,10 @@
   border-radius: 8px;
 }
 
-// .highlighter-banner___36EFl .ant-switch-handle::before
+.dismissable {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 10px;
+  text-decoration: underline;
+}

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, memo } from 'react';
 import styles from './AiHighlighterToggle.m.less';
 import { Services } from 'components-react/service-provider';
 import { useDebounce, useVuex } from 'components-react/hooks';
-import { DownOutlined, UpOutlined, CloseOutlined } from '@ant-design/icons';
+import { DownOutlined, UpOutlined } from '@ant-design/icons';
 import { Alert, Button } from 'antd';
 import { getConfigByGame, isGameSupported } from 'services/highlighter/models/game-config.models';
 import { $t } from 'services/i18n';
@@ -235,16 +235,6 @@ export default function AiHighlighterToggle({
                   ) : (
                     <DownOutlined style={{ color: '#BDC2C4' }} />
                   )}
-                  {isUpdateMode && (
-                    <CloseOutlined
-                      aria-label={$t('Dismiss AI Highlighter Banner')}
-                      style={{ color: '#BDC2C4', marginLeft: '8px' }}
-                      onClick={e => {
-                        e.stopPropagation();
-                        DismissablesService.actions.dismiss(EDismissable.HighlighterBanner);
-                      }}
-                    />
-                  )}
                 </div>
               </div>
               <div className={styles.headlineWrapper}>
@@ -382,6 +372,11 @@ export default function AiHighlighterToggle({
                   </>
                 )}
               </>
+            )}
+            {isUpdateMode && (
+              <div className={styles.dismissable}>
+                <a>{$t('Do not ask again')}</a>
+              </div>
             )}
           </div>
         </div>

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -2,9 +2,8 @@ import { SwitchInput } from 'components-react/shared/inputs/SwitchInput';
 import React, { useEffect, useState, memo } from 'react';
 import styles from './AiHighlighterToggle.m.less';
 import { Services } from 'components-react/service-provider';
-import * as remote from '@electron/remote';
 import { useDebounce, useVuex } from 'components-react/hooks';
-import { DownOutlined, UpOutlined } from '@ant-design/icons';
+import { DownOutlined, UpOutlined, CloseOutlined } from '@ant-design/icons';
 import { Alert, Button } from 'antd';
 import { getConfigByGame, isGameSupported } from 'services/highlighter/models/game-config.models';
 import { $t } from 'services/i18n';
@@ -15,10 +14,22 @@ import { EAvailableFeatures } from 'services/incremental-rollout';
 import { promptAction } from 'components-react/modals';
 import InputWrapper from 'components-react/shared/inputs/InputWrapper';
 import Translate from 'components-react/shared/Translate';
+import { EDismissable } from 'services/dismissables';
 
-export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded: boolean }) {
+export default function AiHighlighterToggle({
+  cardIsExpanded,
+  isUpdateMode,
+}: {
+  cardIsExpanded: boolean;
+  isUpdateMode?: boolean;
+}) {
   //TODO M: Probably good way to integrate the highlighter in to GoLiveSettings
-  const { HighlighterService, StreamingService, IncrementalRolloutService } = Services;
+  const {
+    HighlighterService,
+    StreamingService,
+    IncrementalRolloutService,
+    DismissablesService,
+  } = Services;
   const {
     useHighlighter,
     highlighterVersion,
@@ -26,6 +37,7 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
     isVerticalReplayBuffer,
     outputDisplay,
     gameName,
+    shouldShow,
   } = useVuex(() => {
     return {
       useHighlighter: HighlighterService.views.useAiHighlighter,
@@ -34,6 +46,7 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
       isVerticalReplayBuffer: StreamingService.views.isVerticalReplayBuffer,
       outputDisplay: StreamingService.views.outputDisplay,
       gameName: StreamingService.views.gameName,
+      shouldShow: DismissablesService.views.shouldShow(EDismissable.HighlighterBanner),
     };
   });
 
@@ -46,7 +59,7 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
   useEffect(() => {
     const supportedGame = isGameSupported(gameName);
     setGameIsSupported(!!supportedGame);
-    if (supportedGame) {
+    if (supportedGame && !isUpdateMode) {
       setIsExpanded(true);
       setGameConfig(getConfigByGame(supportedGame));
     } else {
@@ -83,18 +96,15 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
   }
 
   function getInitialExpandedState() {
-    if (gameIsSupported) {
-      return true;
-    } else {
-      if (useHighlighter) {
-        return true;
-      } else {
-        return cardIsExpanded;
-      }
-    }
+    if (isUpdateMode) return false;
+    if (gameIsSupported) return true;
+    if (useHighlighter) return true;
+    return cardIsExpanded;
   }
   const initialExpandedState = getInitialExpandedState();
   const [isExpanded, setIsExpanded] = useState(initialExpandedState);
+
+  const showHighlighterBanner = shouldShow || !isUpdateMode;
 
   const toggleHighlighter = useDebounce(300, handleToggleHighlighter);
 
@@ -160,7 +170,7 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
 
   return (
     <div>
-      {gameIsSupported ? (
+      {gameIsSupported && showHighlighterBanner ? (
         <div
           key={'aiSelector'}
           data-name="ai-highlighter-selector"
@@ -224,6 +234,14 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
                     <UpOutlined style={{ color: '#BDC2C4' }} />
                   ) : (
                     <DownOutlined style={{ color: '#BDC2C4' }} />
+                  )}
+                  {isUpdateMode && (
+                    <CloseOutlined
+                      style={{ color: '#BDC2C4', marginLeft: '8px' }}
+                      onClick={() =>
+                        DismissablesService.actions.dismiss(EDismissable.HighlighterBanner)
+                      }
+                    />
                   )}
                 </div>
               </div>

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -237,10 +237,12 @@ export default function AiHighlighterToggle({
                   )}
                   {isUpdateMode && (
                     <CloseOutlined
+                      aria-label={$t('Dismiss')}
                       style={{ color: '#BDC2C4', marginLeft: '8px' }}
-                      onClick={() =>
-                        DismissablesService.actions.dismiss(EDismissable.HighlighterBanner)
-                      }
+                      onClick={e => {
+                        e.stopPropagation();
+                        DismissablesService.actions.dismiss(EDismissable.HighlighterBanner);
+                      }}
                     />
                   )}
                 </div>

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -375,7 +375,13 @@ export default function AiHighlighterToggle({
             )}
             {isUpdateMode && (
               <div className={styles.dismissable}>
-                <a>{$t('Do not ask again')}</a>
+                <a
+                  onClick={() =>
+                    DismissablesService.actions.dismiss(EDismissable.HighlighterBanner)
+                  }
+                >
+                  {$t('Do not ask again')}
+                </a>
               </div>
             )}
           </div>

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -59,9 +59,9 @@ export default function AiHighlighterToggle({
   useEffect(() => {
     const supportedGame = isGameSupported(gameName);
     setGameIsSupported(!!supportedGame);
-    if (supportedGame && !isUpdateMode) {
-      setIsExpanded(true);
+    if (supportedGame) {
       setGameConfig(getConfigByGame(supportedGame));
+      if (!isUpdateMode) setIsExpanded(true);
     } else {
       setGameConfig(null);
     }

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -237,7 +237,7 @@ export default function AiHighlighterToggle({
                   )}
                   {isUpdateMode && (
                     <CloseOutlined
-                      aria-label={$t('Dismiss')}
+                      aria-label={$t('Dismiss AI Highlighter Banner')}
                       style={{ color: '#BDC2C4', marginLeft: '8px' }}
                       onClick={e => {
                         e.stopPropagation();

--- a/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
@@ -59,7 +59,9 @@ const TwitchRequiredFields = memo((p: IPlatformComponentParams<'twitch'>) => {
         <GameSelector key="twitch-game" platform="twitch" {...bind.game} layout="vertical" />
         <TwitchTagsInput label={$t('Twitch Tags')} {...bind.tags} layout="vertical" />
       </div>
-      {p.isAiHighlighterEnabled && <AiHighlighterToggle key="ai-toggle" cardIsExpanded={false} />}
+      {p.isAiHighlighterEnabled && (
+        <AiHighlighterToggle key="ai-toggle" cardIsExpanded={false} isUpdateMode={p.isUpdateMode} />
+      )}
     </>
   );
 });

--- a/app/i18n/en-US/highlighter.json
+++ b/app/i18n/en-US/highlighter.json
@@ -227,5 +227,6 @@
   "Vertical replay buffer is active. Would you like to stop the replay buffer to enable AI Highlighter?": "Vertical replay buffer is active. Would you like to stop the replay buffer to enable AI Highlighter?",
   "All Supported Games": "All Supported Games",
   "Deletion info": "Deletion info",
-  "At least one clip could not be deleted from your system. Please delete it manually.": "At least one clip could not be deleted from your system. Please delete it manually."
+  "At least one clip could not be deleted from your system. Please delete it manually.": "At least one clip could not be deleted from your system. Please delete it manually.",
+  "Dismiss AI Highlighter Banner": "Dismiss AI Highlighter Banner"
 }

--- a/app/i18n/en-US/highlighter.json
+++ b/app/i18n/en-US/highlighter.json
@@ -228,5 +228,5 @@
   "All Supported Games": "All Supported Games",
   "Deletion info": "Deletion info",
   "At least one clip could not be deleted from your system. Please delete it manually.": "At least one clip could not be deleted from your system. Please delete it manually.",
-  "Dismiss AI Highlighter Banner": "Dismiss AI Highlighter Banner"
+  "Do not ask again": "Do not ask again"
 }

--- a/app/services/dismissables.ts
+++ b/app/services/dismissables.ts
@@ -20,6 +20,7 @@ export enum EDismissable {
   TikTokReapply = 'tiktok_reapply',
   EnhancedBroadcasting = 'enhanced_broadcasting',
   StreamAvatarAutomationsWelcome = 'stream_avatar_automations_welcome',
+  HighlighterBanner = 'highlighter_banner',
 }
 
 interface IDismissablesServiceState {
@@ -60,9 +61,7 @@ export class DismissablesService extends PersistentStatefulService<IDismissables
   }
 
   dismissAll() {
-    Object.keys(EDismissable).forEach((key: keyof typeof EDismissable) =>
-      this.dismiss(EDismissable[key]),
-    );
+    Object.values(EDismissable).forEach((key: EDismissable) => this.dismiss(key));
   }
 
   /**


### PR DESCRIPTION
# Add dismissable to AI Highlighter toggle in Edit Stream window

## Issues

The banner only renders when `gameIsSupported` is true, and the `[gameName]` effect called `setIsExpanded(true)` unconditionally on that same path. Since `gameName` arrives asynchronously from Vuex, that effect re-fires after mount and overwrites whatever `getInitialExpandedState()` computed — so the `useHighlighter` / `cardIsExpanded` branches of that function were unreachable and the banner opened itself every time. Compounding it, `getInitialExpandedState()` short-circuited on `gameIsSupported` before ever reaching those branches.

In the Edit Stream window (update mode) the highlighter banner is dismissable.

## Fixes

- `AiHighlighterToggle` now takes an `isUpdateMode` prop. `getInitialExpandedState()` returns `false` first thing in update mode, and the `[gameName]` effect only auto-expands when `!isUpdateMode` — so the banner loads collapsed in the Edit Stream window and stays that way until the user opens it.
- Added dismissable only shown only in update mode, which dismisses `EDismissable.HighlighterBanner`.
- Render is gated on `shouldShow || !isUpdateMode`: dismissal is scoped to the Edit Stream window, so the banner still appears normally in the Go Live flow.
- Added `HighlighterBanner` to the `EDismissable` enum.
- `DismissablesService.dismissAll()` switched from `Object.keys` to `Object.values`. It was iterating enum *keys* (`HighlighterBanner`) and passing them where enum *values* (`highlighter_banner`) were expected, so `dismissAll` was writing garbage keys into persisted state and never actually dismissing anything.

<img width="300" height="250" alt="Screenshot 2026-08-26 185951" src="https://github.com/user-attachments/assets/d5cc3fcc-a037-4add-8d10-31888b39dbc6" />
<img width="300" height="250" alt="Screenshot 2026-08-26 185944" src="https://github.com/user-attachments/assets/5ab27bbd-5c47-4a95-8cb1-d67121b0f591" />
<img width="300" height="250" alt="Screenshot 2026-08-26 185936" src="https://github.com/user-attachments/assets/7459e38c-44e8-4da4-b74a-3d925be06ae1" />

**File(s) changed:** `app/components-react/windows/go-live/AiHighlighterToggle.tsx`, `app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx`, `app/services/dismissables.ts`

## Performance Implications

None. One additional Vuex-derived value in the existing `useVuex` selector, and one fewer state write on mount.