### PR TITLE
Fix HackerOne -3045235 by disabling the hyperlink

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -40,6 +40,52 @@ Function un.ModifyUnWelcome
   ${NSD_Check} $cleanupCheckbox
 FunctionEnd
 
+; H1-3045235: the installer runs elevated (nsis.perMachine = true -> RequestExecutionLevel
+; admin), and NSIS's license page turns URLs in the licence text -- e.g. the GPLv3 header's
+; <https://fsf.org/> -- into live hyperlinks. NSIS opens them with a plain ShellExecute, so the
+; browser inherits the installer's Administrator token. Kill the link instead of the URL: the
+; GPL text is not ours to edit ("changing it is not allowed").
+;
+; Installer pass only. electron-builder runs makensis twice, and on the BUILD_UNINSTALLER pass
+; assistedInstaller.nsh skips every installer page (it is all inside !ifndef BUILD_UNINSTALLER)
+; while still inserting MUI_UNPAGE_INSTFILES -- which would swallow the define below and fail
+; with "Call must be used with function names starting with un.".
+!ifndef BUILD_UNINSTALLER
+Function DisableLicenseLinks
+  Push $0
+  Push $1
+  Push $2
+  ; The licence RichEdit (id 1000) is on the inner dialog (class #32770), a child of
+  ; $HWNDPARENT -- GetDlgItem on $HWNDPARENT itself returns 0. Same lookup electron-builder
+  ; uses in its own LicenseShow (app-builder-lib/out/targets/nsis/nsisLicense.js).
+  FindWindow $0 "#32770" "" $HWNDPARENT
+  GetDlgItem $1 $0 1000
+  ${If} $1 <> 0
+    ; NSIS opens URLs in response to the EN_LINK notification. Clearing ENM_LINK
+    ; (0x04000000) from the event mask stops the control from ever sending it.
+    SendMessage $1 0x043B 0 0 $2              ; EM_GETEVENTMASK
+    IntOp $2 $2 & 0xFBFFFFFF
+    SendMessage $1 0x0445 0 $2                ; EM_SETEVENTMASK
+    SendMessage $1 0x045B 0 0                 ; EM_AUTOURLDETECT off
+    ; Strip CFE_LINK across the document so the text also stops *looking* clickable.
+    System::Call "*(i 0, i -1) i .r2"
+    SendMessage $1 0x0437 0 $2                ; EM_EXSETSEL: select all
+    System::Free $2
+    System::Alloc 116
+    Pop $2
+    System::Call "*$2(i 116, i 0x20, i 0)"    ; cbSize, dwMask = CFM_LINK, dwEffects = 0
+    SendMessage $1 0x0444 1 $2                ; EM_SETCHARFORMAT, SCF_SELECTION
+    System::Free $2
+    System::Call "*(i 0, i 0) i .r2"
+    SendMessage $1 0x0437 0 $2                ; restore caret to start
+    System::Free $2
+  ${EndIf}
+  Pop $2
+  Pop $1
+  Pop $0
+FunctionEnd
+!endif
+
 Function un.LeaveUnWelcome
   ${NSD_GetState} $cleanupCheckbox $0
   ${If} $0 <> 0
@@ -52,3 +98,12 @@ Function un.LeaveUnWelcome
     RMDir /r /REBOOTOK "C:\\ProgramData\\obs-studio-hook"
   ${EndIf}
 FunctionEnd
+
+; Must stay LAST in this file. electron-builder includes installer.nsh in the script header,
+; then inserts the licence page afterwards (assistedInstaller.nsh -> !insertmacro licensePage),
+; which is the first MUI page it inserts -- so this define is the one it picks up. Defining it
+; earlier does not work: MUI_UNPAGE_WELCOME above consumes MUI_PAGE_CUSTOMFUNCTION_SHOW.
+; Installer pass only -- see the note on DisableLicenseLinks above.
+!ifndef BUILD_UNINSTALLER
+  !define MUI_PAGE_CUSTOMFUNCTION_SHOW DisableLicenseLinks
+!endif

--- a/installer.nsh
+++ b/installer.nsh
@@ -55,7 +55,7 @@ Function DisableLicenseLinks
   Push $0
   Push $1
   Push $2
-  ; The licence RichEdit (id 1000) is on the inner dialog (class #32770), a child of
+  ; The license RichEdit (id 1000) is on the inner dialog (class #32770), a child of
   ; $HWNDPARENT -- GetDlgItem on $HWNDPARENT itself returns 0. Same lookup electron-builder
   ; uses in its own LicenseShow (app-builder-lib/out/targets/nsis/nsisLicense.js).
   FindWindow $0 "#32770" "" $HWNDPARENT


### PR DESCRIPTION
- fix https://app.asana.com/1/1083097041131/project/1209632301705219/task/1210265116004123

The installer runs elevated (nsis.perMachine = true -> RequestExecutionLevel
admin), and NSIS's license page turns URLs in the licence text into live
hyperlinks -- including the GPLv3 header's <https://fsf.org/>. NSIS opens them
with a plain ShellExecute, so the browser inherits the installer's Administrator
token.

Remove the link rather than the URL: the GPL text is not ours to edit
("changing it is not allowed").

DisableLicenseLinks now clears ENM_LINK from the RichEdit's event mask. That is
the actual kill switch -- NSIS opens URLs in response to the EN_LINK
notification, so a control that never sends it can never trigger the
ShellExecute. It also turns off EM_AUTOURLDETECT and strips CFE_LINK across the
document so the text stops looking clickable.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Below is image, user can no longer click on the URL:
<img width="749" height="582" alt="image" src="https://github.com/user-attachments/assets/6ce6e30c-73b2-4803-828f-8651df6a3ea6" />
