### PR TITLE
Add timeout for AI Highlighter test.

### DIFF
--- a/test/regular/highlighter.ts
+++ b/test/regular/highlighter.ts
@@ -55,7 +55,10 @@ test('Highlighter save and export', async t => {
 test('AI Highlighter', withUser('twitch', { prime: true }), async t => {
   // AI Highlighter install button shows
   await showPage('Highlighter');
-  await waitForDisplayed('[name="installHighlighter"]');
+  await waitForDisplayed('[name="installHighlighter"]', {
+    timeout: 3000,
+    timeoutMsg: 'Highlighter tab AI Highlighter install button did not show',
+  });
 
   // Go live with AI Highlighter enabled
   await prepareToGoLive();


### PR DESCRIPTION
# Add Timeout to the AI Highlighter Test's Install Button

## Issues

In `test/regular/highlighter.ts`, the `'AI Highlighter'` test waited on `[name="installHighlighter"]` with `waitForDisplayed`'s default timeout, which was attempting to select before the page had fully loaded.

## Fixes

Specify a 3s timeout and a `timeoutMsg` ("Highlighter tab AI Highlighter install button did not show") to identify a failure vs. a timeout.

**File(s) changed:** `test/regular/highlighter.ts`

## Performance Implications

None. Test-only change.