### PR TITLE
Fix onboarding test

### DIFF
--- a/test/regular/onboarding.ts
+++ b/test/regular/onboarding.ts
@@ -246,7 +246,6 @@ test.skip('Go through onboarding and install theme', async t => {
   await goThroughOnboarding(t, login, newUser, async () => {
     // Confirm sources
     t.not(await getNumElements('div[data-role=source]'), 0, 'Theme installed before login');
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled');
 
     // login new user after onboarding
     await clickIfDisplayed('li[data-testid=nav-auth]');

--- a/test/regular/onboarding.ts
+++ b/test/regular/onboarding.ts
@@ -225,13 +225,12 @@ test('Go through onboarding', async t => {
 
     t.true(await isDisplayed('span=Sources'), 'Sources selector is visible');
 
-    // Confirm sources and dual output status
+    // Confirm sources
     t.is(
       await getNumElements('div[data-role=source]'),
       0,
       'Old user onboarded without theme has no sources',
     );
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Dual output not enabled');
   });
 
   t.pass();
@@ -245,7 +244,7 @@ test.skip('Go through onboarding and install theme', async t => {
   const newUser = true;
 
   await goThroughOnboarding(t, login, newUser, async () => {
-    // Confirm sources and dual output status
+    // Confirm sources
     t.not(await getNumElements('div[data-role=source]'), 0, 'Theme installed before login');
     t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled');
 
@@ -256,9 +255,8 @@ test.skip('Go through onboarding and install theme', async t => {
     await logIn(t, 'twitch', { prime: false }, false, false, true);
     await sleep(1000);
 
-    // Confirm switched to scene with default sources and dual output status
+    // Confirm switched to scene with default sources
     await confirmDefaultSources(t);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -272,9 +270,7 @@ test('Go through onboarding as a new user', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme);
-    // Confirm sources and dual output status
     await confirmDefaultSources(t);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -289,9 +285,7 @@ test.skip('Go through onboarding as a new user and install theme', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme);
-    // Confirm sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.CheckOverlaySources);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Single output enabled.');
   });
 
   t.pass();
@@ -305,10 +299,7 @@ test('Login new user after onboarding skipped', async t => {
 
   await goThroughOnboarding(t, login, newUser, async () => {
     await finishOnboarding(installTheme, HardwareConfigButtons.Skip);
-
-    // Confirm switched to scene with default sources and dual output status
     await confirmDefaultSources(t, DefaultSourcesCheck.NoDefaultSources);
-    t.true(await isDisplayed('i[data-testid=dual-output-inactive]'), 'Dual output not enabled.');
   });
 
   t.pass();


### PR DESCRIPTION
Reposting PR since the bundle was reverted: https://github.com/streamlabs/desktop/pull/6132
Remove verification of `DualOutputToggle.tsx` elements that is not displayed on the `EOnboardingSteps.HardwareSetup` page

Now this command will pass:
```
yarn test:file test-dist/test/regular/onboarding.js
```