### PR TITLE
Fix onboarding test

### DIFF
--- a/test/regular/onboarding.ts
+++ b/test/regular/onboarding.ts
@@ -231,7 +231,6 @@ test('Go through onboarding', async t => {
       0,
       'Old user onboarded without theme has no sources',
     );
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Dual output not enabled');
   });
 
   t.pass();
@@ -258,7 +257,6 @@ test.skip('Go through onboarding and install theme', async t => {
 
     // Confirm switched to scene with default sources and dual output status
     await confirmDefaultSources(t);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -274,7 +272,6 @@ test('Go through onboarding as a new user', async t => {
     await finishOnboarding(installTheme);
     // Confirm sources and dual output status
     await confirmDefaultSources(t);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -291,7 +288,6 @@ test.skip('Go through onboarding as a new user and install theme', async t => {
     await finishOnboarding(installTheme);
     // Confirm sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.CheckOverlaySources);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -308,7 +304,6 @@ test('Login new user after onboarding skipped', async t => {
 
     // Confirm switched to scene with default sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.NoDefaultSources);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Dual output not enabled.');
   });
 
   t.pass();

--- a/test/regular/onboarding.ts
+++ b/test/regular/onboarding.ts
@@ -225,7 +225,7 @@ test('Go through onboarding', async t => {
 
     t.true(await isDisplayed('span=Sources'), 'Sources selector is visible');
 
-    // Confirm sources and dual output status
+    // Confirm sources
     t.is(
       await getNumElements('div[data-role=source]'),
       0,
@@ -244,7 +244,7 @@ test.skip('Go through onboarding and install theme', async t => {
   const newUser = true;
 
   await goThroughOnboarding(t, login, newUser, async () => {
-    // Confirm sources and dual output status
+    // Confirm sources
     t.not(await getNumElements('div[data-role=source]'), 0, 'Theme installed before login');
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled');
 
@@ -255,7 +255,7 @@ test.skip('Go through onboarding and install theme', async t => {
     await logIn(t, 'twitch', { prime: false }, false, false, true);
     await sleep(1000);
 
-    // Confirm switched to scene with default sources and dual output status
+    // Confirm switched to scene with default sources
     await confirmDefaultSources(t);
   });
 
@@ -270,7 +270,6 @@ test('Go through onboarding as a new user', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme);
-    // Confirm sources and dual output status
     await confirmDefaultSources(t);
   });
 
@@ -286,7 +285,6 @@ test.skip('Go through onboarding as a new user and install theme', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme);
-    // Confirm sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.CheckOverlaySources);
   });
 
@@ -301,8 +299,6 @@ test('Login new user after onboarding skipped', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme, HardwareConfigButtons.Skip);
-
-    // Confirm switched to scene with default sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.NoDefaultSources);
   });
 


### PR DESCRIPTION
Remove verification of `DualOutputToggle.tsx` elements that is not displayed on the `EOnboardingSteps.HardwareSetup` page

Now this command will pass:
```
yarn test:file test-dist/test/regular/onboarding.js
```