### PR TITLE
Fix deasync notarization issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "cross-env": "7.0.3",
     "css-element-queries": "1.2.3",
     "css-loader": "2.1.1",
+    "deasync": "0.1.31",
     "dotenv": "8.2.0",
     "electron": "43.2.0",
     "electron-builder": "26.15.7",
@@ -254,7 +255,6 @@
     "zustand": "^4.4.1"
   },
   "optionalDependencies": {
-    "deasync": "0.1.31",
     "node-gyp": "12.2.0",
     "node-win32-np": "1.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15318,8 +15318,6 @@ __metadata:
     webpack-merge: 5.2.0
     zustand: ^4.4.1
   dependenciesMeta:
-    deasync:
-      optional: true
     node-gyp:
       optional: true
     node-win32-np:


### PR DESCRIPTION
* Move 'deasync' to devDependencies so it no longer fails notarization step blocking the mac-release. Apple's notarization is rejecting prebuilt deasync binaries compiled against an SDK older than 10.9. Deasync is only used by tests on macOS and electron-builder excludes devDependencies from the app bundle
* I think this issue may have been triggered by the recent electron-builder upgrade? It now packs deasync into the app bundle