### PR TITLE
nav-menu: update to top-nav layout

### DIFF
--- a/app/components-react/nav-menu/FeaturesNav.m.less
+++ b/app/components-react/nav-menu/FeaturesNav.m.less
@@ -1,0 +1,38 @@
+@import '../../styles/index';
+@import '../../styles/mixins';
+@import '../../styles/badges';
+@import '../../styles/ultra';
+
+.features-nav {
+  .badge {
+    border-radius: 4px;
+    background-color: var(--button);
+    color: var(--paragraph);
+    padding: 2px 6px;
+    margin-left: 8px;
+  }
+
+  .ultra:not(.active) {
+    .ultra-text() !important;
+
+    i {
+      .ultra-text('warm') !important;
+    }
+  }
+
+  :global(.ant-menu-item) {
+    &.active {
+      color: var(--nav-active) !important;
+
+      svg {
+        fill: var(--nav-active) !important;
+      }
+    }
+
+    @media (max-width: 1200px) {
+      :global(.ant-menu-title-content) {
+        display: none;
+      }
+    }
+  }
+}

--- a/app/components-react/nav-menu/FeaturesNav.tsx
+++ b/app/components-react/nav-menu/FeaturesNav.tsx
@@ -1,5 +1,4 @@
 import * as remote from '@electron/remote';
-import { Menu } from 'antd';
 import cx from 'classnames';
 import { ClassValue } from 'classnames/types';
 import { useVuex } from 'components-react/hooks';
@@ -10,7 +9,7 @@ import throttle from 'lodash/throttle';
 import React, { memo, useCallback, useMemo } from 'react';
 import { ENavMenuKey, TExternalLinkType, TNavMenuItem } from 'services/nav-menu';
 import { TAppPage } from 'services/navigation';
-import styles from './NavMenu.m.less';
+import styles from './FeaturesNav.m.less';
 
 /** Types that open an external dashboard link rather than an in-app page */
 const DASHBOARD_LINK_TYPES = new Set([
@@ -21,7 +20,12 @@ const DASHBOARD_LINK_TYPES = new Set([
   'multistream',
 ]);
 
-export default memo(function FeaturesNav() {
+/**
+ * Returns a fragment of feature nav items to be rendered inside a parent
+ * <Menu mode="horizontal">. Called as a hook from NavMenu so that rc-menu's
+ * overflow measurement sees individual items rather than an opaque component.
+ */
+export function useFeaturesNav() {
   const {
     MagicLinkService,
     NavigationService,
@@ -31,7 +35,7 @@ export default memo(function FeaturesNav() {
     VisionService,
   } = Services;
 
-  const { isRunning: isVisionRunning } = useRealmObject(VisionService.state);
+  const { isEnabled: isVisionEnabled } = useRealmObject(VisionService.enabledState);
 
   const { setCurrentMenuItem, loggedOutMenuItemTargets, menuItems } = useVuex(() => ({
     setCurrentMenuItem: NavMenuService.actions.setCurrentMenuItem,
@@ -41,9 +45,9 @@ export default memo(function FeaturesNav() {
 
   const menuStyles = useMemo(
     (): Partial<Record<ENavMenuKey, ClassValue>> => ({
-      [ENavMenuKey.AI]: isVisionRunning && styles.ultra,
+      [ENavMenuKey.AI]: isVisionEnabled && styles.ultra,
     }),
-    [isVisionRunning],
+    [isVisionEnabled],
   );
 
   const navigate = useCallback(
@@ -83,7 +87,13 @@ export default memo(function FeaturesNav() {
   );
 
   const handleNavigation = useCallback((menuItem: TNavMenuItem, key?: ENavMenuKey) => {
+    if (menuItem.target === 'Ultra') {
+      UsageStatisticsService.actions.recordClick('NavMenu', 'ultra');
+      MagicLinkService.actions.linkToPrime('slobs-nav-menu');
+      return;
+    }
     if (menuItem.type && DASHBOARD_LINK_TYPES.has(menuItem.type)) {
+      if (!UserService.views.isLoggedIn) return;
       openDashboard(menuItem.type);
       return;
     }
@@ -96,14 +106,7 @@ export default memo(function FeaturesNav() {
   }, []);
 
   return (
-    <Menu
-      key="features-nav"
-      forceSubMenuRender
-      mode="inline"
-      className={cx(styles.topNav, styles.open)}
-      defaultSelectedKeys={[ENavMenuKey.Editor]}
-      getPopupContainer={(triggerNode: any) => triggerNode}
-    >
+    <>
       {menuItems.map(menuItem => (
         <FeaturesNavItem
           key={menuItem.key}
@@ -112,15 +115,15 @@ export default memo(function FeaturesNav() {
           handleNavigation={handleNavigation}
         />
       ))}
-    </Menu>
+    </>
   );
-});
+}
 
 const FeaturesNavItem = memo(
   (p: {
     menuItem: TNavMenuItem;
-    handleNavigation: (menuItem: TNavMenuItem, key?: ENavMenuKey) => void;
     className?: string;
+    handleNavigation: (menuItem: TNavMenuItem, key?: ENavMenuKey) => void;
   }) => {
     const { NavMenuService } = Services;
     const { menuItem, handleNavigation, className } = p;
@@ -129,12 +132,11 @@ const FeaturesNavItem = memo(
       currentMenuItem: NavMenuService.views.currentMenuItem,
     }));
 
-    const handleClick = useCallback(() => {
-      handleNavigation(menuItem);
-    }, [handleNavigation, menuItem]);
+    const handleClick = useCallback(() => handleNavigation(menuItem), [handleNavigation, menuItem]);
 
     return (
       <MenuItem
+        wrapperClassName={cx(styles.featuresNav)}
         className={cx(className, currentMenuItem === menuItem.key && styles.active)}
         title={menuItem.title}
         icon={menuItem?.icon ? <i className={menuItem?.icon} /> : undefined}
@@ -143,7 +145,7 @@ const FeaturesNavItem = memo(
         <div style={{ display: 'flex', alignItems: 'center' }}>
           {menuItem.title}
           {menuItem.badge && (
-            <div className={styles.betaTag}>
+            <div className={styles.badge}>
               <p style={{ margin: 0 }}>{menuItem.badge}</p>
             </div>
           )}

--- a/app/components-react/nav-menu/NavMenu.m.less
+++ b/app/components-react/nav-menu/NavMenu.m.less
@@ -3,268 +3,55 @@
 @import '../../styles/badges';
 @import '../../styles/ultra';
 
-.nav-menu-sider {
+.nav-menu {
   position: relative;
-  z-index: 990; // allows logout confirmation modal to show above resize bars
   width: 100%;
-  overflow: visible;
-  transition: width 300ms;
 
-  .app-menu-item {
-    padding-left: 40px !important;
+  // The unified Menu fills the bar; rc-menu renders its own flex container.
+  :global(.ant-menu-horizontal) {
+    width: 100%;
   }
 
-  :global(li.ant-menu-item),
-  :global(li.ant-menu-submenu) {
-    background: none;
-    color: var(--paragraph);
-    height: unset !important;
-    min-height: 30px !important;
-    min-width: 200px !important;
-    line-height: normal !important;
-    margin: 10px 0 !important;
-    overflow-wrap: break-word !important;
-    padding-bottom: 0px;
+  // Allow logout confirmation modal to show above resize bars
+  z-index: 990;
+  overflow: visible;
 
-    :active,
-    :link,
-    :focus,
-    :visited {
-      background: none;
+  .link-badge {
+    transform: scale(1.2, 1.2);
+    margin: auto;
+    display: block;
+    border: 1px solid var(--section-alt);
+    font-size: 8px;
+  }
+
+  // Fixed height (matching antd's own @menu-horizontal-line-height) so every
+  // item — icon-only, icon+label, or a raw control like the profile dropdown —
+  // sits at the same vertical position instead of sizing to its own content.
+  :global(.ant-menu-item) {
+    height: 46px;
+    padding: 0 16px !important;
+    background: none !important;
+    color: var(--paragraph) !important;
+    display: flex;
+    align-items: center;
+
+    &:global(.ant-menu-item-selected)::after {
+      display: none;
+    }
+
+    i:not(.link-badge) {
+      font-size: 14px;
     }
 
     svg {
       fill: var(--paragraph);
       width: 14px;
       height: 14px;
-    }
-  }
-
-  :global(li.ant-menu-item):not(.active):hover svg,
-  :global(li.ant-menu-submenu):not(.active):hover svg {
-    fill: var(--title) !important;
-  }
-
-  :global(li.ant-menu-item.ant-menu-item-selected),
-  :global(li.ant-menu-submenu.ant-menu-item-selected) {
-    background: none;
-
-    &::after {
-      display: none;
-    }
-  }
-}
-
-.nav-menu-scroll {
-  min-height: 100%;
-  height: 100%;
-  min-width: 50px;
-  padding-right: 0 !important;
-  display: flex;
-  flex-direction: column;
-
-  :global(.os-content) {
-    display: flex !important;
-    flex-direction: column !important;
-    height: 100% !important;
-  }
-}
-
-button.nav-menu-button {
-  height: 100%;
-  background-color: var(--sider);
-  border: 0;
-  border-left: 1px solid var(--border);
-  border-right: 1px solid var(--border);
-  border-radius: 0;
-  padding-right: 3px;
-  padding-left: 3px;
-  padding-bottom: 5px;
-
-  &:hover,
-  &:focus,
-  &:active {
-    background-color: var(--sider);
-    border: 0;
-    border-left: 1px solid var(--border);
-    border-right: 1px solid var(--border);
-  }
-
-  i {
-    color: var(--icon);
-    font-size: 12px;
-  }
-
-  &.left-dock {
-    border-left: 0;
-
-    @media (max-width: 1070px) {
-      border-left: 1px solid var(--border) !important;
-      border-right: 1px solid var(--border) !important;
-    }
-  }
-
-  &.sider-open {
-    border: 0;
-    border-left: 1px solid var(--border);
-    border-right: 1px solid var(--border);
-    padding-left: 2px;
-    padding-right: 3px;
-
-    &.left-dock {
-      border-left: 1px solid var(--border) !important;
-
-      @media (min-width: 1070px) {
-        border-right: 0 !important;
-      }
-    }
-  }
-
-  &.flipped {
-    transform: scaleX(-1);
-  }
-}
-
-.sider-closed {
-  width: 50px !important;
-  min-width: 50px !important;
-  max-width: 50px !important;
-}
-
-.top-nav {
-  flex: 1 1 auto;
-  border-right: 0px !important;
-
-  &.closed {
-    :global(.ant-menu-item-icon) {
-      i {
-        font-size: 18px;
-      }
+      margin-right: 10px;
     }
 
-    :global(.ant-menu-item:hover),
-    :global(.ant-menu-submenu:hover) {
-      i,
-      svg {
-        transition: all 0.2s ease-in-out !important;
-        transform: scale(1.2, 1.2) !important;
-      }
-    }
-
-    :global(i.ant-menu-submenu-arrow) {
-      display: none !important;
-    }
-
-    :global(div.ant-menu.ant-menu-sub.ant-menu-inline),
-    :global(span.ant-menu-title-content) {
-      visibility: hidden;
-      opacity: 0;
-    }
-
-    .app-icons {
-      min-width: unset;
-      border-radius: 50%;
-      width: 25px;
-      height: 25px;
-      transform: translate(-18%, 0%);
-      transition: width 0.15s ease-in-out, height 0.15s ease-in-out;
-
-      &:hover {
-        transition: transform 0.2s ease-in-out;
-        transform: scale(1.1, 1.1) translate(-15%, 0%);
-      }
-    }
-
-    :global(li.ant-menu-item),
-    :global(div.ant-menu-submenu-title) {
-      align-items: center;
-      display: flex;
-      overflow: visible;
+    &:hover:not(:active) svg {
+      fill: var(--title);
     }
   }
-
-  &.open {
-    :global(li.ant-menu-item),
-    :global(li.ant-menu-submenu) {
-      overflow: unset !important;
-      text-overflow: unset !important;
-      overflow-wrap: break-word !important;
-      padding-bottom: 0px;
-      white-space: normal !important;
-
-      svg {
-        margin-right: 10px;
-      }
-    }
-
-    .app-icons {
-      border-radius: 50%;
-      width: 17px;
-      height: 17px;
-    }
-
-    :global(div.ant-menu-submenu-title) {
-      padding-left: 16px !important;
-    }
-
-    :global(div.ant-menu.ant-menu-sub.ant-menu-inline),
-    :global(span.ant-menu-title-content) {
-      visibility: visible !important;
-      opacity: 1 !important;
-      overflow: visible;
-      transition: opacity 150ms ease-in 150ms;
-    }
-  }
-
-  :global(.ant-menu-submenu-vertical .ant-menu-submenu-popup) {
-    display: none !important;
-  }
-}
-
-.studio-mode {
-  color: var(--nav-active) !important;
-
-  i {
-    color: var(--nav-active) !important;
-  }
-}
-
-.active {
-  background-color: none;
-  border: none;
-  color: var(--nav-active) !important;
-
-  i {
-    color: var(--nav-active) !important;
-  }
-
-  svg {
-    fill: var(--nav-active) !important;
-  }
-}
-
-.ultra {
-  &:not(.active) {
-    .ultra-text() !important;
-
-    i {
-      .ultra-text('warm') !important;
-    }
-  }
-}
-
-.toggle-error {
-  padding: 0px !important;
-  text-align: unset !important;
-  :global(.ant-message-notice-content) {
-    padding: 4px 16px;
-  }
-}
-
-.beta-tag {
-  border-radius: 4px;
-  background-color: var(--button);
-  color: var(--paragraph);
-  padding: 2px 6px;
-  margin-left: 8px;
 }

--- a/app/components-react/nav-menu/NavMenu.tsx
+++ b/app/components-react/nav-menu/NavMenu.tsx
@@ -1,49 +1,31 @@
-import { Layout } from 'antd';
+import { Menu } from 'antd';
 import cx from 'classnames';
-import { useRealmObject } from 'components-react/hooks/realm';
-import { Services } from 'components-react/service-provider';
-import HelpTip from 'components-react/shared/HelpTip';
-import Scrollable from 'components-react/shared/Scrollable';
-import React, { memo } from 'react';
-import { EDismissable } from 'services/dismissables';
-import { $t } from 'services/i18n';
-import FeaturesNav from './FeaturesNav';
+import React from 'react';
+import { ENavMenuKey } from 'services/nav-menu';
+import { useFeaturesNav } from './FeaturesNav';
 import styles from './NavMenu.m.less';
-import NavTools from './NavTools';
-
-const { Sider } = Layout;
+import { useNavTools } from './NavTools';
 
 export default function NavMenu() {
-  const { CustomizationService } = Services;
-  const { leftDock } = useRealmObject(CustomizationService.state);
+  // Both hooks are inlined here (not rendered as component children) so that
+  // rc-menu's overflow measurement sees individual Menu.Item nodes rather than
+  // opaque component elements - antd 4.16 / rc-menu 9 only flattens arrays and
+  // fragments that are *direct* children of <Menu>.
+  const featureItems = useFeaturesNav();
+  const { items: toolItems, modals } = useNavTools();
 
   return (
-    <Layout hasSider className="nav-menu">
-      <Sider className={cx(styles.navMenuSider, !leftDock && styles.noLeftDock)}>
-        <Scrollable className={cx(styles.navMenuScroll)}>
-          <FeaturesNav />
-          <NavTools />
-        </Scrollable>
-        <LoginHelpTip />
-      </Sider>
-    </Layout>
+    <div className={cx(styles.navMenu)}>
+      <Menu
+        key="nav-menu"
+        mode="horizontal"
+        defaultSelectedKeys={[ENavMenuKey.Editor]}
+        getPopupContainer={triggerNode => triggerNode}
+      >
+        {featureItems}
+        {toolItems}
+      </Menu>
+      {modals}
+    </div>
   );
 }
-
-const LoginHelpTip = memo(function LoginHelpTip() {
-  return (
-    <HelpTip
-      title={$t('Login')}
-      dismissableKey={EDismissable.LoginPrompt}
-      position={{ top: 'calc(100vh - 175px)', left: '80px' }}
-      arrowPosition="bottom"
-      style={{ position: 'absolute' }}
-    >
-      <div>
-        {$t(
-          'Gain access to additional features by logging in with your preferred streaming platform.',
-        )}
-      </div>
-    </HelpTip>
-  );
-});

--- a/app/components-react/nav-menu/NavTools.tsx
+++ b/app/components-react/nav-menu/NavTools.tsx
@@ -15,7 +15,12 @@ import { Services } from '../service-provider';
 import styles from './NavTools.m.less';
 import PlatformIndicator from './PlatformIndicator';
 
-export default memo(function NavTools() {
+/**
+ * Returns nav tool items (fragment) and any modals that must live outside
+ * the <Menu> element. Called as a hook from NavMenu so that rc-menu's overflow
+ * measurement sees individual items rather than an opaque component.
+ */
+export function useNavTools() {
   const {
     UserService,
     SettingsService,
@@ -56,7 +61,7 @@ export default memo(function NavTools() {
   }
 
   async function openDashboard(page?: string) {
-    UsageStatisticsService.actions.recordClick('SideNav2', page || 'dashboard');
+    UsageStatisticsService.actions.recordClick('NavMenu', page || 'dashboard');
     if (dashboardOpening) return;
     setDashboardOpening(true);
 
@@ -83,12 +88,12 @@ export default memo(function NavTools() {
     : $t('Are you sure you want to log out?');
 
   function openHelp() {
-    UsageStatisticsService.actions.recordClick('SideNav2', 'help');
+    UsageStatisticsService.actions.recordClick('NavMenu', 'help');
     openSettingsWindow(ESettingsCategory.GetSupport);
   }
 
   async function upgradeToPrime() {
-    UsageStatisticsService.actions.recordClick('SideNav2', 'prime');
+    UsageStatisticsService.actions.recordClick('NavMenu', 'prime');
     MagicLinkService.linkToPrime('slobs-side-nav');
   }
 
@@ -107,7 +112,7 @@ export default memo(function NavTools() {
     setShowModal(status);
   };
 
-  return (
+  const items = (
     <>
       <Menu
         key="tools-nav"
@@ -193,7 +198,11 @@ export default memo(function NavTools() {
       />
     </>
   );
-});
+
+  const modals = <>{/* TODO @nav: Add relevant modals */}</>;
+
+  return { items, modals };
+}
 
 function NavToolsItem(p: {
   menuItem: TNavMenuItem;

--- a/app/components-react/root/StudioFooter.tsx
+++ b/app/components-react/root/StudioFooter.tsx
@@ -9,7 +9,6 @@ import styles from './StudioFooter.m.less';
 import PerformanceMetrics from '../shared/PerformanceMetrics';
 import TestWidgets from './TestWidgets';
 import StartStreamingButton from './StartStreamingButton';
-import NotificationsArea from './NotificationsArea';
 import { Tooltip } from 'antd';
 import { confirmAsync } from 'components-react/modals';
 import RecordingSwitcher from 'components-react/windows/go-live/RecordingSwitcher';
@@ -143,7 +142,6 @@ function StudioFooterComponent() {
           />
         </Tooltip>
         <PerformanceMetrics mode="limited" className="performance-metrics" />
-        <NotificationsArea />
       </div>
 
       <div className={styles.navRight}>

--- a/app/components-react/shared/MenuItem.m.less
+++ b/app/components-react/shared/MenuItem.m.less
@@ -1,28 +1,25 @@
 @import '../../styles/index';
 @import '../../styles/mixins';
 
-.menuitem-wrapper {
-  :global(span.ant-menu-title-content) {
-    overflow: visible;
-    text-overflow: unset;
-    white-space: normal;
-  }
+.menu-item {
+  &-wrapper {
+    display: flex;
+    align-items: center;
 
-  :global(div.ant-menu-submenu-title) {
-    height: unset;
-    line-height: unset;
-    min-height: 30px;
-  }
+    :global(span.ant-menu-title-content) {
+      overflow: visible;
+      text-overflow: unset;
+      white-space: normal;
+    }
 
-  .root-menu-item {
-    padding-left: 16px !important;
-  }
+    :global(div.ant-menu-submenu-title) {
+      height: unset;
+      line-height: unset;
+      min-height: 30px;
+    }
 
-  .app-nav-menu-item {
-    padding-left: 16px !important;
-    &:global(.ant-menu-item) {
-      min-height: unset !important;
-      height: 30px !important;
+    .root-menu-item {
+      padding-left: 16px !important;
     }
   }
 }

--- a/app/components-react/shared/MenuItem.tsx
+++ b/app/components-react/shared/MenuItem.tsx
@@ -5,27 +5,44 @@ import cx from 'classnames';
 
 interface IMenuProps extends MenuItemProps {
   title?: string;
+  /**
+   * Classes applied to the menu item li. Used to style the container for the
+   * item's contents.
+   *
+   * @note `className` lands on the inner Menu.Item instead, where layout rules
+   * like alignment never take effect. Instead, use `wrapperClassName` there.
+   */
   className?: string;
+  /**
+   * Classes applied to the wrapper div, which is the actual flex child of the
+   * surrounding `<Menu>`'s overflow container.
+   */
+  wrapperClassName?: string;
+  /**
+   * Styles applied to the menu item li. Used to style the container for the
+   * item's contents.
+   *
+   * @note `style` lands on the inner Menu.Item instead, where layout rules
+   * like alignment never take effect. Instead, use `wrapperStyle` there.
+   */
   style?: CSSProperties;
-  type?: 'item' | 'submenu' | 'app';
+  /**
+   * Styles applied to the wrapper div, which is the actual flex child of the
+   * surrounding `<Menu>`'s overflow container.
+   */
+  wrapperStyle?: CSSProperties;
 }
 
 export default function MenuItem(p: IMenuProps) {
-  const { title, style, type = 'item' } = p;
-
+  const { title, wrapperStyle, wrapperClassName, ...itemProps } = p;
   return (
     <>
-      <div title={title} className={styles.menuitemWrapper} style={style}>
-        <Menu.Item
-          {...p}
-          className={cx(
-            p?.className,
-            type === 'item' && styles.rootMenuItem,
-            type === 'submenu' && styles.submenuItem,
-            type === 'app' && styles.appNavMenuItem,
-          )}
-          title={false}
-        >
+      <div
+        title={title}
+        className={cx(styles.menuItemWrapper, wrapperClassName)}
+        style={wrapperStyle}
+      >
+        <Menu.Item {...itemProps} className={cx(p?.className)} title={false}>
           {p.children}
         </Menu.Item>
       </div>

--- a/app/components-react/windows/Main.tsx
+++ b/app/components-react/windows/Main.tsx
@@ -272,6 +272,8 @@ export default function Main() {
       onDrop={(ev: React.DragEvent) => onDropHandler(ev)}
     >
       <TitleBar windowId="main" className={cx({ [styles.titlebarError]: errorAlert })} />
+      {/* TODO @onboarding: Remove conditional check once new onboarding is live. */}
+      {page !== 'Onboarding' && !showLoadingSpinner && <NavMenu />}
       <div
         className={cx(styles.mainContents, {
           [styles.mainContentsRight]: renderDock && leftDock && hasLiveDock,
@@ -279,11 +281,6 @@ export default function Main() {
           [styles.mainContentsOnboarding]: page === 'Onboarding',
         })}
       >
-        {page !== 'Onboarding' && !showLoadingSpinner && (
-          <div className={styles.navMenuContainer}>
-            <NavMenu />
-          </div>
-        )}
         {renderDock && leftDock && (
           <LiveDockContainer
             max={maxDockWidth}


### PR DESCRIPTION
**Stack:** `master` <- [`../1`](https://github.com/streamlabs/desktop/pull/6134) <- [`../2`](https://github.com/streamlabs/desktop/pull/6135) <- **`feat/wr/nav/pr/3`** <- [`../4`](https://github.com/streamlabs/desktop/pull/6137) <- [`../5`](https://github.com/streamlabs/desktop/pull/6138)
*Can merge separate from children?* **No**
*See PR 5 for screenshots of final product.*
Figma: [link](https://www.figma.com/design/MUtozEwe7kjyjpP3ai8upE/Desktop-Iteration?node-id=141-4926&t=2CfGrBa2eOJxjDmm-1)

---

Replaces the vertical Layout/Sider sidebar with a horizontal Menu, converting FeaturesNav and NavTools into hooks so their items render as flat Menu.Item children.

- Convert `FeaturesNav` and `NavTools` from components into `useFeaturesNav`/`useNavTools` hooks, inlined directly in `NavMenu` so rc-menu's overflow measurement sees individual items
- Rework `MenuItem` to separate `wrapperClassName`/`wrapperStyle` (outer flex child) from `className`/`style` (inner `Menu.Item`)
- Drop the login help tip and the left-dock handling that no longer apply to a horizontal bar
- Remove `NotificationsArea` from `StudioFooter` ahead of moving it into the nav