### PR TITLE
Fix Kick game persistence.

### DIFF
--- a/app/components-react/windows/go-live/GameSelector.tsx
+++ b/app/components-react/windows/go-live/GameSelector.tsx
@@ -123,6 +123,15 @@ export default function GameSelector(p: TProps) {
       });
     }
 
+    if (isKick) {
+      // Kick's API requires the category id, but this component renders the name,
+      // so the service has to track both
+      Services.KickService.actions.setGameInfo({
+        gameId: game?.value ?? '',
+        gameName: game?.label ?? '',
+      });
+    }
+
     if (!game) return;
     setGames([game]);
   }

--- a/app/services/platforms/kick.ts
+++ b/app/services/platforms/kick.ts
@@ -84,6 +84,7 @@ interface IKickUpdateStreamResponse {
 interface IKickStartStreamSettings {
   title: string;
   game: string;
+  gameName?: string;
   video?: IVideo;
   mode?: TOutputOrientation;
 }
@@ -91,6 +92,7 @@ interface IKickStartStreamSettings {
 export interface IKickStartStreamOptions {
   title: string;
   game: string;
+  gameName?: string;
 }
 
 interface IKickRequestHeaders extends Dictionary<string> {
@@ -109,6 +111,7 @@ export class KickService
       title: '',
       mode: 'landscape',
       game: '',
+      gameName: '',
     },
     ingest: '',
     chatUrl: '',
@@ -422,12 +425,24 @@ export class KickService
    */
   async searchGames(searchString: string): Promise<IGame[]> {
     const host = this.hostsService.streamlabs;
-    const url = `https://${host}/api/v5/slobs/kick/info?category=${searchString}`;
+    const params = new URLSearchParams({ category: searchString });
+    const url = `https://${host}/api/v5/slobs/kick/info?${params.toString()}`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers });
 
     return jfetch<IKickStreamInfoResponse>(request)
       .then(async res => {
+        if (searchString === '') {
+          console.debug('Kick search string is empty.');
+          return [] as IGame[];
+        }
+
+        // To prevent errors when the response is not valid return an empty array
+        if (typeof res !== 'object' || res === null) {
+          console.error('Received a non-JSON response fetching Kick categories info.');
+          return [] as IGame[];
+        }
+
         const data = res as IKickStreamInfoResponse;
 
         if (data.categories && data.categories.length > 0) {
@@ -452,7 +467,16 @@ export class KickService
   }
 
   async fetchGame(name: string): Promise<IGame> {
+    // Don't attempt to search for an empty game name
+    // Note: on app start, there will not be a game selected yet
+    if (!name || name === '') return Promise.resolve({ id: '', name: '', image: '' } as IGame);
+
     return (await this.searchGames(name))[0];
+  }
+
+  setGameInfo({ gameId, gameName }: { gameId: string; gameName: string }) {
+    this.UPDATE_STREAM_SETTINGS({ game: gameId, gameName });
+    this.SET_GAME_NAME(gameName);
   }
 
   /**
@@ -593,5 +617,8 @@ export class KickService
   @mutation()
   SET_GAME_NAME(gameName: string) {
     this.state.gameName = gameName;
+    // also mirror into settings so it survives into savedSettings, which clones
+    // state.settings rather than reading the top-level state
+    this.state.settings = { ...this.state.settings, gameName };
   }
 }

--- a/app/services/platforms/kick.ts
+++ b/app/services/platforms/kick.ts
@@ -424,6 +424,11 @@ export class KickService
    * show live approval status.
    */
   async searchGames(searchString: string): Promise<IGame[]> {
+    if (!searchString || searchString === '') {
+      console.debug('Kick search string is empty.');
+      return [] as IGame[];
+    }
+
     const host = this.hostsService.streamlabs;
     const params = new URLSearchParams({ category: searchString });
     const url = `https://${host}/api/v5/slobs/kick/info?${params.toString()}`;
@@ -432,11 +437,6 @@ export class KickService
 
     return jfetch<IKickStreamInfoResponse>(request)
       .then(async res => {
-        if (searchString === '') {
-          console.debug('Kick search string is empty.');
-          return [] as IGame[];
-        }
-
         // To prevent errors when the response is not valid return an empty array
         if (typeof res !== 'object' || res === null) {
           console.error('Received a non-JSON response fetching Kick categories info.');

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -105,6 +105,7 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     return (
       (this.platforms.twitch?.enabled && this.platforms.twitch.game) ||
       (this.platforms.facebook?.enabled && this.platforms.facebook.game) ||
+      (this.platforms.kick?.enabled && this.platforms.kick.game) ||
       ''
     );
   }
@@ -113,6 +114,7 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     return (
       (this.platforms.twitch?.enabled && this.platforms.twitch.gameName) ||
       (this.platforms.facebook?.enabled && this.platforms.facebook.game) ||
+      (this.platforms.kick?.enabled && this.platforms.kick.gameName) ||
       ''
     );
   }


### PR DESCRIPTION
# Persist the Selected Kick Category Across the Go Live and Edit Stream Windows

## Issues

Selecting a Kick category did not persist. The field reverted to the previous category, or rendered a bare numeric id, and the choice was invisible to everything downstream of the form.

**The selection never reached service state.** `GameSelector` renders its value from the service but sends changes to the form, and nothing joined the two for Kick. `KickEditStreamInfo.tsx:37` binds the selector with `{...bind.game}`, supplying both `value` and `onChange`, but `GameSelector` never reads `p.value` — it computes its own from `platformService.state.settings.game` (line 27) and `Services.KickService.state.gameName` (line 43), then renders `<ListInput value={selectedGameId}>`. `onSelect` wrote back to the service for TikTok and Twitch (`TikTokService.actions.setGameName`, `TwitchService.actions.setGameInfo`) but had no Kick branch, so after a Kick selection the form held the new id while the service still held the old one, and the next render read the service and reverted.


## Fixes

Give `KickService` a write-back method and call it from the selector, mirroring the Twitch branch that already sits beside it. `setGameInfo({ gameId, gameName })` writes `UPDATE_STREAM_SETTINGS({ game: gameId, gameName })` and `SET_GAME_NAME(gameName)`, covering both the id the API needs and the name the component renders.

Move the name inside `settings` so the saved-settings path can see it. `gameName?: string` is added to `IKickStartStreamSettings` and `IKickStartStreamOptions`, seeded as `''` in `initialState`, and — critically — mirrored by the `SET_GAME_NAME` mutation itself rather than at each call site.

The top-level `state.gameName` is deliberately kept rather than replaced, because `GameSelector.tsx:43` still reads it.

`StreamInfoView.game` and `.gameName` gain Kick clauses, so the common-field getters resolve for a Kick-only stream instead of returning `''`.

`searchGames` builds its query with `URLSearchParams`, matching `putChannelInfo`, and guards the response with `typeof res !== 'object'` before casting — logging a distinct message so a diagnostic log separates "the API answered with no categories" from "we never reached the API". Both paths still resolve to `[]`, so callers are unaffected.

`fetchGame` returns an empty `IGame` for a falsy name instead of issuing a request.

**Files changed:** `app/services/platforms/kick.ts`, `app/components-react/windows/go-live/GameSelector.tsx`, `app/services/streaming/streaming-view.ts`

## Performance Implications

Net reduction. The `fetchGame` guard removes one HTTP request per app start, on the path that runs while the Go Live window is loading. Nothing new is requested. The costs are one optional string in Kick's settings object, one object spread per `SET_GAME_NAME` call, and two mutations on an explicit user selection — all negligible against the request they replace.