### PR TITLE
Fix source selection after disabling dual output

### DIFF
--- a/app/components-react/editor/elements/SourceSelector.tsx
+++ b/app/components-react/editor/elements/SourceSelector.tsx
@@ -387,6 +387,7 @@ class SourceSelectorController {
        * clicking on the source selector selects both sources
        */
       if (
+        this.isDualOutputActive &&
         this.dualOutputService.views.hasNodeMap(this.scene.id) &&
         this.dualOutputService.views.activeDisplays.horizontal &&
         this.dualOutputService.views.activeDisplays.vertical
@@ -504,6 +505,7 @@ class SourceSelectorController {
      * in the vertical display, convert the vertical node id to the horizontal node id.
      */
     if (
+      this.isDualOutputActive &&
       this.dualOutputService.views.activeDisplays.horizontal &&
       this.dualOutputService.views.activeDisplays.vertical
     ) {

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -174,7 +174,7 @@ class DualOutputViews extends ViewHandler<IDualOutputServiceState> {
   }
 
   get onlyVerticalDisplayActive() {
-    return this.activeDisplays.vertical && !this.activeDisplays.horizontal;
+    return this.dualOutputMode && this.activeDisplays.vertical && !this.activeDisplays.horizontal;
   }
 
   get platformsDualStreaming() {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -151,9 +151,7 @@ export class Scene {
   getSourceSelectorNodes(): TSceneNode[] {
     let nodes = this.getNodes();
 
-    const populateWithVerticalNodes =
-      !this.dualOutputService.views.activeDisplays.horizontal &&
-      this.dualOutputService.views.activeDisplays.vertical;
+    const populateWithVerticalNodes = this.dualOutputService.views.onlyVerticalDisplayActive;
 
     nodes = nodes.filter(node => {
       // if only the vertical display is active

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -3,10 +3,92 @@ import { getApiClient } from '../../helpers/api-client';
 import { test, useWebdriver, TExecutionContext } from '../../helpers/webdriver';
 import { ScenesService, Scene, SceneItem } from 'services/scenes';
 import { VideoSettingsService } from 'services/settings-v2/video';
+import { SelectionService } from 'services/api/external-api/selection';
+import { click, focusMain, focusWindow, waitForDisplayed } from '../../helpers/modules/core';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
+
+async function setDualOutputMode(t: TExecutionContext, status: boolean) {
+  try {
+    t.true(await focusWindow('worker'), 'Worker window is available');
+    // Exercise the normal mode transition without requiring a provider login.
+    await t.context.app.client.execute(`
+      window.servicesManager.getResource('DualOutputService').setDualOutputMode(${status}, true);
+      0;
+    `);
+    await t.context.app.client.waitUntil(
+      () =>
+        t.context.app.client.execute(`
+          const dualOutput = window.servicesManager.getResource('DualOutputService');
+          return dualOutput.views.dualOutputMode === ${status} && !dualOutput.views.isLoading;
+        `),
+      { timeout: 10000, timeoutMsg: 'Dual output mode transition did not complete' },
+    );
+  } finally {
+    await focusMain();
+  }
+}
+
+for (const horizontalVisible of [false, true]) {
+  test(`Selection after disabling dual output with horizontal ${
+    horizontalVisible ? 'visible' : 'hidden'
+  }`, async t => {
+    const client = await getApiClient();
+    const scenesService = client.getResource<ScenesService>('ScenesService');
+    const dualOutputService = client.getResource<DualOutputService>('DualOutputService');
+    const selection = client.getResource<SelectionService>('SelectionService');
+    const scene = scenesService.createScene('Selection transition');
+    scenesService.makeSceneActive(scene.id);
+    const horizontalItem = scene.createAndAddSource('Selection target', 'color_source');
+    horizontalItem.fitToScreen();
+
+    await setDualOutputMode(t, true);
+    dualOutputService.toggleDisplay(horizontalVisible, 'horizontal');
+    const verticalItem = scene.getItems().find(item => item.display === 'vertical');
+    t.truthy(verticalItem, 'Dual output created a vertical partner');
+    t.deepEqual(
+      scene.getSourceSelectorNodes().map(node => node.id),
+      [horizontalVisible ? horizontalItem.id : verticalItem.id],
+      'Dual output source rows follow the visible displays',
+    );
+
+    await setDualOutputMode(t, false);
+    await waitForDisplayed('#horizontal-display');
+    t.deepEqual(
+      scene.getSourceSelectorNodes().map(node => node.id),
+      [horizontalItem.id],
+      'Single output source rows always use horizontal items',
+    );
+
+    await click('[data-name="Selection target"]');
+    t.deepEqual(selection.getIds(), [horizontalItem.id], 'List selects only the visible item');
+
+    selection.reset();
+    await t.context.app.client.waitUntil(async () => {
+      const selectedRows = await t.context.app.client.$$(
+        '.ant-tree-node-selected [data-name="Selection target"]',
+      );
+      return selectedRows.length === 0;
+    });
+    await click('#horizontal-display');
+    await waitForDisplayed('.ant-tree-node-selected [data-name="Selection target"]');
+    t.deepEqual(selection.getIds(), [horizontalItem.id], 'Canvas selection highlights the list');
+
+    await setDualOutputMode(t, true);
+    t.is(
+      dualOutputService.state.videoSettings.activeDisplays.horizontal,
+      horizontalVisible,
+      'The saved horizontal display preference is preserved',
+    );
+    t.deepEqual(
+      scene.getSourceSelectorNodes().map(node => node.id),
+      [horizontalVisible ? horizontalItem.id : verticalItem.id],
+      'Re-enabling dual output restores the corresponding source rows',
+    );
+  });
+}
 
 function confirmDualOutputSources(t: TExecutionContext, scene: Scene) {
   const numSceneItems = scene

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -10,6 +10,9 @@ import { click, focusMain, waitForDisplayed } from '../../helpers/modules/core';
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
 
+testSelectionAfterDisablingDualOutput(false);
+testSelectionAfterDisablingDualOutput(true);
+
 async function setDualOutputMode(status: boolean) {
   const client = await getApiClient();
   // The RPC fallback exposes this private method; its loading-mode decorator returns a promise.
@@ -22,7 +25,7 @@ async function setDualOutputMode(status: boolean) {
   await focusMain();
 }
 
-for (const horizontalVisible of [false, true]) {
+function testSelectionAfterDisablingDualOutput(horizontalVisible: boolean) {
   test(`Selection after disabling dual output with horizontal ${
     horizontalVisible ? 'visible' : 'hidden'
   }`, async t => {

--- a/test/regular/api/dual-output.ts
+++ b/test/regular/api/dual-output.ts
@@ -4,31 +4,22 @@ import { test, useWebdriver, TExecutionContext } from '../../helpers/webdriver';
 import { ScenesService, Scene, SceneItem } from 'services/scenes';
 import { VideoSettingsService } from 'services/settings-v2/video';
 import { SelectionService } from 'services/api/external-api/selection';
-import { click, focusMain, focusWindow, waitForDisplayed } from '../../helpers/modules/core';
+import { click, focusMain, waitForDisplayed } from '../../helpers/modules/core';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
 
-async function setDualOutputMode(t: TExecutionContext, status: boolean) {
-  try {
-    t.true(await focusWindow('worker'), 'Worker window is available');
-    // Exercise the normal mode transition without requiring a provider login.
-    await t.context.app.client.execute(`
-      window.servicesManager.getResource('DualOutputService').setDualOutputMode(${status}, true);
-      0;
-    `);
-    await t.context.app.client.waitUntil(
-      () =>
-        t.context.app.client.execute(`
-          const dualOutput = window.servicesManager.getResource('DualOutputService');
-          return dualOutput.views.dualOutputMode === ${status} && !dualOutput.views.isLoading;
-        `),
-      { timeout: 10000, timeoutMsg: 'Dual output mode transition did not complete' },
-    );
-  } finally {
-    await focusMain();
-  }
+async function setDualOutputMode(status: boolean) {
+  const client = await getApiClient();
+  // The RPC fallback exposes this private method; its loading-mode decorator returns a promise.
+  const dualOutput = client.getResource<{
+    setDualOutputMode(status: boolean, skipShowVideoSettings: boolean): Promise<void>;
+  }>('DualOutputService');
+
+  // Exercise the normal mode transition without requiring a provider login.
+  await dualOutput.setDualOutputMode(status, true);
+  await focusMain();
 }
 
 for (const horizontalVisible of [false, true]) {
@@ -44,7 +35,7 @@ for (const horizontalVisible of [false, true]) {
     const horizontalItem = scene.createAndAddSource('Selection target', 'color_source');
     horizontalItem.fitToScreen();
 
-    await setDualOutputMode(t, true);
+    await setDualOutputMode(true);
     dualOutputService.toggleDisplay(horizontalVisible, 'horizontal');
     const verticalItem = scene.getItems().find(item => item.display === 'vertical');
     t.truthy(verticalItem, 'Dual output created a vertical partner');
@@ -54,7 +45,7 @@ for (const horizontalVisible of [false, true]) {
       'Dual output source rows follow the visible displays',
     );
 
-    await setDualOutputMode(t, false);
+    await setDualOutputMode(false);
     await waitForDisplayed('#horizontal-display');
     t.deepEqual(
       scene.getSourceSelectorNodes().map(node => node.id),
@@ -76,7 +67,7 @@ for (const horizontalVisible of [false, true]) {
     await waitForDisplayed('.ant-tree-node-selected [data-name="Selection target"]');
     t.deepEqual(selection.getIds(), [horizontalItem.id], 'Canvas selection highlights the list');
 
-    await setDualOutputMode(t, true);
+    await setDualOutputMode(true);
     t.is(
       dualOutputService.state.videoSettings.activeDisplays.horizontal,
       horizontalVisible,


### PR DESCRIPTION
The PR fixes the following issue:
```
Steps:
- Enable dual output mode
- Disable Horizontal canvas in the top right corner settings
- Disable dual output mode

Expected: When sources selected on canvas, they highlighted in the list an vice versa.
Actual: This does not happen. Selection link is lost.

Note: it works again if enable dual output and enable there horizontal canvas. So it must be a pure UI issue.
```
Reproduction video:

https://github.com/user-attachments/assets/ad1a4a80-f7a0-40f4-b1b2-5e91cd94cd14

### Description

Disabling dual output after hiding the horizontal canvas left the Sources list using vertical item IDs while the canvas displayed horizontal items, breaking selection highlighting in both directions.

Use horizontal items consistently when dual output is off, and restrict paired selection and highlight mapping to dual-output mode. Preserve saved display visibility preferences when dual output is re-enabled.

Added regression tests covering selection in both directions after disabling dual output with horizontal hidden or visible, plus restoration of display preferences.
