### PR TITLE
fix: point stream-labs references at the streamlabs org

### DIFF
--- a/docs/how_to_update_fork.md
+++ b/docs/how_to_update_fork.md
@@ -4,7 +4,7 @@
 ## Prepare electron source 
 Get source and update it with commands
 ```
-git clone https://github.com/stream-labs/electron.git
+git clone https://github.com/streamlabs/electron.git
 cd electron 
 git checkout sl_2-0-x
 git remote add upstream https://github.com/electron/electron.git
@@ -35,7 +35,7 @@ Last command print in log paths to tar.gz zip and sha256 files what need to be u
 Do not commit changes in electron.gyp and package.json if you do not want manualy merge next time. 
 
 ## Upload files to github 
-* Go to `https://github.com/stream-labs/electron/releases`
+* Go to `https://github.com/streamlabs/electron/releases`
 * Create new release with save version as set in `package.json` - `2.0.16-streamlabs`
 * upload tgz package file 
 * upload relese zip file 


### PR DESCRIPTION
## What

Points the `stream-labs` GitHub references in `docs/how_to_update_fork.md` at the `streamlabs` org.

## Why

Streamlabs renamed its GitHub organization from `stream-labs` to `streamlabs`. GitHub keeps 301 redirects from the old namespace, but only until somebody claims that namespace and creates a repository with a matching name. At that point the redirect stops resolving and the URL points at their repository instead.

**The `stream-labs` namespace is no longer under our control.** It is currently held by an organization created on 2026-08-23 that has no public repositories, which is the only reason the redirects still resolve today.

Tracked as HackerOne #3065731 (Critical).

## Impact

`docs/how_to_update_fork.md` instructs developers to `git clone https://github.com/stream-labs/electron.git` — our **custom Electron fork**, which is the runtime Streamlabs Desktop is built on. A developer following our own documentation after the redirect breaks would build Desktop on an Electron fork from a repository we do not control.

## Not changed

The Azure DevOps build badge in `README.md` contains the string `stream-labs.streamlabs-obs`. That is an Azure DevOps build-definition identifier, not a GitHub path, so it is deliberately left alone.

## Also worth knowing

Local checkouts of this repo commonly still have `origin` set to `git@github.com:stream-labs/desktop.git`. Worth running:

```
git remote -v
git remote set-url origin git@github.com:streamlabs/desktop.git
```
