### PR TITLE
Fix dual output source z order

### DIFF
--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -29,6 +29,7 @@ import { NotificationsService, ENotificationType } from 'services/notifications'
 import { $t } from 'services/i18n';
 import { JsonrpcService } from 'services/api/jsonrpc';
 import { CustomizationService, CustomizationState } from 'services/customization';
+import { orderNodesByDisplay } from './node-order';
 
 interface IDisplayVideoSettings {
   horizontal: IVideoInfo;
@@ -538,15 +539,12 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     // the reordering of the nodes below is replicated from the copy nodes command
     const scene = this.scenesService.views.getScene(sceneId);
     const selection = new Selection(scene.id, scene.getNodes());
-    const verticalNodes = [] as TSceneNode[];
-
     const initialNodeOrder = scene.getNodesIds();
     const nodeIdsMap: Dictionary<string> = {};
 
     selection.getNodes().forEach(node => {
       const verticalNode = this.createPartnerNode(node);
       nodeIdsMap[node.id] = verticalNode.id;
-      verticalNodes.push(verticalNode);
     });
 
     // recreate parent/child relationships
@@ -563,8 +561,10 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
       this.sceneNodeHandled.next();
     });
 
-    const order = compact(scene.getNodesIds().map(origNodeId => nodeIdsMap[origNodeId]));
-    scene.setNodesOrder(order.concat(initialNodeOrder));
+    // Reparenting inserts every child immediately after its new parent, which can
+    // reverse sibling order. Rebuild both display blocks from the original order.
+    const verticalNodeOrder = compact(initialNodeOrder.map(nodeId => nodeIdsMap[nodeId]));
+    scene.setNodesOrder(initialNodeOrder.concat(verticalNodeOrder));
   }
 
   /**
@@ -838,19 +838,11 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
 
       if (!copiedSceneItem) return null;
 
-      // Dual output scenes should be ordered so that all of the vertical nodes are
-      // after all of the horizontal nodes. So place the vertical node at the correct position.
-      const selection = scene.getSelection(copiedSceneItem.id);
+      // Keep both display blocks in a consistent order while preserving the
+      // new item's top-most position within each display.
+      orderNodesByDisplay(scene);
 
-      const numHorizontalNodes = this.scenesService.views.activeScene.nodes.filter(
-        n => n.display === 'horizontal',
-      ).length;
-
-      // place the vertical node after the last horizontal node
-      selection.freeze();
-      selection.placeAfter(scene.getNodesIds()[numHorizontalNodes]);
-
-      this.sceneCollectionsService.createNodeMapEntry(sceneId, sceneItem.id, copiedSceneItem.id);
+      this.sceneCollectionsService.createNodeMapEntry(scene.id, sceneItem.id, copiedSceneItem.id);
       return copiedSceneItem;
     }
   }

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -29,7 +29,7 @@ import { NotificationsService, ENotificationType } from 'services/notifications'
 import { $t } from 'services/i18n';
 import { JsonrpcService } from 'services/api/jsonrpc';
 import { CustomizationService, CustomizationState } from 'services/customization';
-import { orderNodesByDisplay } from './node-order';
+import { getValidatedDualOutputNodeOrder, orderNodesByDisplay } from './node-order';
 
 interface IDisplayVideoSettings {
   horizontal: IVideoInfo;
@@ -729,6 +729,23 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     horizontalNodeIds.forEach((horizontalId: string) => {
       this.sceneCollectionsService.removeNodeMapEntry(sceneId, horizontalId);
     });
+
+    const scene = this.scenesService.views.getScene(sceneId)!;
+    // Validation and stale-entry cleanup can replace the per-scene map object,
+    // so fetch it once more before repairing an order loaded from disk.
+    const refreshedNodeMap = this.views.sceneNodeMaps[sceneId];
+    const validatedOrder = getValidatedDualOutputNodeOrder(scene, refreshedNodeMap);
+    if ('reason' in validatedOrder) {
+      console.warn(
+        `Skipping dual output node-order repair for scene ${sceneId}: ${validatedOrder.reason}`,
+      );
+    } else {
+      const currentOrder = scene.getNodesIds();
+      if (validatedOrder.nodeIds.some((nodeId, index) => nodeId !== currentOrder[index])) {
+        scene.setNodesOrder(validatedOrder.nodeIds);
+        console.info(`Repaired dual output node order for scene ${sceneId}`);
+      }
+    }
 
     this.SET_IS_LOADING(false);
   }

--- a/app/services/dual-output/node-order.ts
+++ b/app/services/dual-output/node-order.ts
@@ -76,55 +76,40 @@ export function getValidatedDualOutputNodeOrder(
   }
 
   const horizontalNodes = nodes.filter(node => node.display === 'horizontal');
-  const horizontalNodeIds = new Set(horizontalNodes.map(node => node.id));
-  const ancestorsByNodeId = new Map<string, Set<string>>();
+  // A valid flattened folder tree is a depth-first preorder. Each folder is
+  // pushed and popped at most once, keeping hierarchy validation linear.
+  const openFolderIds: string[] = [];
 
   for (const node of horizontalNodes) {
-    const ancestors = new Set<string>();
-    let parentId = node.parentId;
+    const parentId = node.parentId || '';
 
-    while (parentId) {
-      if (ancestors.has(parentId) || parentId === node.id) {
-        return { isValid: false, reason: 'the horizontal folder hierarchy contains a cycle' };
-      }
-
+    if (parentId) {
       const parent = nodesById.get(parentId);
-      if (!parent || !horizontalNodeIds.has(parentId) || !parent.isFolder()) {
+      if (!parent || parent.display !== 'horizontal' || !parent.isFolder()) {
         return { isValid: false, reason: 'a horizontal node has an invalid parent' };
       }
 
-      ancestors.add(parentId);
-      parentId = parent.parentId;
+      while (openFolderIds.length && openFolderIds.at(-1) !== parentId) {
+        openFolderIds.pop();
+      }
+
+      if (!openFolderIds.length) {
+        return {
+          isValid: false,
+          reason: 'the horizontal folder hierarchy is not depth-first and contiguous',
+        };
+      }
+    } else {
+      openFolderIds.length = 0;
     }
 
-    ancestorsByNodeId.set(node.id, ancestors);
-
     const verticalNode = nodesById.get(nodeMap[node.id])!;
-    const expectedVerticalParentId = node.parentId ? nodeMap[node.parentId] : '';
+    const expectedVerticalParentId = parentId ? nodeMap[parentId] : '';
     if ((verticalNode.parentId || '') !== (expectedVerticalParentId || '')) {
       return { isValid: false, reason: 'mapped nodes do not have mirrored parents' };
     }
-  }
 
-  for (let folderIndex = 0; folderIndex < horizontalNodes.length; folderIndex++) {
-    const folder = horizontalNodes[folderIndex];
-    if (!folder.isFolder()) continue;
-
-    const descendantIndices = horizontalNodes.reduce((indices, node, nodeIndex) => {
-      if (ancestorsByNodeId.get(node.id)!.has(folder.id)) indices.push(nodeIndex);
-      return indices;
-    }, [] as number[]);
-
-    if (
-      descendantIndices.some((nodeIndex, descendantIndex) => {
-        return nodeIndex !== folderIndex + descendantIndex + 1;
-      })
-    ) {
-      return {
-        isValid: false,
-        reason: 'the horizontal folder hierarchy is not depth-first and contiguous',
-      };
-    }
+    if (node.isFolder()) openFolderIds.push(node.id);
   }
 
   const horizontalOrder = horizontalNodes.map(node => node.id);

--- a/app/services/dual-output/node-order.ts
+++ b/app/services/dual-output/node-order.ts
@@ -1,0 +1,16 @@
+import type { Scene } from 'services/scenes';
+
+/**
+ * Group dual-output nodes by display without changing either display's z-order.
+ * Scene nodes are stored from top to bottom, so the filters below are stable.
+ */
+export function orderNodesByDisplay(scene: Scene) {
+  const nodes = scene.getNodes();
+  const horizontalNodeIds = nodes.filter(node => node.display !== 'vertical').map(node => node.id);
+  const verticalNodeIds = nodes.filter(node => node.display === 'vertical').map(node => node.id);
+  const orderedNodeIds = horizontalNodeIds.concat(verticalNodeIds);
+
+  if (orderedNodeIds.every((nodeId, index) => nodeId === nodes[index].id)) return;
+
+  scene.setNodesOrder(orderedNodeIds);
+}

--- a/app/services/dual-output/node-order.ts
+++ b/app/services/dual-output/node-order.ts
@@ -1,4 +1,8 @@
-import type { Scene } from 'services/scenes';
+import type { Scene, TSceneNode } from 'services/scenes';
+
+export type TValidatedNodeOrder =
+  | { isValid: true; nodeIds: string[] }
+  | { isValid: false; reason: string };
 
 /**
  * Group dual-output nodes by display without changing either display's z-order.
@@ -13,4 +17,119 @@ export function orderNodesByDisplay(scene: Scene) {
   if (orderedNodeIds.every((nodeId, index) => nodeId === nodes[index].id)) return;
 
   scene.setNodesOrder(orderedNodeIds);
+}
+
+/**
+ * Build the canonical order for a persisted dual-output scene.
+ *
+ * Horizontal nodes are the authored order shown in the source selector. The
+ * vertical order is derived from that order through the node map rather than
+ * preserving a potentially corrupted persisted vertical order.
+ */
+export function getValidatedDualOutputNodeOrder(
+  scene: Scene,
+  nodeMap?: Dictionary<string>,
+): TValidatedNodeOrder {
+  if (!nodeMap) return { isValid: false, reason: 'the scene has no node map' };
+
+  const nodes = scene.getNodes();
+  const nodesById = new Map<string, TSceneNode>();
+
+  nodes.forEach(node => nodesById.set(node.id, node));
+  if (nodesById.size !== nodes.length) {
+    return { isValid: false, reason: 'the scene contains duplicate node ids' };
+  }
+
+  const pairs = Object.entries(nodeMap);
+  const pairedNodeIds = new Set<string>();
+
+  for (const [horizontalNodeId, verticalNodeId] of pairs) {
+    if (pairedNodeIds.has(horizontalNodeId) || pairedNodeIds.has(verticalNodeId)) {
+      return { isValid: false, reason: 'the node map is not one-to-one' };
+    }
+
+    const horizontalNode = nodesById.get(horizontalNodeId);
+    const verticalNode = nodesById.get(verticalNodeId);
+    if (!horizontalNode || !verticalNode) {
+      return { isValid: false, reason: 'the node map references a missing scene node' };
+    }
+    if (horizontalNode.display !== 'horizontal' || verticalNode.display !== 'vertical') {
+      return { isValid: false, reason: 'a mapped node has the wrong display' };
+    }
+    if (horizontalNode.sceneNodeType !== verticalNode.sceneNodeType) {
+      return { isValid: false, reason: 'mapped nodes have different node types' };
+    }
+    if (
+      horizontalNode.isItem() &&
+      verticalNode.isItem() &&
+      horizontalNode.sourceId !== verticalNode.sourceId
+    ) {
+      return { isValid: false, reason: 'mapped items reference different sources' };
+    }
+
+    pairedNodeIds.add(horizontalNodeId);
+    pairedNodeIds.add(verticalNodeId);
+  }
+
+  if (pairedNodeIds.size !== nodes.length) {
+    return { isValid: false, reason: 'the node map does not cover every scene node' };
+  }
+
+  const horizontalNodes = nodes.filter(node => node.display === 'horizontal');
+  const horizontalNodeIds = new Set(horizontalNodes.map(node => node.id));
+  const ancestorsByNodeId = new Map<string, Set<string>>();
+
+  for (const node of horizontalNodes) {
+    const ancestors = new Set<string>();
+    let parentId = node.parentId;
+
+    while (parentId) {
+      if (ancestors.has(parentId) || parentId === node.id) {
+        return { isValid: false, reason: 'the horizontal folder hierarchy contains a cycle' };
+      }
+
+      const parent = nodesById.get(parentId);
+      if (!parent || !horizontalNodeIds.has(parentId) || !parent.isFolder()) {
+        return { isValid: false, reason: 'a horizontal node has an invalid parent' };
+      }
+
+      ancestors.add(parentId);
+      parentId = parent.parentId;
+    }
+
+    ancestorsByNodeId.set(node.id, ancestors);
+
+    const verticalNode = nodesById.get(nodeMap[node.id])!;
+    const expectedVerticalParentId = node.parentId ? nodeMap[node.parentId] : '';
+    if ((verticalNode.parentId || '') !== (expectedVerticalParentId || '')) {
+      return { isValid: false, reason: 'mapped nodes do not have mirrored parents' };
+    }
+  }
+
+  for (let folderIndex = 0; folderIndex < horizontalNodes.length; folderIndex++) {
+    const folder = horizontalNodes[folderIndex];
+    if (!folder.isFolder()) continue;
+
+    const descendantIndices = horizontalNodes.reduce((indices, node, nodeIndex) => {
+      if (ancestorsByNodeId.get(node.id)!.has(folder.id)) indices.push(nodeIndex);
+      return indices;
+    }, [] as number[]);
+
+    if (
+      descendantIndices.some((nodeIndex, descendantIndex) => {
+        return nodeIndex !== folderIndex + descendantIndex + 1;
+      })
+    ) {
+      return {
+        isValid: false,
+        reason: 'the horizontal folder hierarchy is not depth-first and contiguous',
+      };
+    }
+  }
+
+  const horizontalOrder = horizontalNodes.map(node => node.id);
+  return {
+    isValid: true,
+    nodeIds: horizontalOrder.concat(horizontalOrder.map(nodeId => nodeMap[nodeId])),
+  };
 }

--- a/app/services/dual-output/node-order.ts
+++ b/app/services/dual-output/node-order.ts
@@ -5,8 +5,9 @@ export type TValidatedNodeOrder =
   | { isValid: false; reason: string };
 
 /**
- * Group dual-output nodes by display without changing either display's z-order.
- * Scene nodes are stored from top to bottom, so the filters below are stable.
+ * Restore the canonical dual-output storage layout: every horizontal node
+ * precedes every vertical node. The stable partition preserves each display's
+ * top-to-bottom z-order.
  */
 export function orderNodesByDisplay(scene: Scene) {
   const nodes = scene.getNodes();

--- a/app/services/editor-commands/commands/copy-nodes.ts
+++ b/app/services/editor-commands/commands/copy-nodes.ts
@@ -9,6 +9,7 @@ import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
 import { EditorService } from 'services/editor';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { cloneDeep } from 'lodash';
+import { orderNodesByDisplay } from 'services/dual-output/node-order';
 
 /**
  * Copies nodes
@@ -230,6 +231,7 @@ export class CopyNodesCommand extends Command {
           }),
       );
       scene.setNodesOrder(order.concat(initialNodeOrder));
+      orderNodesByDisplay(scene);
     } else {
       const order = compact(
         this.selection

--- a/app/services/editor-commands/commands/create-folder.ts
+++ b/app/services/editor-commands/commands/create-folder.ts
@@ -7,6 +7,7 @@ import { $t } from 'services/i18n';
 import { DualOutputService } from 'services/dual-output';
 import { SceneCollectionsService } from 'services/scene-collections';
 import partition from 'lodash/partition';
+import { orderNodesByDisplay } from 'services/dual-output/node-order';
 
 /**
  * Creates a folder
@@ -69,13 +70,7 @@ export class CreateFolderCommand extends Command {
         this.verticalFolderId,
       );
 
-      // place vertical folder correctly in node list
-      const numHorizontalNodes = scene
-        .getModel()
-        .nodes.filter(node => node.display === 'horizontal').length;
-      const verticalFolderSelection = scene.getSelection(this.verticalFolderId);
-      verticalFolderSelection.freeze();
-      verticalFolderSelection.placeAfter(scene.getNodesIds()[numHorizontalNodes]);
+      orderNodesByDisplay(scene);
     }
 
     if (this.items) {

--- a/app/services/editor-commands/commands/create-folder.ts
+++ b/app/services/editor-commands/commands/create-folder.ts
@@ -1,7 +1,7 @@
 import { Command } from './command';
 import { Selection } from 'services/selection';
 import { Inject } from 'services/core/injector';
-import { ScenesService } from 'services/scenes';
+import { Scene, ScenesService, TSceneNode } from 'services/scenes';
 import { ReorderNodesCommand, EPlaceType } from './reorder-nodes';
 import { $t } from 'services/i18n';
 import { DualOutputService } from 'services/dual-output';
@@ -17,7 +17,7 @@ import { orderNodesByDisplay } from 'services/dual-output/node-order';
  * For dual output scenes, it's more complicated because the vertical nodes
  * also need to be moved into a matching folder.
  *  1. create a folder for the horizontal display
- *  2. map over the selection (of horizontal nodes) to locate all the matching vertical nodes
+ *  2. map over the selection to locate all matching opposite-display nodes
  *  3. create a folder for the dual output nodes
  *  4. move the horizontal node selection into the horizontal folder
  *  5. move the vertical node selection into the vertical folder
@@ -47,15 +47,76 @@ export class CreateFolderCommand extends Command {
     return $t('Create %{folderName}', { folderName: this.name });
   }
 
+  /**
+   * Expand a one-display selection to complete dual-output node pairs.
+   *
+   * Source-selector selections only contain nodes from the visible display
+   * when one canvas is hidden. Resolve their partners here so every caller of
+   * this command preserves the mirrored folder hierarchy.
+   */
+  private getPairedNodes(scene: Scene): TSceneNode[] {
+    const selectedNodes = this.items.getNodes();
+    if (!selectedNodes.length) return selectedNodes;
+
+    const nodeMap = this.dualOutputService.views.sceneNodeMaps[this.sceneId];
+    if (!nodeMap) {
+      throw new Error(`Cannot group dual output nodes in scene ${this.sceneId}: missing node map`);
+    }
+
+    const horizontalNodeIds = new Set(Object.keys(nodeMap));
+    const horizontalIdsByVerticalId = new Map<string, string>();
+    Object.entries(nodeMap).forEach(([horizontalNodeId, verticalNodeId]) => {
+      if (horizontalNodeIds.has(verticalNodeId) || horizontalIdsByVerticalId.has(verticalNodeId)) {
+        throw new Error(
+          `Cannot group dual output nodes in scene ${this.sceneId}: ambiguous node map`,
+        );
+      }
+      horizontalIdsByVerticalId.set(verticalNodeId, horizontalNodeId);
+    });
+
+    const pairedNodeIds = new Set<string>();
+    selectedNodes.forEach(node => {
+      let partnerNodeId: string | undefined;
+      let expectedPartnerDisplay: 'horizontal' | 'vertical' | undefined;
+      if (node.display === 'horizontal') {
+        partnerNodeId = nodeMap[node.id];
+        expectedPartnerDisplay = 'vertical';
+      } else if (node.display === 'vertical') {
+        partnerNodeId = horizontalIdsByVerticalId.get(node.id);
+        expectedPartnerDisplay = 'horizontal';
+      }
+      const partnerNode = partnerNodeId ? scene.getNode(partnerNodeId) : null;
+
+      if (
+        !partnerNode ||
+        partnerNode.display !== expectedPartnerDisplay ||
+        partnerNode.sceneNodeType !== node.sceneNodeType ||
+        (node.isItem() && (!partnerNode.isItem() || partnerNode.sourceId !== node.sourceId))
+      ) {
+        throw new Error(
+          `Cannot group dual output node ${node.id} in scene ${this.sceneId}: invalid partner`,
+        );
+      }
+
+      pairedNodeIds.add(node.id);
+      pairedNodeIds.add(partnerNode.id);
+    });
+
+    return scene.getNodes().filter(node => pairedNodeIds.has(node.id));
+  }
+
   execute() {
     const scene = this.scenesService.views.getScene(this.sceneId);
+    const createVerticalFolder = this.dualOutputService.views.hasSceneNodeMaps;
+    const nodesToGroup =
+      this.items && createVerticalFolder ? this.getPairedNodes(scene) : this.items?.getNodes();
     const folder = scene.createFolder(this.name, { id: this.folderId, display: 'horizontal' });
     this.folderId = folder.id;
 
     // Handle vertical folder for dual output scene collections
     // Note: Check the existence of all scene node maps because the scene may not have a
     // node map created for it
-    if (this.dualOutputService.views.hasSceneNodeMaps) {
+    if (createVerticalFolder) {
       // create vertical folder
       const verticalFolder = scene.createFolder(this.name, {
         id: this.verticalFolderId,
@@ -76,8 +137,8 @@ export class CreateFolderCommand extends Command {
     if (this.items) {
       // if the scene has dual output nodes filter the nodes by display
       // and move them into their respective folders
-      if (this.verticalFolderId) {
-        const selection = partition(this.items.getNodes(), n => n.display === 'vertical');
+      if (createVerticalFolder) {
+        const selection = partition(nodesToGroup, n => n.display === 'vertical');
         const verticalSelection = scene.getSelection(selection[0]);
         const horizontalSelection = scene.getSelection(selection[1]);
         verticalSelection.freeze();

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -13,6 +13,7 @@ import { $t } from 'services/i18n';
 import namingHelpers from 'util/NamingHelpers';
 import uuid from 'uuid/v4';
 import { DualOutputService } from 'services/dual-output';
+import { orderNodesByDisplay } from 'services/dual-output/node-order';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { TDisplayType } from 'services/settings-v2/video';
 import { InitAfter, ViewHandler } from 'services/core';
@@ -553,6 +554,7 @@ export class ScenesService extends StatefulService<IScenesState> {
 
     if (this.dualOutputService.views.hasSceneNodeMaps) {
       this.dualOutputService.createPartnerNode(sceneItem);
+      orderNodesByDisplay(scene);
       /* For some reason dragging items after enabling dual output makes them
        * duplicate, associate selection on switch to mitigate this issue
        */

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -3,10 +3,39 @@ import { getApiClient } from '../../helpers/api-client';
 import { test, useWebdriver, TExecutionContext } from '../../helpers/webdriver';
 import { ScenesService, Scene, SceneItem } from 'services/scenes';
 import { VideoSettingsService } from 'services/settings-v2/video';
+import { EditorCommandsService } from 'services/editor-commands';
+import { SceneCollectionsService } from 'services/scene-collections';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
+
+function confirmNodeOrder(
+  t: TExecutionContext,
+  scene: Scene,
+  horizontalNames: string[],
+  verticalNames: string[],
+) {
+  const nodes = scene.getNodes();
+
+  t.deepEqual(
+    nodes.map(node => `${node.display}:${node.name}`),
+    horizontalNames
+      .map(name => `horizontal:${name}`)
+      .concat(verticalNames.map(name => `vertical:${name}`)),
+    'Scene nodes are grouped by display and preserve each display z-order',
+  );
+}
+
+function confirmHistoryDepth(
+  t: TExecutionContext,
+  editorCommandsService: EditorCommandsService,
+  undoDepth: number,
+  redoDepth: number,
+) {
+  t.is(editorCommandsService.state.undoMetadata.length, undoDepth, 'Undo history depth is correct');
+  t.is(editorCommandsService.state.redoMetadata.length, redoDepth, 'Redo history depth is correct');
+}
 
 function confirmDualOutputSources(t: TExecutionContext, scene: Scene) {
   const numSceneItems = scene
@@ -59,6 +88,12 @@ test('Convert single output collection to dual output', async (t: TExecutionCont
   scene.createAndAddSource('Item1', 'color_source');
   scene.createAndAddSource('Item2', 'color_source');
   scene.createAndAddSource('Item3', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const folderItem1 = scene.createAndAddSource('Folder Item1', 'color_source');
+  folderItem1.setParent(folder.id);
+  const folderItem2 = scene.createAndAddSource('Folder Item2', 'color_source');
+  folderItem2.setParent(folder.id);
+  const singleOutputOrder = scene.getNodes().map(node => node.name);
 
   // single output
   const horizontalContext = videoSettingsService.contexts.horizontal;
@@ -83,6 +118,16 @@ test('Convert single output collection to dual output', async (t: TExecutionCont
   // confirm dual output collection length is double the single output collection length
   const dualOutputLength = sceneItems.length;
   t.is(singleOutputLength * 2, dualOutputLength);
+
+  confirmNodeOrder(t, scene, singleOutputOrder, singleOutputOrder);
+  t.deepEqual(
+    scene
+      .getFolder(nodeMap[folder.id])
+      .getNodes()
+      .map(node => node.name),
+    folder.getNodes().map(node => node.name),
+    'Nested sibling z-order is preserved in the vertical folder',
+  );
 
   // confirm that converting the single output collection to a dual output collection did not add sources
   confirmDualOutputSources(t, scene);
@@ -119,4 +164,194 @@ test('Convert single output collection to dual output', async (t: TExecutionCont
       );
     }
   });
+});
+
+test('New source is top-most in both displays for an inactive scene', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const editorCommandsService = client.getResource<EditorCommandsService>('EditorCommandsService');
+
+  const targetScene = scenesService.createScene('Target Scene');
+  targetScene.createAndAddSource('Item1', 'color_source');
+  targetScene.createAndAddSource('Item2', 'color_source');
+  targetScene.createAndAddSource('Item3', 'color_source');
+
+  // Use a different active scene with a different node count. The old implementation
+  // incorrectly used the active scene to place a partner created in the target scene.
+  const activeScene = scenesService.createScene('Active Scene');
+  activeScene.createAndAddSource('Other Item', 'color_source');
+  activeScene.createAndAddSource('Other Item 2', 'color_source');
+  activeScene.makeActive();
+
+  // A collection retains its node maps while Dual Output is disabled. Creating a
+  // source in that state still creates both nodes before the vertical canvas is shown.
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  editorCommandsService.executeCommand(
+    'CreateNewItemCommand',
+    targetScene.id,
+    'Newest Item',
+    'color_source',
+    {},
+    { sourceAddOptions: {} },
+  );
+  confirmHistoryDepth(t, editorCommandsService, 1, 0);
+
+  const expectedOrder = ['Newest Item', 'Item3', 'Item2', 'Item1'];
+  confirmNodeOrder(t, targetScene, expectedOrder, expectedOrder);
+
+  // Enabling Dual Output must not change which item is top-most.
+  dualOutputService.toggleDualOutputMode(true);
+  confirmNodeOrder(t, targetScene, expectedOrder, expectedOrder);
+
+  const createdNodeIds = targetScene
+    .getNodes()
+    .filter(node => node.name === 'Newest Item')
+    .map(node => node.id);
+  t.is(createdNodeIds.length, 2);
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[targetScene.id][createdNodeIds[0]],
+    createdNodeIds[1],
+    'The new horizontal and vertical items are paired in the node map',
+  );
+
+  // One undo/redo must remove and restore the complete horizontal/vertical pair.
+  editorCommandsService.undo();
+  confirmHistoryDepth(t, editorCommandsService, 0, 1);
+  confirmNodeOrder(t, targetScene, ['Item3', 'Item2', 'Item1'], ['Item3', 'Item2', 'Item1']);
+  t.false(
+    Object.prototype.hasOwnProperty.call(
+      sceneCollectionsService.sceneNodeMaps[targetScene.id],
+      createdNodeIds[0],
+    ),
+    'Undo removes the item pair from the node map',
+  );
+
+  editorCommandsService.redo();
+  confirmHistoryDepth(t, editorCommandsService, 1, 0);
+  confirmNodeOrder(t, targetScene, expectedOrder, expectedOrder);
+  t.deepEqual(
+    targetScene
+      .getNodes()
+      .filter(node => node.name === 'Newest Item')
+      .map(node => node.id),
+    createdNodeIds,
+    'Redo reuses both scene node ids',
+  );
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[targetScene.id][createdNodeIds[0]],
+    createdNodeIds[1],
+    'Redo restores the item pair in the node map',
+  );
+});
+
+test('Paired folder grouping remains atomic and ordered', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const editorCommandsService = client.getResource<EditorCommandsService>('EditorCommandsService');
+  const scene = scenesService.createScene('Folder Scene');
+  scene.createAndAddSource('Item1', 'color_source');
+  scene.createAndAddSource('Item2', 'color_source');
+  scene.createAndAddSource('Item3', 'color_source');
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const selectedNodeIds = scene
+    .getNodes()
+    .filter(node => node.name === 'Item3')
+    .map(node => node.id);
+  const selection = scene.getSelection(selectedNodeIds);
+  const serializedSelection = {
+    _type: 'HELPER',
+    resourceId: (selection as any).resourceId,
+  } as any;
+
+  editorCommandsService.executeCommand(
+    'CreateFolderCommand',
+    scene.id,
+    'Newest Folder',
+    serializedSelection,
+  );
+  confirmHistoryDepth(t, editorCommandsService, 1, 0);
+
+  const folders = scene.getFolders().filter(folder => folder.name === 'Newest Folder');
+  t.is(folders.length, 2);
+  const horizontalFolder = folders.find(folder => folder.display === 'horizontal');
+  const verticalFolder = folders.find(folder => folder.display === 'vertical');
+  t.truthy(horizontalFolder);
+  t.truthy(verticalFolder);
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[scene.id][horizontalFolder.id],
+    verticalFolder.id,
+    'Horizontal and vertical folders are paired in the node map',
+  );
+  t.deepEqual(
+    horizontalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['horizontal:Item3'],
+  );
+  t.deepEqual(
+    verticalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['vertical:Item3'],
+  );
+  confirmNodeOrder(
+    t,
+    scene,
+    ['Newest Folder', 'Item3', 'Item2', 'Item1'],
+    ['Newest Folder', 'Item3', 'Item2', 'Item1'],
+  );
+
+  const folderIds = [horizontalFolder.id, verticalFolder.id];
+
+  // This deliberately uses one undo and one redo: the paired folder and both
+  // display-specific grouping operations belong to one editor command.
+  editorCommandsService.undo();
+  confirmHistoryDepth(t, editorCommandsService, 0, 1);
+  t.is(scene.getFolders().filter(folder => folder.name === 'Newest Folder').length, 0);
+  confirmNodeOrder(t, scene, ['Item3', 'Item2', 'Item1'], ['Item3', 'Item2', 'Item1']);
+  t.false(
+    Object.prototype.hasOwnProperty.call(
+      sceneCollectionsService.sceneNodeMaps[scene.id],
+      horizontalFolder.id,
+    ),
+    'Undo removes the folder pair from the node map',
+  );
+
+  editorCommandsService.redo();
+  confirmHistoryDepth(t, editorCommandsService, 1, 0);
+  t.deepEqual(
+    scene
+      .getFolders()
+      .filter(folder => folder.name === 'Newest Folder')
+      .map(folder => folder.id),
+    folderIds,
+    'Redo reuses both folder ids',
+  );
+  const restoredHorizontalFolder = scene.getFolder(horizontalFolder.id);
+  const restoredVerticalFolder = scene.getFolder(verticalFolder.id);
+  t.deepEqual(
+    restoredHorizontalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['horizontal:Item3'],
+  );
+  t.deepEqual(
+    restoredVerticalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['vertical:Item3'],
+  );
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[scene.id][horizontalFolder.id],
+    verticalFolder.id,
+    'Redo restores the folder pair in the node map',
+  );
+  confirmNodeOrder(
+    t,
+    scene,
+    ['Newest Folder', 'Item3', 'Item2', 'Item1'],
+    ['Newest Folder', 'Item3', 'Item2', 'Item1'],
+  );
 });

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -432,7 +432,10 @@ test('New source is top-most in both displays for an inactive scene', async t =>
   );
 });
 
-test('Paired folder grouping remains atomic and ordered', async t => {
+async function confirmSingleDisplayFolderGrouping(
+  t: TExecutionContext,
+  selectedDisplay: 'horizontal' | 'vertical',
+) {
   const client = await getApiClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');
   const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
@@ -440,16 +443,21 @@ test('Paired folder grouping remains atomic and ordered', async t => {
     'SceneCollectionsService',
   );
   const editorCommandsService = client.getResource<EditorCommandsService>('EditorCommandsService');
-  const scene = scenesService.createScene('Folder Scene');
-  scene.createAndAddSource('Item1', 'color_source');
-  scene.createAndAddSource('Item2', 'color_source');
-  scene.createAndAddSource('Item3', 'color_source');
+  const collectionId = sceneCollectionsService.activeCollection.id;
+  const scene = scenesService.createScene(`${selectedDisplay} Folder Scene`);
+  const item1 = scene.createAndAddSource('Item1', 'color_source');
+  const item2 = scene.createAndAddSource('Item2', 'color_source');
+  const item3 = scene.createAndAddSource('Item3', 'color_source');
   dualOutputService.convertSingleOutputToDualOutputCollection();
+  dualOutputService.toggleDualOutputMode(true);
+  dualOutputService.toggleDisplay(selectedDisplay === 'horizontal', 'horizontal');
+  dualOutputService.toggleDisplay(selectedDisplay === 'vertical', 'vertical');
 
   const selectedNodeIds = scene
-    .getNodes()
-    .filter(node => node.name === 'Item3')
+    .getSourceSelectorNodes()
+    .filter(node => node.name === 'Item3' || node.name === 'Item2')
     .map(node => node.id);
+  t.is(selectedNodeIds.length, 2, `Selection contains only ${selectedDisplay} nodes`);
   const selection = scene.getSelection(selectedNodeIds);
   const serializedSelection = {
     _type: 'HELPER',
@@ -477,12 +485,21 @@ test('Paired folder grouping remains atomic and ordered', async t => {
   );
   t.deepEqual(
     horizontalFolder.getNodes().map(node => `${node.display}:${node.name}`),
-    ['horizontal:Item3'],
+    ['horizontal:Item3', 'horizontal:Item2'],
   );
   t.deepEqual(
     verticalFolder.getNodes().map(node => `${node.display}:${node.name}`),
-    ['vertical:Item3'],
+    ['vertical:Item3', 'vertical:Item2'],
   );
+  [item3, item2].forEach(item => {
+    t.is(scene.getNode(item.id).parentId, horizontalFolder.id);
+    t.is(
+      scene.getNode(sceneCollectionsService.sceneNodeMaps[scene.id][item.id]).parentId,
+      verticalFolder.id,
+    );
+  });
+  t.is(scene.getNode(item1.id).parentId, '');
+  t.is(scene.getNode(sceneCollectionsService.sceneNodeMaps[scene.id][item1.id]).parentId, '');
   confirmNodeOrder(
     t,
     scene,
@@ -520,11 +537,11 @@ test('Paired folder grouping remains atomic and ordered', async t => {
   const restoredVerticalFolder = scene.getFolder(verticalFolder.id);
   t.deepEqual(
     restoredHorizontalFolder.getNodes().map(node => `${node.display}:${node.name}`),
-    ['horizontal:Item3'],
+    ['horizontal:Item3', 'horizontal:Item2'],
   );
   t.deepEqual(
     restoredVerticalFolder.getNodes().map(node => `${node.display}:${node.name}`),
-    ['vertical:Item3'],
+    ['vertical:Item3', 'vertical:Item2'],
   );
   t.is(
     sceneCollectionsService.sceneNodeMaps[scene.id][horizontalFolder.id],
@@ -537,4 +554,44 @@ test('Paired folder grouping remains atomic and ordered', async t => {
     ['Newest Folder', 'Item3', 'Item2', 'Item1'],
     ['Newest Folder', 'Item3', 'Item2', 'Item1'],
   );
+
+  // A valid mirrored hierarchy allows collection-load validation to repair
+  // persisted vertical sibling order.
+  const restoredNodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  scene.getNode(restoredNodeMap[item3.id]).placeAfter(restoredNodeMap[item2.id]);
+  t.deepEqual(
+    restoredVerticalFolder.getNodes().map(node => node.name),
+    ['Item2', 'Item3'],
+    'Vertical sibling order is deliberately corrupted before reload',
+  );
+
+  dualOutputService.toggleDualOutputMode(false);
+  await sceneCollectionsService.create({ name: `${selectedDisplay} Folder Other Collection` });
+  await sceneCollectionsService.load(collectionId);
+
+  const reloadedScene = (scenesService as any).getScene(scene.id) as Scene;
+  const reloadedNodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const reloadedHorizontalFolder = reloadedScene.getFolder(horizontalFolder.id);
+  const reloadedVerticalFolder = reloadedScene.getFolder(verticalFolder.id);
+  t.deepEqual(
+    reloadedHorizontalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['horizontal:Item3', 'horizontal:Item2'],
+  );
+  t.deepEqual(
+    reloadedVerticalFolder.getNodes().map(node => `${node.display}:${node.name}`),
+    ['vertical:Item3', 'vertical:Item2'],
+    'Collection load accepts the mirrored hierarchy and repairs vertical sibling order',
+  );
+  [item3, item2].forEach(item => {
+    t.is(reloadedScene.getNode(item.id).parentId, reloadedHorizontalFolder.id);
+    t.is(reloadedScene.getNode(reloadedNodeMap[item.id]).parentId, reloadedVerticalFolder.id);
+  });
+}
+
+test('Horizontal-only folder grouping remains mirrored, atomic, and ordered', async t => {
+  await confirmSingleDisplayFolderGrouping(t, 'horizontal');
+});
+
+test('Vertical-only folder grouping remains mirrored, atomic, and ordered', async t => {
+  await confirmSingleDisplayFolderGrouping(t, 'vertical');
 });

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -349,6 +349,95 @@ test('Collection load does not normalize an unmirrored folder hierarchy', async 
   );
 });
 
+test('Dual output validation does not normalize a non-contiguous folder hierarchy', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const scene = scenesService.createScene('Non-contiguous Folder Scene');
+  const rootItem = scene.createAndAddSource('Root Item', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const folderItem1 = scene.createAndAddSource('Folder Item1', 'color_source');
+  folderItem1.setParent(folder.id);
+  const folderItem2 = scene.createAndAddSource('Folder Item2', 'color_source');
+  folderItem2.setParent(folder.id);
+
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const nodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const horizontalNodeIds = [folder.id, folderItem1.id, rootItem.id, folderItem2.id];
+  const verticalNodeIds = [folder.id, folderItem1.id, folderItem2.id, rootItem.id].map(
+    nodeId => nodeMap[nodeId],
+  );
+
+  // Root Item closes Folder's subtree before Folder Item2 tries to re-enter it.
+  // Keep the mapped parents valid so the preorder check is the only reason to
+  // reject normalization.
+  scene.setNodesOrder(horizontalNodeIds.concat(verticalNodeIds));
+  const unsafeOrder = scene.getNodes().map(node => node.id);
+
+  dualOutputService.validateDualOutputCollection();
+
+  t.deepEqual(
+    scene.getNodes().map(node => node.id),
+    unsafeOrder,
+    'Validation leaves z-order untouched when a closed folder subtree is reopened',
+  );
+  t.is(
+    scene.getNode(folderItem2.id).parentId,
+    folder.id,
+    'Validation does not mutate the malformed horizontal hierarchy',
+  );
+  t.is(
+    scene.getNode(nodeMap[folderItem2.id]).parentId,
+    nodeMap[folder.id],
+    'The rejected hierarchy still has mirrored vertical parents',
+  );
+});
+
+test('Dual output validation does not normalize a child-before-parent hierarchy', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const scene = scenesService.createScene('Child Before Parent Scene');
+  const rootItem = scene.createAndAddSource('Root Item', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const folderItem = scene.createAndAddSource('Folder Item', 'color_source');
+  folderItem.setParent(folder.id);
+
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const nodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const horizontalNodeIds = [folderItem.id, folder.id, rootItem.id];
+  const verticalNodeIds = [folder.id, folderItem.id, rootItem.id].map(nodeId => nodeMap[nodeId]);
+
+  scene.setNodesOrder(horizontalNodeIds.concat(verticalNodeIds));
+  const unsafeOrder = scene.getNodes().map(node => node.id);
+
+  dualOutputService.validateDualOutputCollection();
+
+  t.deepEqual(
+    scene.getNodes().map(node => node.id),
+    unsafeOrder,
+    'Validation leaves z-order untouched when a child precedes its parent folder',
+  );
+  t.is(
+    scene.getNode(folderItem.id).parentId,
+    folder.id,
+    'Validation does not mutate the child-before-parent hierarchy',
+  );
+  t.is(
+    scene.getNode(nodeMap[folderItem.id]).parentId,
+    nodeMap[folder.id],
+    'The rejected hierarchy still has mirrored vertical parents',
+  );
+});
+
 test('New source is top-most in both displays for an inactive scene', async t => {
   const client = await getApiClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -166,6 +166,189 @@ test('Convert single output collection to dual output', async (t: TExecutionCont
   });
 });
 
+test('Collection load repairs persisted vertical z-order', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const collectionId = sceneCollectionsService.activeCollection.id;
+  const scene = scenesService.createScene('Load Repair Scene');
+  const item1 = scene.createAndAddSource('Item1', 'color_source');
+  scene.createAndAddSource('Item2', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const nestedFolder = scene.createFolder('Nested Folder');
+  nestedFolder.setParent(folder.id);
+  const folderItem1 = scene.createAndAddSource('Folder Item1', 'color_source');
+  folderItem1.setParent(nestedFolder.id);
+  const folderItem2 = scene.createAndAddSource('Folder Item2', 'color_source');
+  folderItem2.setParent(nestedFolder.id);
+  const item3 = scene.createAndAddSource('Item3', 'color_source');
+
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const nodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const expectedNodeMap = { ...nodeMap };
+  const expectedOrder = [
+    'Item3',
+    'Folder',
+    'Nested Folder',
+    'Folder Item2',
+    'Folder Item1',
+    'Item2',
+    'Item1',
+  ];
+
+  // Recreate the persisted shape produced by the old insertion code: the
+  // horizontal item is top-most, while its vertical partner is at the bottom.
+  scene.getNode(nodeMap[item3.id]).placeAfter(nodeMap[item1.id]);
+  scene.getNode(nodeMap[folderItem2.id]).placeAfter(nodeMap[folderItem1.id]);
+  confirmNodeOrder(t, scene, expectedOrder, [
+    'Folder',
+    'Nested Folder',
+    'Folder Item1',
+    'Folder Item2',
+    'Item2',
+    'Item1',
+    'Item3',
+  ]);
+
+  // Switching away persists the bad order. Loading the collection exercises
+  // the normal validateDualOutputCollection path rather than calling the
+  // validator directly from the test.
+  const otherCollection = await sceneCollectionsService.create({
+    name: 'Load Repair Other Collection',
+  });
+  await sceneCollectionsService.load(collectionId);
+
+  const restoredScene = (scenesService as any).getScene(scene.id) as Scene;
+  confirmNodeOrder(t, restoredScene, expectedOrder, expectedOrder);
+
+  const restoredNodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  t.deepEqual(
+    restoredNodeMap,
+    expectedNodeMap,
+    'Collection load repairs only order and preserves every existing node pair',
+  );
+  const restoredVerticalFolder = restoredScene.getFolder(restoredNodeMap[nestedFolder.id]);
+  t.is(
+    restoredVerticalFolder.parentId,
+    restoredNodeMap[folder.id],
+    'Collection load preserves the mirrored nested-folder relationship',
+  );
+  t.deepEqual(
+    restoredVerticalFolder.getNodes().map(node => node.name),
+    ['Folder Item2', 'Folder Item1'],
+    'Collection load restores nested vertical sibling z-order from the horizontal folder',
+  );
+
+  // Switching away saves the repaired order. A second load verifies that the
+  // repair is durable and idempotent through the normal persistence path.
+  await sceneCollectionsService.load(otherCollection.id);
+  await sceneCollectionsService.load(collectionId);
+  const reloadedScene = (scenesService as any).getScene(scene.id) as Scene;
+  confirmNodeOrder(t, reloadedScene, expectedOrder, expectedOrder);
+});
+
+test('Collection load does not normalize order with a malformed node map', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const collectionId = sceneCollectionsService.activeCollection.id;
+  const scene = scenesService.createScene('Malformed Map Scene');
+  const item1 = scene.createAndAddSource('Item1', 'color_source');
+  const item2 = scene.createAndAddSource('Item2', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const folderItem = scene.createAndAddSource('Folder Item', 'color_source');
+  folderItem.setParent(folder.id);
+
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const nodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const verticalFolderId = nodeMap[folder.id];
+  const verticalFolderItemId = nodeMap[folderItem.id];
+
+  // Keep the map complete and bijective, but swap a folder and item partner.
+  // Existing collection validation intentionally leaves these present nodes in
+  // place; z-order normalization must decline to infer an order from this map.
+  sceneCollectionsService.createNodeMapEntry(scene.id, folder.id, verticalFolderItemId);
+  sceneCollectionsService.createNodeMapEntry(scene.id, folderItem.id, verticalFolderId);
+
+  scene.getNode(nodeMap[item2.id]).placeAfter(nodeMap[item1.id]);
+  const malformedOrder = scene.getNodes().map(node => node.id);
+
+  await sceneCollectionsService.create({ name: 'Malformed Map Other Collection' });
+  await sceneCollectionsService.load(collectionId);
+
+  const restoredScene = (scenesService as any).getScene(scene.id) as Scene;
+  t.deepEqual(
+    restoredScene.getNodes().map(node => node.id),
+    malformedOrder,
+    'Load leaves z-order untouched when pair types make the node map unsafe to normalize',
+  );
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[scene.id][folder.id],
+    verticalFolderItemId,
+    'Existing validation semantics leave the malformed folder mapping intact',
+  );
+  t.is(
+    sceneCollectionsService.sceneNodeMaps[scene.id][folderItem.id],
+    verticalFolderId,
+    'Existing validation semantics leave the malformed item mapping intact',
+  );
+});
+
+test('Collection load does not normalize an unmirrored folder hierarchy', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+  const sceneCollectionsService = client.getResource<SceneCollectionsService>(
+    'SceneCollectionsService',
+  );
+  const collectionId = sceneCollectionsService.activeCollection.id;
+  const scene = scenesService.createScene('Unmirrored Folder Scene');
+  scene.createAndAddSource('Root Item', 'color_source');
+  const folder = scene.createFolder('Folder');
+  const folderItem = scene.createAndAddSource('Folder Item', 'color_source');
+  folderItem.setParent(folder.id);
+
+  dualOutputService.convertSingleOutputToDualOutputCollection();
+
+  const nodeMap = sceneCollectionsService.sceneNodeMaps[scene.id];
+  const verticalFolderItem = scene.getNode(nodeMap[folderItem.id]);
+  verticalFolderItem.detachParent();
+
+  const horizontalNodeIds = scene
+    .getNodes()
+    .filter(node => node.display === 'horizontal')
+    .map(node => node.id);
+  const verticalNodeIds = scene
+    .getNodes()
+    .filter(node => node.display === 'vertical')
+    .map(node => node.id);
+  scene.setNodesOrder(verticalNodeIds.concat(horizontalNodeIds));
+  const unsafeOrder = scene.getNodes().map(node => node.id);
+
+  await sceneCollectionsService.create({ name: 'Unmirrored Folder Other Collection' });
+  await sceneCollectionsService.load(collectionId);
+
+  const restoredScene = (scenesService as any).getScene(scene.id) as Scene;
+  t.deepEqual(
+    restoredScene.getNodes().map(node => node.id),
+    unsafeOrder,
+    'Load leaves z-order untouched when mapped folder relationships are not mirrored',
+  );
+  t.is(
+    restoredScene.getNode(nodeMap[folderItem.id]).parentId,
+    '',
+    'Load does not infer or mutate a malformed vertical parent relationship',
+  );
+});
+
 test('New source is top-most in both displays for an inactive scene', async t => {
   const client = await getApiClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');


### PR DESCRIPTION
### Description

This fixes the following issue:

```
Steps:
- Add a new source in a single output mode
- Enable dual output

Expected results:
The latest source is present at the top of the sources list and rendered on top of other
sources for both vertical and horizontal canvases.

Actual results:
The latest source is present at the top of the sources list and rendered on top of other
sources for the horizontal canvas, but it is rendered behind other sources on the vertical canvas (see screenshot)
```

<img width="1584" height="663" alt="image" src="https://github.com/user-attachments/assets/7262bef5-5a50-4100-baf5-c1191c32b01d" />


### Details

When a source was added in single-output mode and Dual Output was subsequently enabled, the source remained top-most on the horizontal canvas but could render behind older sources on the vertical canvas.

Collections saved with this incorrect vertical order also retained the problem after restarting Desktop.

### Even more details

Horizontal and vertical scene nodes share one scene-node list and are connected through `sceneNodeMaps`. Partner creation and single-to-dual conversion did not consistently preserve the horizontal z-order when constructing the vertical node block. Nested-folder reparenting could also reverse sibling order.

### Changes

- Preserve source z-order when converting a single-output collection to Dual Output.
- Keep newly created source, copied-source, and folder partners correctly ordered for both active and inactive scenes.
- Preserve nested-folder sibling order during conversion.
- Validate mapped dual-output scenes when a collection is loaded.
- Rebuild the vertical node order from the authoritative horizontal order for valid existing scenes.
- Require a complete one-to-one node map with matching displays, node types, sources, and mirrored folder relationships before repairing.
- Leave malformed or incomplete scene graphs untouched and log a warning instead of guessing.
- Avoid changing node mappings while repairing persisted order.