### PR TITLE
Allow click on disabled switcher card toggle.

### DIFF
--- a/app/components-react/windows/go-live/SwitcherCard.tsx
+++ b/app/components-react/windows/go-live/SwitcherCard.tsx
@@ -149,13 +149,11 @@ export const SwitcherCard = forwardRef<ISwitcherCardHandle, ISwitcherCardProps>(
 });
 
 function SwitcherCardContents(p: ISwitcherCardContentsProps) {
-  // Note on disabling the switch by adding the `ant-switch-disabled` class to it. This ensures that the switch
-  // will appear visually disabled and will not respond to user interactions, but is still clickable programmatically.
+  // Note on disabling the switch by adding the `ant-switch-disabled` class to it instead of the native `disabled` attribute.
   // This is to allow the `onClick` in the parent container to still be triggered even when the switch should be disabled.
-  // The `onClick` on the parent container normally would bubble to a descendent element, except for native form controls
-  // with the HTML `disabled` attribute. Using the `ant-switch-disabled` class allows the `pointer-events` CSS property
-  // to be set to `none` as well as the `cursor` property to be set to `not-allowed`, effectively mimicking the behavior
-  // of a disabled switch without actually using the HTML `disabled` attribute. Custom styles will not allow for both.
+  // Native form controls with the HTML `disabled` attribute never dispatch a `click` event, so the `click` event on a parent
+  // container does not bubble to the descendent element. Using the `ant-switch-disabled` class mimics the appearance
+  // of a disabled switch without actually using the HTML `disabled` attribute.
   return (
     <div
       className={cx(styles.platformSwitcher, { [styles.cardDisabled]: p.disabled }, p.className)}

--- a/app/components-react/windows/go-live/SwitcherCard.tsx
+++ b/app/components-react/windows/go-live/SwitcherCard.tsx
@@ -149,6 +149,9 @@ export const SwitcherCard = forwardRef<ISwitcherCardHandle, ISwitcherCardProps>(
 });
 
 function SwitcherCardContents(p: ISwitcherCardContentsProps) {
+  // Note on disabling the switch by adding the `ant-switch-disabled` class to it. This ensures that the switch
+  // will appear visually disabled and will not respond to user interactions, but is still clickable programmatically.
+  // This is to allow the onClick in the parent container to still be triggered even when the switch should be disabled.
   return (
     <div
       className={cx(styles.platformSwitcher, { [styles.cardDisabled]: p.disabled }, p.className)}
@@ -169,10 +172,9 @@ function SwitcherCardContents(p: ISwitcherCardContentsProps) {
               <SwitchInput
                 value={p.value}
                 name={p.name}
-                disabled={p.disabled}
+                className={cx({ 'ant-switch-disabled': p.disabled }, p.switchClassName)}
                 label={p.label ?? p.title}
                 nolabel
-                className={p.switchClassName}
                 skipWrapperAttrs={true}
               />
             </Tooltip>
@@ -180,10 +182,9 @@ function SwitcherCardContents(p: ISwitcherCardContentsProps) {
             <SwitchInput
               value={p.value}
               name={p.name}
-              disabled={p.disabled}
+              className={cx({ 'ant-switch-disabled': p.disabled }, p.switchClassName)}
               label={p.label ?? p.title}
               nolabel
-              className={p.switchClassName}
               skipWrapperAttrs={true}
             />
           )}

--- a/app/components-react/windows/go-live/SwitcherCard.tsx
+++ b/app/components-react/windows/go-live/SwitcherCard.tsx
@@ -151,7 +151,11 @@ export const SwitcherCard = forwardRef<ISwitcherCardHandle, ISwitcherCardProps>(
 function SwitcherCardContents(p: ISwitcherCardContentsProps) {
   // Note on disabling the switch by adding the `ant-switch-disabled` class to it. This ensures that the switch
   // will appear visually disabled and will not respond to user interactions, but is still clickable programmatically.
-  // This is to allow the onClick in the parent container to still be triggered even when the switch should be disabled.
+  // This is to allow the `onClick` in the parent container to still be triggered even when the switch should be disabled.
+  // The `onClick` on the parent container normally would bubble to a descendent element, except for native form controls
+  // with the HTML `disabled` attribute. Using the `ant-switch-disabled` class allows the `pointer-events` CSS property
+  // to be set to `none` as well as the `cursor` property to be set to `not-allowed`, effectively mimicking the behavior
+  // of a disabled switch without actually using the HTML `disabled` attribute. Custom styles will not allow for both.
   return (
     <div
       className={cx(styles.platformSwitcher, { [styles.cardDisabled]: p.disabled }, p.className)}


### PR DESCRIPTION
# Fire the SwitcherCard onClick Even When Its Toggle Is Disabled

## Issues

On the Live Output Editing and Stream Shift cards, a disabled switch should still fire the onClick.

<img width="500" height="455" alt="Screenshot 2026-08-28 131507" src="https://github.com/user-attachments/assets/24de860a-e292-476b-a77d-393914bc0c1f" />

A native `disabled` form control never dispatches a `click` event at all. `SwitcherCardContents` wraps the whole card in a single `onClick` handler specifically so any click anywhere on the card reaches the descendants, but a click landing exactly on the switch pill never reached it, because the browser suppressed the event before it could bubble. 

## Fixes

`SwitcherCardContents` no longer passes `disabled={p.disabled}` to the inner `SwitchInput`. Instead it adds the `ant-switch-disabled` class directly to the switch's `className` whenever `p.disabled` is true, which is the same class antd's own `disabled` prop would have applied (`cursor: not-allowed; opacity: 0.4`, per `antd/lib/switch/style/index.css`), so the toggle still looks disabled.

Removing the native `disabled` attribute means the underlying `<button>` is a normal, fully interactive element again, so a click on it fires and bubbles like any other click on the card, reaching the existing `onClick` on the wrapping div unchanged.

**File(s) changed:** `app/components-react/windows/go-live/SwitcherCard.tsx`

## Performance Implications

None.